### PR TITLE
feat(tests): add TestsGenerator for tests directory structure

### DIFF
--- a/start_green_stay_green/generators/tests_gen.py
+++ b/start_green_stay_green/generators/tests_gen.py
@@ -1,0 +1,190 @@
+"""Tests directory generator.
+
+Generates tests directory structure for target projects (tests/, tests/__init__.py,
+tests/test_main.py with passing test).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from start_green_stay_green.generators.base import BaseGenerator
+from start_green_stay_green.generators.base import GenerationError
+
+
+@dataclass(frozen=True)
+class TestsConfig:
+    """Configuration for tests structure generation.
+
+    Attributes:
+        project_name: Name of the project (e.g., "my-project")
+        language: Programming language (python, typescript, go, rust, etc.)
+        package_name: Name of the main package/module (e.g., "my_project")
+    """
+
+    project_name: str
+    language: str
+    package_name: str
+
+    def __post_init__(self) -> None:
+        """Validate configuration after initialization.
+
+        Raises:
+            ValueError: If any required field is empty
+        """
+        if not self.project_name:
+            msg = "Project name cannot be empty"
+            raise ValueError(msg)
+        if not self.language:
+            msg = "Language cannot be empty"
+            raise ValueError(msg)
+        if not self.package_name:
+            msg = "Package name cannot be empty"
+            raise ValueError(msg)
+
+
+class TestsGenerator(BaseGenerator):
+    """Generate tests directory structure for target projects.
+
+    This generator creates the tests directory structure (tests/, tests/__init__.py,
+    tests/test_main.py) with a passing test for the Hello World code.
+
+    Attributes:
+        output_dir: Directory where tests structure will be created
+        config: Configuration for tests generation
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        config: TestsConfig,
+    ) -> None:
+        """Initialize the Tests Generator.
+
+        Args:
+            output_dir: Directory where tests structure will be created
+            config: TestsConfig with project settings
+
+        Raises:
+            ValueError: If output_dir is invalid or language is unsupported
+        """
+        self.output_dir = Path(output_dir)
+        self.config = config
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        """Validate configuration and ensure output directory exists.
+
+        Raises:
+            ValueError: If configuration is invalid
+        """
+        if not self.config.language:
+            msg = "Language cannot be empty"
+            raise ValueError(msg)
+
+        if not self.config.package_name:
+            msg = "Package name cannot be empty"
+            raise ValueError(msg)
+
+        if not self.config.project_name:
+            msg = "Project name cannot be empty"
+            raise ValueError(msg)
+
+        # Ensure output directory exists
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def generate(self) -> dict[str, Any]:
+        """Generate tests directory structure.
+
+        Returns:
+            Dictionary mapping file names to their generated file paths
+
+        Raises:
+            GenerationError: If generation fails
+            ValueError: If configuration is invalid
+        """
+        files: dict[str, Path] = {}
+
+        # Generate language-specific tests structure
+        if self.config.language == "python":
+            files.update(self._generate_python_tests())
+        else:
+            # For now, only Python is supported
+            msg = f"Language {self.config.language} not supported yet"
+            raise GenerationError(msg)
+
+        return files
+
+    def _generate_python_tests(self) -> dict[str, Path]:
+        """Generate Python tests structure.
+
+        Returns:
+            Dictionary mapping file names to file paths
+        """
+        files: dict[str, Path] = {}
+
+        # Create tests directory
+        tests_dir = self.output_dir / "tests"
+        tests_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate tests/__init__.py
+        init_key = "tests/__init__.py"
+        files[init_key] = self._write_file(
+            tests_dir / "__init__.py",
+            self._python_tests_init_py(),
+        )
+
+        # Generate tests/test_main.py
+        test_main_key = "tests/test_main.py"
+        files[test_main_key] = self._write_file(
+            tests_dir / "test_main.py",
+            self._python_test_main_py(),
+        )
+
+        return files
+
+    def _write_file(self, file_path: Path, content: str) -> Path:
+        """Write a test file to disk.
+
+        Args:
+            file_path: Path where file will be written
+            content: Content to write to the file
+
+        Returns:
+            Path to the written file
+
+        Raises:
+            GenerationError: If file cannot be written
+        """
+        try:
+            file_path.write_text(content)
+        except OSError as e:
+            msg = f"Failed to write {file_path.name}: {e}"
+            raise GenerationError(msg, cause=e) from e
+        return file_path
+
+    def _python_tests_init_py(self) -> str:
+        """Generate Python tests/__init__.py content.
+
+        Returns:
+            Content for tests/__init__.py with package docstring
+        """
+        return f'"""Tests for {self.config.project_name}."""\n'
+
+    def _python_test_main_py(self) -> str:
+        """Generate Python tests/test_main.py content.
+
+        Returns:
+            Content for test_main.py with passing test for main()
+        """
+        return f'''"""Tests for {self.config.package_name}.main module."""
+
+from {self.config.package_name}.main import main
+
+
+def test_main_runs() -> None:
+    """Test that main() runs without error."""
+    main()  # Should print "Hello from {self.config.project_name}!"
+'''

