### PR TITLE
fix(typescript): generate missing config files and fix quality checks

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -88,7 +88,7 @@ if $VERBOSE; then
 fi
 
 COV_START=$(date +%s)
-pytest "${COVERAGE_ARGS[@]}" tests/ 2>/tmp/coverage-stderr.txt || {
+pytest -m "not integration and not e2e" "${COVERAGE_ARGS[@]}" tests/ 2>/tmp/coverage-stderr.txt || {
     echo "✗ Coverage generation failed" >&2
     exit 1
 }

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -20,6 +20,7 @@ from rich.panel import Panel
 import typer
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
+from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.generators.architecture import (
     ArchitectureEnforcementGenerator,
 )
@@ -900,8 +901,22 @@ def _generate_project_files(
         _generate_precommit_step(project_path, project_name, language)
         _generate_skills_step(project_path)
 
-        # AI-powered features
-        _generate_with_orchestrator(project_path, project_name, language, orchestrator)
+        # AI-powered features (non-fatal: project is usable without AI content)
+        try:
+            _generate_with_orchestrator(
+                project_path, project_name, language, orchestrator
+            )
+        except (AIGenerationError, OSError) as ai_err:
+            console.print(
+                f"\n[yellow]Warning:[/yellow] AI-powered generation failed: {ai_err}"
+            )
+            console.print(
+                "[yellow]⊘[/yellow] Project generated without AI features "
+                "(CI, CLAUDE.md, architecture rules, subagents)."
+            )
+            console.print(
+                "  Re-run with a valid API key to generate these artifacts.\n"
+            )
 
         # Generate live metrics dashboard if enabled
         if enable_live_dashboard:

--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -232,6 +232,34 @@ if __name__ == "__main__":
             self._typescript_tsconfig_json(),
         )
 
+        # Generate .eslintrc.js
+        eslintrc_key = ".eslintrc.js"
+        files[eslintrc_key] = self._write_file(
+            self.output_dir / ".eslintrc.js",
+            self._typescript_eslintrc_js(),
+        )
+
+        # Generate .prettierrc
+        prettierrc_key = ".prettierrc"
+        files[prettierrc_key] = self._write_file(
+            self.output_dir / ".prettierrc",
+            self._typescript_prettierrc(),
+        )
+
+        # Generate jest.config.js
+        jest_config_key = "jest.config.js"
+        files[jest_config_key] = self._write_file(
+            self.output_dir / "jest.config.js",
+            self._typescript_jest_config_js(),
+        )
+
+        # Generate .prettierignore
+        prettierignore_key = ".prettierignore"
+        files[prettierignore_key] = self._write_file(
+            self.output_dir / ".prettierignore",
+            self._typescript_prettierignore(),
+        )
+
         return files
 
     def _typescript_index_ts(self) -> str:
@@ -276,6 +304,85 @@ main();
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }
+"""
+
+    def _typescript_eslintrc_js(self) -> str:
+        """Generate TypeScript .eslintrc.js content.
+
+        Returns:
+            Content for .eslintrc.js with TypeScript parser and recommended rules
+        """
+        return """module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ["dist", "node_modules"],
+};
+"""
+
+    def _typescript_prettierignore(self) -> str:
+        """Generate TypeScript .prettierignore content.
+
+        Returns:
+            Content for .prettierignore to exclude non-source files
+        """
+        return """dist
+node_modules
+coverage
+.claude
+"""
+
+    def _typescript_prettierrc(self) -> str:
+        """Generate TypeScript .prettierrc content.
+
+        Returns:
+            Content for .prettierrc with standard formatting options
+        """
+        return """{
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2
+}
+"""
+
+    def _typescript_jest_config_js(self) -> str:
+        """Generate TypeScript jest.config.js content.
+
+        Returns:
+            Content for jest.config.js with ts-jest preset and coverage thresholds
+        """
+        return """module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
+  testMatch: ["**/*.test.ts", "**/*.spec.ts"],
+  moduleFileExtensions: ["ts", "js", "json"],
+  collectCoverageFrom: [
+    "src/**/*.ts",
+    "!src/**/*.d.ts",
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+  },
+};
 """
 
     def _generate_go_structure(self) -> dict[str, Path]:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,10 @@
+"""Auto-mark all tests in tests/e2e/ as e2e tests."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Add e2e marker to all tests collected from this directory."""
+    for item in items:
+        if "/e2e/" in str(item.fspath):
+            item.add_marker(pytest.mark.e2e)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,10 @@
+"""Auto-mark all tests in tests/integration/ as integration tests."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Add integration marker to all tests collected from this directory."""
+    for item in items:
+        if "/integration/" in str(item.fspath):
+            item.add_marker(pytest.mark.integration)

