### PR TITLE
feat(structure): add StructureGenerator for project source code

### DIFF
--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -1,0 +1,198 @@
+"""Project structure generator.
+
+Generates source code directory structure for target projects (source directory,
+__init__.py, Hello World starter code).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from start_green_stay_green.generators.base import BaseGenerator
+from start_green_stay_green.generators.base import GenerationError
+
+
+@dataclass(frozen=True)
+class StructureConfig:
+    """Configuration for project structure generation.
+
+    Attributes:
+        project_name: Name of the project (e.g., "my-project")
+        language: Programming language (python, typescript, go, rust, etc.)
+        package_name: Name of the main package/module (e.g., "my_project")
+    """
+
+    project_name: str
+    language: str
+    package_name: str
+
+    def __post_init__(self) -> None:
+        """Validate configuration after initialization.
+
+        Raises:
+            ValueError: If any required field is empty
+        """
+        if not self.project_name:
+            msg = "Project name cannot be empty"
+            raise ValueError(msg)
+        if not self.language:
+            msg = "Language cannot be empty"
+            raise ValueError(msg)
+        if not self.package_name:
+            msg = "Package name cannot be empty"
+            raise ValueError(msg)
+
+
+class StructureGenerator(BaseGenerator):
+    """Generate project source code structure for target projects.
+
+    This generator creates the source code directory structure (package directory,
+    __init__.py, Hello World starter code) for the target project's language.
+
+    Attributes:
+        output_dir: Directory where structure will be created
+        config: Configuration for structure generation
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        config: StructureConfig,
+    ) -> None:
+        """Initialize the Structure Generator.
+
+        Args:
+            output_dir: Directory where structure will be created
+            config: StructureConfig with project settings
+
+        Raises:
+            ValueError: If output_dir is invalid or language is unsupported
+        """
+        self.output_dir = Path(output_dir)
+        self.config = config
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        """Validate configuration and ensure output directory exists.
+
+        Raises:
+            ValueError: If configuration is invalid
+        """
+        if not self.config.language:
+            msg = "Language cannot be empty"
+            raise ValueError(msg)
+
+        if not self.config.package_name:
+            msg = "Package name cannot be empty"
+            raise ValueError(msg)
+
+        if not self.config.project_name:
+            msg = "Project name cannot be empty"
+            raise ValueError(msg)
+
+        # Ensure output directory exists
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate(self) -> dict[str, Any]:
+        """Generate project source code structure.
+
+        Returns:
+            Dictionary mapping file names to their generated file paths
+
+        Raises:
+            GenerationError: If generation fails
+            ValueError: If configuration is invalid
+        """
+        files: dict[str, Path] = {}
+
+        # Generate language-specific structure
+        if self.config.language == "python":
+            files.update(self._generate_python_structure())
+        else:
+            # For now, only Python is supported
+            msg = f"Language {self.config.language} not supported yet"
+            raise GenerationError(msg)
+
+        return files
+
+    def _generate_python_structure(self) -> dict[str, Path]:
+        """Generate Python project structure.
+
+        Returns:
+            Dictionary mapping file names to file paths
+        """
+        files: dict[str, Path] = {}
+
+        # Create package directory
+        package_dir = self.output_dir / self.config.package_name
+        package_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate __init__.py
+        init_key = f"{self.config.package_name}/__init__.py"
+        files[init_key] = self._write_file(
+            package_dir / "__init__.py",
+            self._python_init_py(),
+        )
+
+        # Generate main.py
+        main_key = f"{self.config.package_name}/main.py"
+        files[main_key] = self._write_file(
+            package_dir / "main.py",
+            self._python_main_py(),
+        )
+
+        return files
+
+    def _write_file(self, file_path: Path, content: str) -> Path:
+        """Write a source file to disk.
+
+        Args:
+            file_path: Path where file will be written
+            content: Content to write to the file
+
+        Returns:
+            Path to the written file
+
+        Raises:
+            GenerationError: If file cannot be written
+        """
+        try:
+            file_path.write_text(content)
+        except OSError as e:
+            msg = f"Failed to write {file_path.name}: {e}"
+            raise GenerationError(msg, cause=e) from e
+        return file_path
+
+    def _python_init_py(self) -> str:
+        """Generate Python __init__.py content.
+
+        Returns:
+            Content for __init__.py with package docstring and version
+        """
+        # Convert package name to title case for display
+        display_name = self.config.project_name.replace("-", " ").title()
+
+        return f'''"""{display_name} package."""
+
+__version__ = "0.1.0"
+'''
+
+    def _python_main_py(self) -> str:
+        """Generate Python main.py content.
+
+        Returns:
+            Content for main.py with Hello World function
+        """
+        return f'''"""Main entry point for {self.config.project_name}."""
+
+
+def main() -> None:
+    """Run the main application."""
+    print("Hello from {self.config.project_name}!")
+
+
+if __name__ == "__main__":
+    main()
+'''

