### PR TITLE
fix(metrics): replace substring path check with proper ancestry (#209)

### DIFF
--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -339,14 +339,12 @@ class MetricsGenerator(BaseGenerator):
         """
         # Resolve to absolute path
         resolved_path = output_dir.resolve()
-        resolved_str = str(resolved_path)
 
-        # Check against dangerous paths
+        # Check against dangerous paths using proper path ancestry
         for dangerous_path in DANGEROUS_PATHS:
             dangerous_resolved = Path(dangerous_path).expanduser().resolve()
-            if (
-                resolved_path == dangerous_resolved
-                or str(dangerous_resolved) in resolved_str
+            if resolved_path == dangerous_resolved or resolved_path.is_relative_to(
+                dangerous_resolved
             ):
                 msg = (
                     f"Output directory '{output_dir}' resolves to dangerous "

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -7,6 +7,7 @@ across multiple languages and configurations.
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -503,6 +504,33 @@ class TestSecurityValidations:
             safe_path = Path(tmpdir) / "project" / "metrics"
             # Should not raise
             result = generator.write_metrics_config(safe_path)
+            assert result.exists()
+
+    @patch(
+        "start_green_stay_green.generators.metrics.DANGEROUS_PATHS",
+        {"/run", "/etc"},
+    )
+    def test_output_dir_no_false_positive_on_substring_match(self) -> None:
+        """Test that paths containing dangerous substrings are not blocked (#209).
+
+        On Ubuntu, /var/run resolves to /run via symlink. A naive substring
+        check would block /home/runner/work/... because '/run' appears in
+        '/runner'. The fix uses proper path ancestry checks.
+        """
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+        )
+        generator = MetricsGenerator(None, config)
+
+        with TemporaryDirectory() as tmpdir:
+            # Create path that contains '/run' as a substring (like /runner)
+            runner_path = Path(tmpdir) / "runner" / "work" / "docs"
+            runner_path.mkdir(parents=True)
+            # Should NOT raise — /runner is not a child of /run
+            result = generator.write_dashboard(runner_path)
+            assert result is not None
             assert result.exists()
 
     def test_dashboard_html_escapes_project_name(self) -> None:


### PR DESCRIPTION
## Summary

- `_validate_output_dir()` used naive substring matching (`str(dangerous_resolved) in resolved_str`) which caused false positives on Ubuntu CI where `/var/run` → `/run` matched inside `/home/runner/work/...`
- Replaced with `resolved_path.is_relative_to(dangerous_resolved)` for proper path ancestry checking
- Added TDD test that reproduces the false positive by mocking `DANGEROUS_PATHS` with `/run`

Fixes #209

## Test plan

- [x] Gate 1: `pre-commit run --all-files` — all hooks pass
- [ ] Gate 2: CI pipeline green
- [ ] Gate 3: Code review LGTM
- [ ] Verify metrics workflow succeeds after merge (dashboard regeneration step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)