### PR TITLE
fix(generators): fix generated project failing check-all.sh

### DIFF
--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -253,6 +253,7 @@ dev = [
     "isort>=5.12.0",
     "mypy>=1.5.0",
     "bandit>=1.7.5",
+    "safety>=3.0.0",
     "radon>=6.0.0",
     "mutmut>=2.4.0",
     "pre-commit>=3.4.0",
@@ -310,6 +311,10 @@ precision = 2
 show_missing = true
 skip_covered = false
 fail_under = 90
+exclude_lines = [
+    "if __name__ == .__main__.",
+    "pragma: no cover",
+]
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -1208,8 +1208,8 @@ class TestPythonAnalyzeMutationsScript:
             assert "mutmut show <id>" in content
             assert "mutmut html" in content
 
-    def test_analyze_mutations_script_has_ruff_noqa_annotations(self) -> None:
-        """Test analyze_mutations.py has appropriate ruff noqa annotations."""
+    def test_analyze_mutations_script_has_no_unnecessary_noqa(self) -> None:
+        """Test analyze_mutations.py omits noqa for rules not in generated config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ScriptConfig(
                 language="python",
@@ -1219,9 +1219,11 @@ class TestPythonAnalyzeMutationsScript:
             scripts = generator.generate()
 
             content = scripts["analyze_mutations.py"].read_text()
-            assert "# ruff: noqa: T201" in content  # print() allowed
-            assert "# ruff: noqa: PLR0915" in content  # Many statements allowed
-            assert "# noqa: S608" in content  # SQL string formatting allowed
+            # T201 and PLR0915 are not enabled in generated ruff config
+            assert "# ruff: noqa: T201" not in content
+            assert "# ruff: noqa: PLR0915" not in content
+            # S608 should not appear inside SQL f-strings as string content
+            assert "# noqa: S608" not in content
 
     def test_analyze_mutations_script_handles_file_filter(self) -> None:
         """Test analyze_mutations.py supports filtering by filename."""


### PR DESCRIPTION
## Summary
- Fix double-braced f-strings in `analyze_mutations.py` template (36 lint errors → 0)
- Remove unused `noqa` directives for rules not enabled in generated ruff config
- Fix unsorted imports in analyze_mutations template (isort failure)
- Add `exclude_lines` for `if __name__ == "__main__"` pattern (coverage 71% → 100%)
- Remove SQL noqa comments embedded inside f-string query content (latent SQLite error)
- Add missing `safety` dependency to generated `pyproject.toml` dev deps

## Test plan
- [x] All 122 generator unit tests pass
- [x] Regenerated test-python-project passes all 7 `check-all.sh` checks (was 3/7)
- [x] Pre-commit hooks pass (32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)