### PR TITLE
fix(ci): add write permissions for Claude code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write  # Required to post PR comments/reviews
+      issues: write         # Required to post issue comments
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write  # Required to post PR comments/reviews
+      issues: write         # Required to post issue comments
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read         # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Claude Code Review workflows were passing in CI but no comments were being posted to PRs or issues.

## Root Cause

The  requires  and  permissions to post comments, but both workflows only had  permissions:

```yaml
permissions:
  pull-requests: read  # ❌ Should be 'write'
  issues: read         # ❌ Should be 'write'
```

## Solution

Updated both workflow files to grant write permissions:

- ✅ `.github/workflows/claude-code-review.yml`
- ✅ `.github/workflows/claude.yml`

## Testing

Once merged, the next PR will trigger the Claude code review action which will now be able to post comments.

## References

- [Claude Code Action Docs](https://github.com/anthropics/claude-code-action)
- Workflow logs showed successful execution but no comment posting

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)