### PR TITLE
fix(tests): address PR #198 review feedback — DRY and assertion quality

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,36 @@ This module provides:
 - Common test fixtures
 - Test isolation enforcement
 - Language parametrization fixtures for multi-language testing
+- API key isolation helpers for subprocess-based tests
 """
 
 from collections.abc import Generator
+import os
 from pathlib import Path
 
 import pytest
 
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
+
+
+def get_env_without_api_keys() -> dict[str, str]:
+    """Return a copy of os.environ with Anthropic API keys removed.
+
+    Prevents subprocess-based tests from calling the real Anthropic API.
+    Uses null keyring backend to prevent keyring lookups.
+
+    This is the canonical helper for API key isolation in subprocess tests.
+    See Issue #196.
+
+    Returns:
+        Environment dict with API keys removed and null keyring backend.
+    """
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)
+    env.pop("CLAUDE_API_KEY", None)
+    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    return env
+
 
 # Expected file extensions per language
 LANGUAGE_EXTENSIONS: dict[str, str] = {

--- a/tests/e2e/test_init_command.py
+++ b/tests/e2e/test_init_command.py
@@ -9,26 +9,11 @@ backend to prevent real Anthropic API calls. See Issue #196.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 import subprocess
 import tempfile
 
-
-def _get_env_without_api_keys() -> dict[str, str]:
-    """Return a copy of os.environ with Anthropic API keys removed.
-
-    Prevents subprocess-based tests from calling the real Anthropic API.
-    Uses null keyring backend to prevent keyring lookups.
-
-    Returns:
-        Environment dict with API keys removed and null keyring backend.
-    """
-    env = os.environ.copy()
-    env.pop("ANTHROPIC_API_KEY", None)
-    env.pop("CLAUDE_API_KEY", None)
-    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    return env
+from tests.conftest import get_env_without_api_keys
 
 
 class TestInitCommand:
@@ -57,7 +42,7 @@ class TestInitCommand:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             # Verify command succeeded
@@ -131,7 +116,7 @@ class TestInitCommand:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             assert result.returncode == 0, f"Command failed: {result.stderr}"
@@ -169,7 +154,7 @@ class TestInitCommand:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             assert result.returncode == 0, f"Command failed: {result.stderr}"

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -14,12 +14,13 @@ backend to prevent real Anthropic API calls. See Issue #196.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 import subprocess
 import tempfile
 
 import pytest
+
+from tests.conftest import get_env_without_api_keys
 
 # Languages fully supported in the CLI pipeline (all generators)
 CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust")
@@ -58,22 +59,6 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
 }
 
 
-def _get_env_without_api_keys() -> dict[str, str]:
-    """Return a copy of os.environ with Anthropic API keys removed.
-
-    Prevents subprocess-based tests from calling the real Anthropic API.
-    Uses null keyring backend to prevent keyring lookups.
-
-    Returns:
-        Environment dict with API keys removed and null keyring backend.
-    """
-    env = os.environ.copy()
-    env.pop("ANTHROPIC_API_KEY", None)
-    env.pop("CLAUDE_API_KEY", None)
-    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    return env
-
-
 class TestLanguageE2E:
     """E2E tests for sgsg init with each supported language."""
 
@@ -96,7 +81,7 @@ class TestLanguageE2E:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             assert (
@@ -130,7 +115,7 @@ class TestLanguageE2E:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             assert (
@@ -155,7 +140,7 @@ class TestLanguageE2E:
                 capture_output=True,
                 text=True,
                 check=False,
-                env=_get_env_without_api_keys(),
+                env=get_env_without_api_keys(),
             )
 
             assert result.returncode == 0, f"sgsg init failed: {result.stdout}"

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -341,7 +341,8 @@ class TestInitFlowIntegration:
 
         content = claude_md.read_text()
         assert "# Claude Code Project Context" in content
-        assert len(content) > 10
+        assert "test-claude-md-project" in content
+        assert len(content) > 50
 
     def test_init_generates_skills_directory(self, tmp_path: Path) -> None:
         """Test init creates .claude/skills directory with skill files.

--- a/tests/integration/test_init_output_dir.py
+++ b/tests/integration/test_init_output_dir.py
@@ -6,29 +6,12 @@ See Issue #196.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 import subprocess
 import sys
 import tempfile
 
-
-def _get_env_without_api_keys() -> dict[str, str]:
-    """Return a copy of os.environ with Anthropic API keys removed.
-
-    Prevents subprocess-based tests from calling the real Anthropic API
-    via environment variables. Also sets SGSG_SKIP_KEYRING=1 to prevent
-    keyring lookups.
-
-    Returns:
-        Environment dict with API keys removed.
-    """
-    env = os.environ.copy()
-    env.pop("ANTHROPIC_API_KEY", None)
-    env.pop("CLAUDE_API_KEY", None)
-    # Force keyring to use a null backend so it returns no stored keys
-    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    return env
+from tests.conftest import get_env_without_api_keys
 
 
 def test_init_with_output_dir_creates_files() -> None:
@@ -55,7 +38,7 @@ def test_init_with_output_dir_creates_files() -> None:
             capture_output=True,
             text=True,
             check=False,
-            env=_get_env_without_api_keys(),
+            env=get_env_without_api_keys(),
         )
 
         # Check command succeeded
@@ -119,7 +102,7 @@ def test_init_output_dir_resolves_correctly() -> None:
             capture_output=True,
             text=True,
             check=False,
-            env=_get_env_without_api_keys(),
+            env=get_env_without_api_keys(),
         )
 
         assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Extract triplicated `_get_env_without_api_keys()` to `tests/conftest.py` as canonical `get_env_without_api_keys()` helper (DRY principle fix)
- Tighten weakened `assert len(content) > 10` to `> 50` plus assert project name in content for mutation-killing specificity

## Context
Claude code review on PR #198 gave CHANGES_REQUESTED with two required fixes:
1. DRY violation: helper function copy-pasted in 3 files instead of shared
2. Weakened assertion: `> 10` too permissive for stub content validation

## Test plan
- [x] All 31 pre-commit hooks pass (Gate 1)
- [ ] CI pipeline green (Gate 2)
- [ ] Claude review LGTM (Gate 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)