### PR TITLE
fix(ci): update Claude review workflow with direct prompt template

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -36,9 +36,44 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt:  |
+            Please review this pull request and provide feedback using the following template:
 
+            ## Summary
+            Brief overview (2-3 sentences)
+
+            ## Strengths
+            What's done well?
+
+            ## Security Concerns
+            Vulnerabilities? 🔴 BLOCKING | 🟡 HIGH | 🟢 LOW
+
+            ## Problems
+            Critical issues blocking merge (mark 🔴)
+            Consider priority greater than Minor as "Blocking"
+
+            ## Code Quality
+            Non-blocking improvements for educational purposes or for future GitHub Issues
+
+            ## CLAUDE.md Adherence
+            ✅/❌ Coverage, linting, types, patterns, commits
+
+            ## Testing
+            Test quality evaluation
+            Insufficient testing is Blocking (mark 🔴)
+
+            ## Documentation
+            Docs completeness
+
+
+            ## Verdict
+            ✅ LGTM | 🔄 CHANGES_REQUESTED | 💬 COMMENTS
+            **Reasoning:** Specific references
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/tests/unit/ai/test_orchestrator.py
+++ b/tests/unit/ai/test_orchestrator.py
@@ -229,6 +229,22 @@ class TestAIOrchestrator:
         with pytest.raises(ValueError, match="retry_delay must be positive"):
             AIOrchestrator(api_key="test-api-key-123", retry_delay=-0.5)
 
+    def test_orchestrator_stores_exact_retry_delay_value(self) -> None:
+        """Test AIOrchestrator stores exact retry_delay value (kills mutants).
+
+        This test verifies the exact value is stored, killing mutants that
+        might change == to !=, or >= to >, or subtract/add to the value.
+        """
+        orchestrator = AIOrchestrator(api_key="test-api-key-123", retry_delay=3.5)
+        # Verify exact value (not just >= or <=)
+        assert orchestrator.retry_delay == 3.5
+        # Boundary check: not greater than
+        assert not orchestrator.retry_delay > 3.5
+        # Boundary check: not less than
+        assert not orchestrator.retry_delay < 3.5
+        # Verify it's a float, not accidentally converted to int
+        assert isinstance(orchestrator.retry_delay, float)
+
     @patch("start_green_stay_green.ai.orchestrator.Anthropic")
     def test_generate_with_valid_prompt_returns_result(
         self,


### PR DESCRIPTION
## Changes
- Replace plugin-based review with direct prompt template
- Change trigger types to `[opened, synchronize]` for focused reviews
- Add comprehensive review template with clear sections
- Enable Claude to post reviews as PR comments via `gh pr comment`
- Add `claude_args` to allow specific gh CLI commands

## Benefits
- More consistent review format
- Claude can post reviews directly to PRs
- Clearer review structure with Summary, Strengths, Problems, etc.
- Better integration with GitHub workflow

## Testing
Will test with the next PR to verify Claude posts reviews correctly.