--- a/tests/unit/generators/test_tests_generator.py
+++ b/tests/unit/generators/test_tests_generator.py
@@ -1,0 +1,228 @@
+"""Unit tests for Tests Generator."""
+
+import ast
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from start_green_stay_green.generators.base import GenerationError
+from start_green_stay_green.generators.tests_gen import TestsConfig as Config
+from start_green_stay_green.generators.tests_gen import TestsGenerator as Generator
+
+
+class TestGeneratorInitialization:
+    """Test TestsGen initialization and basic instantiation."""
+
+    def test_generator_can_be_instantiated(self) -> None:
+        """Test TestsGenerator can be created with config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            assert generator is not None
+            assert isinstance(generator, Generator)
+
+    def test_generator_has_generate_method(self) -> None:
+        """Test generator has generate method."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            assert hasattr(generator, "generate")
+            assert callable(generator.generate)
+
+
+class TestGeneration:
+    """Test tests directory structure generation."""
+
+    def test_generate_creates_tests_directory(self) -> None:
+        """Test generate creates tests directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            generator.generate()
+
+            # Should create tests directory
+            tests_dir = Path(tmpdir) / "tests"
+            assert tests_dir.exists()
+            assert tests_dir.is_dir()
+
+    def test_generate_creates_init_file(self) -> None:
+        """Test generate creates __init__.py in tests directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert "tests/__init__.py" in files
+            init_path = files["tests/__init__.py"]
+            assert init_path.exists()
+            assert init_path.is_file()
+
+    def test_generate_creates_test_main_file(self) -> None:
+        """Test generate creates test_main.py."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert "tests/test_main.py" in files
+            test_path = files["tests/test_main.py"]
+            assert test_path.exists()
+            assert test_path.is_file()
+
+    def test_init_has_docstring(self) -> None:
+        """Test tests/__init__.py contains docstring."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            init_path = files["tests/__init__.py"]
+            content = init_path.read_text()
+
+            # Should have triple-quoted docstring
+            assert '"""' in content
+
+    def test_test_main_has_test_function(self) -> None:
+        """Test test_main.py contains a test function."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            test_path = files["tests/test_main.py"]
+            content = test_path.read_text()
+
+            assert "def test_" in content
+
+    def test_test_main_imports_from_package(self) -> None:
+        """Test test_main.py imports from the source package."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            test_path = files["tests/test_main.py"]
+            content = test_path.read_text()
+
+            # Should import from the package
+            assert "from test_project" in content or "import test_project" in content
+            assert "main" in content
+
+    def test_test_main_calls_main_function(self) -> None:
+        """Test test_main.py calls main() function."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            test_path = files["tests/test_main.py"]
+            content = test_path.read_text()
+
+            # Should call main()
+            assert "main()" in content
+
+    def test_generated_files_are_valid_python(self) -> None:
+        """Test generated files are syntactically valid Python."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="python",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            # Try to compile the generated files
+            for file_path in files.values():
+                if file_path.suffix == ".py":
+                    content = file_path.read_text()
+                    # Should compile without SyntaxError
+                    ast.parse(content)
+
+
+class TestConfigValidation:
+    """Test TestsGenConfig validation."""
+
+    def test_config_requires_project_name(self) -> None:
+        """Test config validates project_name is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            Config(
+                project_name="",  # Empty string
+                language="python",
+                package_name="test",
+            )
+
+    def test_config_requires_language(self) -> None:
+        """Test config validates language is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            Config(
+                project_name="test",
+                language="",  # Empty string
+                package_name="test",
+            )
+
+    def test_config_requires_package_name(self) -> None:
+        """Test config validates package_name is provided."""
+        with pytest.raises((TypeError, ValueError)):
+            Config(
+                project_name="test",
+                language="python",
+                package_name="",  # Empty string
+            )
+
+
+class TestUnsupportedLanguage:
+    """Test error handling for unsupported languages."""
+
+    def test_unsupported_language_raises_generation_error(self) -> None:
+        """Test that unsupported language raises GenerationError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="rust",  # Not yet supported
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+
+            with pytest.raises(GenerationError) as exc_info:
+                generator.generate()
+
+            assert "not supported" in str(exc_info.value).lower()
+            assert "rust" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary
- Add TestsGenerator to create tests directory structure
- Generate `tests/` directory
- Generate `tests/__init__.py` with package docstring
- Generate `tests/test_main.py` with passing test for Hello World

## Root Cause (Issue #180)
Generated projects were missing tests directory:
- `./scripts/test.sh` failed with "ERROR: file or directory not found: tests/"
- `./scripts/check-all.sh` failed because tests couldn't run
- Coverage reports failed - nothing to test
- Users had to manually create tests directory and write first test

## Changes
**New Generator**: `TestsGenerator`
- Creates tests/ directory structure
- Inherits from BaseGenerator (architectural compliance)
- Supports Python projects (other languages TBD)

**tests/ Directory**:
- Created with proper structure

**tests/__init__.py**:
- Package docstring for tests
- Makes tests/ a proper Python package

**tests/test_main.py**:
- Simple passing test for main() function
- Imports from source package
- Tests that Hello World runs without error

## Testing
- 14 comprehensive tests covering:
  - Generator initialization
  - Directory creation
  - File generation (__init__.py, test_main.py)
  - Content validation (imports, test functions)
  - Python syntax validation (ast.parse)
  - Config validation
  - Unsupported language error handling
- All 32 pre-commit hooks pass ✅

## Example Output
For project `python-test-project`:
```
python-test-project/
├── python_test_project/
│   ├── __init__.py
│   └── main.py
├── tests/
│   ├── __init__.py      # """Tests for python-test-project."""
│   └── test_main.py     # def test_main_runs(): ...
```

## Test Plan
- [x] All 32 pre-commit hooks pass (Gate 1 ✅)
- [ ] CI pipeline passes (Gate 2)
- [ ] Claude review LGTM (Gate 3)

## Related
- Fixes #180
- Part of #170 (Task #13/14)
- Depends on #178 (PR #179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)