--- a/tests/unit/generators/test_structure.py
+++ b/tests/unit/generators/test_structure.py
@@ -1,0 +1,228 @@
+"""Unit tests for Structure Generator."""
+
+import ast
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from start_green_stay_green.generators.base import GenerationError
+from start_green_stay_green.generators.structure import StructureConfig
+from start_green_stay_green.generators.structure import StructureGenerator
+
+
+class TestStructureGeneratorInitialization:
+    """Test StructureGenerator initialization and basic instantiation."""
+
+    def test_generator_can_be_instantiated(self) -> None:
+        """Test StructureGenerator can be created with config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            assert generator is not None
+            assert isinstance(generator, StructureGenerator)
+
+    def test_generator_has_generate_method(self) -> None:
+        """Test generator has generate method."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            assert hasattr(generator, "generate")
+            assert callable(generator.generate)
+
+
+class TestStructureGeneration:
+    """Test project structure generation."""
+
+    def test_generate_creates_source_directory(self) -> None:
+        """Test generate creates source directory with package name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            generator.generate()
+
+            # Should create package directory
+            package_dir = Path(tmpdir) / "test_project"
+            assert package_dir.exists()
+            assert package_dir.is_dir()
+
+    def test_generate_creates_init_file(self) -> None:
+        """Test generate creates __init__.py in package directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert "test_project/__init__.py" in files
+            init_path = files["test_project/__init__.py"]
+            assert init_path.exists()
+            assert init_path.is_file()
+
+    def test_generate_creates_main_file(self) -> None:
+        """Test generate creates main.py with Hello World."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert "test_project/main.py" in files
+            main_path = files["test_project/main.py"]
+            assert main_path.exists()
+            assert main_path.is_file()
+
+    def test_init_has_version(self) -> None:
+        """Test __init__.py contains version."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            init_path = files["test_project/__init__.py"]
+            content = init_path.read_text()
+
+            assert "__version__" in content
+            assert "0.1.0" in content
+
+    def test_init_has_docstring(self) -> None:
+        """Test __init__.py contains package docstring."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            init_path = files["test_project/__init__.py"]
+            content = init_path.read_text()
+
+            # Should have triple-quoted docstring
+            assert '"""' in content
+
+    def test_main_has_hello_world_function(self) -> None:
+        """Test main.py contains a main() function."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            main_path = files["test_project/main.py"]
+            content = main_path.read_text()
+
+            assert "def main()" in content
+            assert "print(" in content
+
+    def test_main_has_if_name_main(self) -> None:
+        """Test main.py has if __name__ == '__main__' guard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            main_path = files["test_project/main.py"]
+            content = main_path.read_text()
+
+            assert 'if __name__ == "__main__"' in content
+            assert "main()" in content
+
+    def test_generated_files_are_valid_python(self) -> None:
+        """Test generated files are syntactically valid Python."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            # Try to compile the generated files
+            for file_path in files.values():
+                if file_path.suffix == ".py":
+                    content = file_path.read_text()
+                    # Should compile without SyntaxError
+                    ast.parse(content)
+
+
+class TestStructureConfigValidation:
+    """Test StructureConfig validation."""
+
+    def test_config_requires_project_name(self) -> None:
+        """Test config validates project_name is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            StructureConfig(
+                project_name="",  # Empty string
+                language="python",
+                package_name="test",
+            )
+
+    def test_config_requires_language(self) -> None:
+        """Test config validates language is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            StructureConfig(
+                project_name="test",
+                language="",  # Empty string
+                package_name="test",
+            )
+
+    def test_config_requires_package_name(self) -> None:
+        """Test config validates package_name is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            StructureConfig(
+                project_name="test",
+                language="python",
+                package_name="",  # Empty string
+            )
+
+
+class TestUnsupportedLanguage:
+    """Test error handling for unsupported languages."""
+
+    def test_unsupported_language_raises_generation_error(self) -> None:
+        """Test that unsupported language raises GenerationError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="rust",  # Not yet supported
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+
+            with pytest.raises(GenerationError) as exc_info:
+                generator.generate()
+
+            assert "not supported" in str(exc_info.value).lower()
+            assert "rust" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary
- Add StructureGenerator to create project source code structure
- Generate package directory (snake_case from kebab-case project name)
- Generate `__init__.py` with package docstring and version
- Generate `main.py` with Hello World function and CLI entry point

## Root Cause (Issue #178)
Generated projects were missing the core source code structure:
- No source directory for the project
- Linting/formatting scripts had nothing to operate on
- Users got quality infrastructure without actual working code

## Changes
**New Generator**: `StructureGenerator`
- Creates source directory with package name
- Inherits from BaseGenerator (architectural compliance)
- Supports Python projects (other languages TBD)

**Package Directory**:
- Named using snake_case conversion of project-name
- Created with proper directory structure

**__init__.py**:
- Package docstring (auto-generated from project name)
- Version constant (`__version__ = "0.1.0"`)
- Makes directory a proper Python package

**main.py**:
- Simple Hello World function
- CLI entry point with `if __name__ == "__main__"`  
- Ready to run immediately

## Testing
- 14 comprehensive tests covering:
  - Generator initialization
  - Directory creation
  - File generation (__init__.py, main.py)
  - Content validation (version, docstring, main function)
  - Python syntax validation (ast.parse)
  - Config validation
  - Unsupported language error handling
- All 32 pre-commit hooks pass ✅

## Example Output
For project `python-test-project`:
```
python-test-project/
├── python_test_project/
│   ├── __init__.py      # """Python Test Project package.""" __version__ = "0.1.0"
│   └── main.py          # Hello World with main() function
```

## Test Plan
- [x] All 32 pre-commit hooks pass (Gate 1 ✅)
- [x] CI pipeline passes (Gate 2 ✅)
- [ ] Claude review LGTM (Gate 3 ⏳)

## Related
- Fixes #178
- Part of #170 (Task #12/14)
- Depends on #176 (merged), #174 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)