### PR TITLE
fix(ui): show checkmarks when progress tasks complete (#172)

### DIFF
--- a/RCA_ISSUE_171.md
+++ b/RCA_ISSUE_171.md
@@ -1,0 +1,258 @@
+# Root Cause Analysis: Spinners Never Show Checkmarks
+
+**Issue ID**: #171 (to be created)
+**Date**: 2026-02-01
+**Severity**: Low (cosmetic, but poor UX)
+**Status**: Identified
+
+## Problem Statement
+
+Progress spinners during `sgsg init` never resolve to checkmarks (✓). They just keep spinning even after tasks complete successfully.
+
+## Reproduction
+
+```bash
+sgsg init \
+  --project-name python-test-project \
+  --language python \
+  --output-dir . \
+  --no-interactive
+```
+
+**Observed**:
+```
+✓ AI features enabled (from environment variable)
+⠇ Generating scripts...
+⠇ Generating pre-commit config...
+⠇ Generating skills...
+⠇ Generating CI pipeline...
+⠇ Generating GitHub Actions review...
+⠇ Generating CLAUDE.md...
+⠇ Generating architecture rules...
+⠇ Generating subagents...
+```
+
+All spinners continue spinning, never show ✓ checkmark.
+
+**Expected**:
+```
+✓ AI features enabled
+✓ Generating scripts...
+✓ Generating pre-commit config...
+✓ Generating skills...
+✓ Generating CI pipeline...
+✓ Generating GitHub Actions review...
+✓ Generating CLAUDE.md...
+✓ Generating architecture rules...
+✓ Generating subagents...
+```
+
+## Root Cause
+
+**Location**: Multiple `_generate_*_step()` functions in `start_green_stay_green/cli.py`
+
+**The Bug**: Incorrect Rich Progress API usage
+
+Every generator step follows this pattern:
+```python
+def _generate_scripts_step(project_path, progress):
+    task = progress.add_task("Generating scripts...", total=None)
+    # ... do work ...
+    progress.update(task, completed=True)  # ❌ WRONG!
+```
+
+**The Problem**:
+
+1. **`total=None`** creates an **indeterminate progress task** (spinner)
+2. **`progress.update(task, completed=True)`** is **invalid** - `completed` is not a parameter of `Progress.update()`
+3. Rich's `Progress.update()` signature:
+   ```python
+   def update(
+       task_id: TaskID,
+       *,
+       total: float | None = None,
+       completed: float | None = None,  # ❌ This is progress amount, NOT boolean!
+       advance: float | None = None,
+       description: str | None = None,
+       visible: bool | None = None,
+       refresh: bool = False,
+       **fields: Any,
+   )
+   ```
+
+4. The `completed` parameter expects a **float** (progress amount), not a **boolean**
+5. For indeterminate tasks (`total=None`), setting `completed=True` doesn't stop the spinner
+
+**What Actually Happens**:
+- `progress.update(task, completed=True)` is silently ignored (True coerced to 1.0)
+- Spinner keeps spinning because task is still visible
+- No checkmark appears because task never finishes
+
+## Analysis
+
+### How Rich Progress Works
+
+**For Determinate Progress** (with total):
+```python
+task = progress.add_task("Task", total=100)
+progress.update(task, advance=10)  # Updates progress
+progress.update(task, completed=100)  # Marks as complete
+```
+
+**For Indeterminate Progress** (spinner):
+```python
+task = progress.add_task("Task", total=None)  # Creates spinner
+# ... do work ...
+progress.stop_task(task)  # Stops spinner
+# OR
+progress.remove_task(task)  # Removes task entirely
+```
+
+### Correct Approaches
+
+**Option 1: Stop Task (keeps visible, stops spinner)**
+```python
+progress.stop_task(task)
+```
+
+**Option 2: Remove Task (hides entirely)**
+```python
+progress.remove_task(task)
+```
+
+**Option 3: Update Description (change to checkmark)**
+```python
+progress.update(task, description="[green]✓[/green] Generating scripts...")
+progress.stop_task(task)
+```
+
+**Option 4: Use Determinate Progress**
+```python
+task = progress.add_task("Generating scripts...", total=1)
+# ... do work ...
+progress.update(task, advance=1)  # Completes and shows checkmark
+```
+
+## Impact
+
+- **Severity**: Low - Cosmetic issue only
+- **UX Impact**: Confusing - looks like tasks are still running
+- **Functionality**: No impact - generation still succeeds
+- **User Perception**: Tool appears "stuck" or "slow"
+
+## Contributing Factors
+
+1. **Incorrect API understanding**: Assumed `completed=True` would work
+2. **No visual feedback testing**: Never ran tool to see spinners
+3. **Copy-paste programming**: Same pattern repeated in all functions
+4. **Missing Rich documentation review**: Didn't read Progress API docs
+
+## Fix Strategy
+
+**Recommended: Option 3** (Update description to checkmark + stop)
+
+**Reasons**:
+- Shows clear completion indicator (✓)
+- Keeps tasks visible for user to review
+- Matches expected UX from reproduction
+- Simple to implement
+
+**Implementation**:
+1. Update all `_generate_*_step()` functions
+2. Replace `progress.update(task, completed=True)` with:
+   ```python
+   progress.update(
+       task,
+       description="[green]✓[/green] Generated scripts"
+   )
+   progress.stop_task(task)
+   ```
+
+## Proposed Solution
+
+### Changes Required
+
+**Pattern to Replace** (11 occurrences):
+```python
+# OLD (broken):
+task = progress.add_task("Generating X...", total=None)
+# ... do work ...
+progress.update(task, completed=True)
+
+# NEW (working):
+task = progress.add_task("Generating X...", total=None)
+# ... do work ...
+progress.update(
+    task,
+    description="[green]✓[/green] Generated X"
+)
+progress.stop_task(task)
+```
+
+### Files to Update
+
+**File**: `start_green_stay_green/cli.py`
+
+**Functions to fix**:
+1. `_generate_scripts_step()` - Line 557
+2. `_generate_precommit_step()` - Line 574
+3. `_generate_skills_step()` - Line 582
+4. `_generate_ci_step()` - Lines 599, 602
+5. `_generate_review_step()` - Lines 617, 620
+6. `_generate_claude_md_step()` - Lines 649, 652
+7. `_generate_architecture_step()` - Lines 670, 675
+8. `_generate_subagents_step()` - Lines 704, 707
+9. `_generate_metrics_dashboard_step()` - Line 805
+
+**Total**: 13 lines to fix
+
+### Test Strategy
+
+**Manual Test**:
+```bash
+sgsg init --project-name test --language python --output-dir /tmp --no-interactive
+```
+
+**Expected Output**:
+```
+✓ AI features enabled
+✓ Generated scripts
+✓ Generated pre-commit config
+✓ Generated skills
+✓ Generated CI pipeline
+✓ Generated GitHub Actions review
+✓ Generated CLAUDE.md
+✓ Generated architecture rules
+✓ Generated subagents
+✓ Project generated successfully
+```
+
+**Unit Test** (optional):
+```python
+def test_progress_tasks_show_checkmarks(capsys):
+    """Test that progress tasks show checkmarks on completion."""
+    # Mock Progress and verify update calls
+    # Check that description contains "✓"
+    # Check that stop_task is called
+```
+
+## Prevention
+
+1. **Read API documentation**: Always check library docs before use
+2. **Visual testing**: Run CLI commands to verify UX
+3. **Type checking**: Use type hints to catch wrong parameter types
+4. **Code review**: Review visual/UX aspects, not just functionality
+
+## Timeline
+
+- **Discovery**: 2026-02-01 (user manual testing)
+- **RCA Completed**: 2026-02-01
+- **Fix Target**: Quick win - same day
+
+## Related Files
+
+- `start_green_stay_green/cli.py` - All `_generate_*_step()` functions
+
+## Conclusion
+
+Simple API misuse - passing boolean to float parameter. Easy fix with immediate visible improvement to UX. Quick win before tackling larger Issue #170.

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -554,7 +554,8 @@ def _generate_scripts_step(
         config=scripts_config,
     )
     scripts_generator.generate()
-    progress.update(task, completed=True)
+    progress.update(task, description="[green]✓[/green] Generated scripts")
+    progress.stop_task(task)
 
 
 def _generate_precommit_step(
@@ -571,7 +572,8 @@ def _generate_precommit_step(
     precommit_result = precommit_generator.generate(precommit_config)
     precommit_file = project_path / ".pre-commit-config.yaml"
     precommit_file.write_text(precommit_result["content"])
-    progress.update(task, completed=True)
+    progress.update(task, description="[green]✓[/green] Generated pre-commit config")
+    progress.stop_task(task)
 
 
 def _generate_skills_step(project_path: Path, progress: Progress) -> None:
@@ -579,7 +581,8 @@ def _generate_skills_step(project_path: Path, progress: Progress) -> None:
     task = progress.add_task("Generating skills...", total=None)
     skills_dir = project_path / ".claude" / "skills"
     _copy_reference_skills(skills_dir)
-    progress.update(task, completed=True)
+    progress.update(task, description="[green]✓[/green] Generated skills")
+    progress.stop_task(task)
 
 
 def _generate_ci_step(
@@ -596,10 +599,12 @@ def _generate_ci_step(
         workflows_dir = project_path / ".github" / "workflows"
         workflows_dir.mkdir(parents=True, exist_ok=True)
         (workflows_dir / "ci.yml").write_text(workflow.content)
-        progress.update(task, completed=True)
+        progress.update(task, description="[green]✓[/green] Generated CI pipeline")
+        progress.stop_task(task)
     else:
         task = progress.add_task("Skipping CI (no API key)...", total=None)
-        progress.update(task, completed=True)
+        progress.update(task, description="[yellow]⊘[/yellow] Skipped CI (no API key)")
+        progress.stop_task(task)
 
 
 def _generate_review_step(
@@ -614,10 +619,16 @@ def _generate_review_step(
         workflows_dir.mkdir(parents=True, exist_ok=True)
         workflow_file = workflows_dir / "code-review.yml"
         workflow_file.write_text(review_result["workflow_content"])
-        progress.update(task, completed=True)
+        progress.update(
+            task, description="[green]✓[/green] Generated GitHub Actions review"
+        )
+        progress.stop_task(task)
     else:
         task = progress.add_task("Skipping code review (no API key)...", total=None)
-        progress.update(task, completed=True)
+        progress.update(
+            task, description="[yellow]⊘[/yellow] Skipped code review (no API key)"
+        )
+        progress.stop_task(task)
 
 
 def _generate_claude_md_step(
@@ -646,10 +657,14 @@ def _generate_claude_md_step(
         }
         claude_md_result = claude_md_generator.generate(project_config)
         (project_path / "CLAUDE.md").write_text(claude_md_result.content)
-        progress.update(task, completed=True)
+        progress.update(task, description="[green]✓[/green] Generated CLAUDE.md")
+        progress.stop_task(task)
     else:
         task = progress.add_task("Skipping CLAUDE.md (no API key)...", total=None)
-        progress.update(task, completed=True)
+        progress.update(
+            task, description="[yellow]⊘[/yellow] Skipped CLAUDE.md (no API key)"
+        )
+        progress.stop_task(task)
 
 
 def _generate_architecture_step(
@@ -667,12 +682,19 @@ def _generate_architecture_step(
             output_dir=project_path / "plans" / "architecture",
         )
         arch_generator.generate(language=language, project_name=project_name)
-        progress.update(task, completed=True)
+        progress.update(
+            task, description="[green]✓[/green] Generated architecture rules"
+        )
+        progress.stop_task(task)
     else:
         task = progress.add_task(
             "Skipping architecture rules (no API key)...", total=None
         )
-        progress.update(task, completed=True)
+        progress.update(
+            task,
+            description="[yellow]⊘[/yellow] Skipped architecture rules (no API key)",
+        )
+        progress.stop_task(task)
 
 
 def _generate_subagents_step(
@@ -701,10 +723,14 @@ def _generate_subagents_step(
         subagents_output_dir.mkdir(parents=True, exist_ok=True)
         for agent_name, result in results.items():
             (subagents_output_dir / f"{agent_name}.md").write_text(result.content)
-        progress.update(task, completed=True)
+        progress.update(task, description="[green]✓[/green] Generated subagents")
+        progress.stop_task(task)
     else:
         task = progress.add_task("Skipping subagents (no API key)...", total=None)
-        progress.update(task, completed=True)
+        progress.update(
+            task, description="[yellow]⊘[/yellow] Skipped subagents (no API key)"
+        )
+        progress.stop_task(task)
 
 
 def _generate_metrics_dashboard_step(
@@ -802,7 +828,8 @@ def _generate_metrics_dashboard_step(
             "You'll need to create scripts/collect_metrics.py manually."
         )
 
-    progress.update(task, completed=True)
+    progress.update(task, description="[green]✓[/green] Generated metrics dashboard")
+    progress.stop_task(task)
 
 
 def _generate_with_orchestrator(


### PR DESCRIPTION
## Summary

Fixes #172 - Progress spinners now show checkmarks (✓) when tasks complete instead of spinning indefinitely.

## Problem

Spinners during `sgsg init` never resolved to checkmarks:
```
✓ AI features enabled
⠇ Generating scripts...              ← keeps spinning forever
⠇ Generating pre-commit config...    ← keeps spinning forever
```

**Root Cause**: Incorrect Rich Progress API usage

## Solution

Update all generation functions to properly complete progress tasks:

```python
# Before (broken):
progress.update(task, completed=True)  # ❌ Invalid API usage

# After (working):
progress.update(task, description="[green]✓[/green] Generated X")
progress.stop_task(task)  # ✅ Correct
```

## Changes

Updated 9 functions in `start_green_stay_green/cli.py`:
- Show `[green]✓[/green]` on successful completion
- Show `[yellow]⊘[/yellow]` when skipped (no API key)
- Call `progress.stop_task()` to stop spinner

## Expected Output

```
✓ AI features enabled
✓ Generated scripts
✓ Generated pre-commit config
✓ Generated skills
✓ Generated CI pipeline
✓ Generated GitHub Actions review
✓ Generated CLAUDE.md
✓ Generated architecture rules
✓ Generated subagents
✓ Project generated successfully
```

## Testing

**Gate 1 (Local)**: ✅ All 32 pre-commit hooks passed
**Gate 2 (CI)**: ⏳ Waiting for pipeline
**Gate 3 (Review)**: ⏳ Waiting for Claude review

## Impact

- **UX**: Much better - clear visual feedback
- **Perception**: Tool no longer appears "stuck"
- **Severity**: Low (cosmetic) but important for polish

See full RCA: `RCA_ISSUE_171.md`

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>