### PR TITLE
fix(scripts): add typecheck.sh and coverage.sh, fix package name template

### DIFF
--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -708,9 +708,9 @@ class TestMutationKillers:
             generator = ScriptsGenerator(Path(tmpdir), config)
             scripts = generator.generate()
 
-            assert len(scripts) == 9
-            assert len(scripts) > 8
-            assert len(scripts) < 10
+            assert len(scripts) == 11
+            assert len(scripts) > 10
+            assert len(scripts) < 12
 
     def test_generated_scripts_exact_count_typescript(self) -> None:
         """Test TypeScript generator creates EXACTLY 5 scripts."""


### PR DESCRIPTION
## Summary
- Add missing `typecheck.sh` script (runs mypy type checking)
- Add missing `coverage.sh` script (runs pytest with coverage)  
- Fix hardcoded package name in `test.sh` template (`start_green_stay_green` → `{package_name}`)

## Root Cause (Issue #174)
The ScriptsGenerator had three bugs:
1. **Missing typecheck.sh**: check-all.sh referenced it (line 91) but generator didn't create it
2. **Missing coverage.sh**: check-all.sh referenced it (line 95) but generator didn't create it  
3. **Hardcoded package name**: test.sh had `--cov=start_green_stay_green` instead of using the user's project name

This caused generated projects to fail when running `./scripts/check-all.sh`.

## Changes
- Added `_python_typecheck_script()` method to generate typecheck.sh
- Added `_python_coverage_script()` method to generate coverage.sh
- Converted `_python_test_script()` to f-string template
- Fixed `--cov` parameter to use `{self.config.package_name}`
- Updated test to expect 11 scripts instead of 9

## Test Plan
- [x] All 32 pre-commit hooks pass (Gate 1 ✅)
- [x] CI pipeline passes (Gate 2 ✅)
- [ ] Claude review LGTM (Gate 3 ⏳)

## Related
- Fixes #174
- Part of #170 (Task #10/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)