### PR TITLE
feat(dependencies): add DependenciesGenerator for requirements and pyproject.toml

### DIFF
--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -6,6 +6,7 @@ import tomllib
 
 import pytest
 
+from start_green_stay_green.generators.base import GenerationError
 from start_green_stay_green.generators.dependencies import DependenciesGenerator
 from start_green_stay_green.generators.dependencies import DependencyConfig
 
@@ -205,3 +206,23 @@ class TestDependencyConfigValidation:
                 language="python",
                 package_name="",  # Empty string
             )
+
+
+class TestUnsupportedLanguage:
+    """Test error handling for unsupported languages."""
+
+    def test_unsupported_language_raises_generation_error(self) -> None:
+        """Test that unsupported language raises GenerationError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = DependencyConfig(
+                project_name="test-project",
+                language="rust",  # Not yet supported
+                package_name="test_project",
+            )
+            generator = DependenciesGenerator(Path(tmpdir), config)
+
+            with pytest.raises(GenerationError) as exc_info:
+                generator.generate()
+
+            assert "not supported" in str(exc_info.value).lower()
+            assert "rust" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary
- Add DependenciesGenerator to create dependency files for generated projects
- Generate `requirements.txt` (empty for Hello World starter)
- Generate `requirements-dev.txt` with all dev tools
- Generate `pyproject.toml` with project metadata and tool configs

## Root Cause (Issue #176)
Generated projects were missing dependency files, causing scripts to fail:
- Scripts referenced tools (pytest, ruff, mypy, etc.) but didn't install them
- `./scripts/check-all.sh` failed immediately with "command not found"
- Poor out-of-box experience for users

## Changes
**New Generator**: `DependenciesGenerator`
- Creates 3 files: requirements.txt, requirements-dev.txt, pyproject.toml
- Supports Python projects (other languages TBD)

**requirements.txt**:
- Empty for Hello World starter (no runtime dependencies)
- Comment indicating where to add production dependencies

**requirements-dev.txt**:
- All tools referenced by generated scripts:
  - pytest, pytest-cov (testing)
  - ruff, black, isort (linting/formatting)
  - mypy (type checking)
  - bandit, safety (security)
  - radon, xenon (complexity)
  - mutmut (mutation testing)
  - pre-commit (hooks)

**pyproject.toml**:
- Project metadata (name, version, description, authors)
- Tool configurations (black, isort, pytest, mypy, ruff, coverage, bandit, mutmut)
- Build system configuration

## Testing
- 12 comprehensive tests covering:
  - Generator initialization
  - File generation
  - Content validation (TOML parsing, required dependencies)
  - Config validation
- All 32 pre-commit hooks pass ✅

## Test Plan
- [x] All 32 pre-commit hooks pass (Gate 1 ✅)
- [x] CI pipeline passes (Gate 2 ✅ - 7/8 jobs passed, Dependency Review pending)
- [ ] Claude review LGTM (Gate 3 ⏳)

## Related
- Fixes #176
- Part of #170 (Task #11/14)
- Depends on #174 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)