--- a/tests/unit/generators/test_structure.py
+++ b/tests/unit/generators/test_structure.py
@@ -35,7 +35,13 @@ EXPECTED_ENTRY_POINTS: dict[str, str] = {
 # Expected config files per language
 EXPECTED_CONFIG_FILES: dict[str, list[str]] = {
     "python": [],
-    "typescript": ["tsconfig.json"],
+    "typescript": [
+        "tsconfig.json",
+        ".eslintrc.js",
+        ".prettierrc",
+        "jest.config.js",
+        ".prettierignore",
+    ],
     "go": ["go.mod"],
     "rust": ["Cargo.toml"],
     "java": ["pom.xml"],
@@ -443,3 +449,184 @@ class TestMultiLanguageStructure:
             assert "Gemfile" in files
             content = files["Gemfile"].read_text()
             assert "source" in content
+
+
+class TestTypeScriptConfigGeneration:
+    """Test TypeScript config file generation."""
+
+    def test_typescript_creates_eslintrc(self) -> None:
+        """Test TypeScript generates .eslintrc.js."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert ".eslintrc.js" in files
+            assert files[".eslintrc.js"].exists()
+
+    def test_eslintrc_uses_typescript_parser(self) -> None:
+        """Test .eslintrc.js configures @typescript-eslint/parser."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[".eslintrc.js"].read_text()
+            assert "@typescript-eslint/parser" in content
+            assert "@typescript-eslint" in content
+
+    def test_eslintrc_has_jest_env(self) -> None:
+        """Test .eslintrc.js enables jest environment."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[".eslintrc.js"].read_text()
+            assert "jest: true" in content
+
+    def test_eslintrc_ignores_dist_and_node_modules(self) -> None:
+        """Test .eslintrc.js ignores dist and node_modules."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[".eslintrc.js"].read_text()
+            assert "dist" in content
+            assert "node_modules" in content
+
+    def test_typescript_creates_prettierrc(self) -> None:
+        """Test TypeScript generates .prettierrc."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert ".prettierrc" in files
+            assert files[".prettierrc"].exists()
+
+    def test_prettierrc_has_formatting_options(self) -> None:
+        """Test .prettierrc contains formatting options."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[".prettierrc"].read_text()
+            assert "semi" in content
+            assert "trailingComma" in content
+            assert "printWidth" in content
+            assert "tabWidth" in content
+
+    def test_typescript_creates_jest_config(self) -> None:
+        """Test TypeScript generates jest.config.js."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert "jest.config.js" in files
+            assert files["jest.config.js"].exists()
+
+    def test_jest_config_uses_ts_jest_preset(self) -> None:
+        """Test jest.config.js uses ts-jest preset."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["jest.config.js"].read_text()
+            assert "ts-jest" in content
+            assert "node" in content
+
+    def test_jest_config_has_coverage_thresholds(self) -> None:
+        """Test jest.config.js has 90% coverage thresholds."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["jest.config.js"].read_text()
+            assert "coverageThreshold" in content
+            assert "90" in content
+
+    def test_jest_config_excludes_declaration_files(self) -> None:
+        """Test jest.config.js excludes .d.ts files from coverage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["jest.config.js"].read_text()
+            assert ".d.ts" in content
+
+    def test_typescript_creates_prettierignore(self) -> None:
+        """Test TypeScript generates .prettierignore."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert ".prettierignore" in files
+            assert files[".prettierignore"].exists()
+
+    def test_prettierignore_excludes_claude_directory(self) -> None:
+        """Test .prettierignore excludes .claude directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="typescript",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[".prettierignore"].read_text()
+            assert ".claude" in content
+            assert "dist" in content
+            assert "node_modules" in content


### PR DESCRIPTION
## Summary

- **Generate missing TypeScript config files**: `.eslintrc.js`, `.prettierrc`, `.prettierignore`, `jest.config.js` are now generated by `green init --language typescript`, fixing all 4 quality check failures in generated projects
- **Add `typecheck.sh` script**: was referenced by `check-all.sh` but never generated
- **Fix `JEST_ARGS` unbound variable**: safe empty-array expansion under `set -u` in generated `test.sh`
- **Make AI generation non-fatal**: projects are now usable without an API key — AI features (CLAUDE.md, subagents, architecture rules) show a warning instead of failing the entire generation
- **Fix test infrastructure**: auto-mark integration/e2e tests with pytest markers via `conftest.py` hooks; exclude them from `coverage.sh` to prevent hangs during pre-commit

## Test plan

- [x] All 32 pre-commit hooks pass locally (Gate 1)
- [ ] CI pipeline green (Gate 2)
- [ ] Code review LGTM (Gate 3)
- [x] 17 new unit tests covering all generated config files and scripts
- [x] Unit tests run in ~10s (1276 tests, 124 integration/e2e properly excluded)
- [ ] Regenerate a TypeScript project and verify `./scripts/check-all.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)