### PR TITLE
fix(dashboard): add null guards to all JS metric handlers (#212)

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -235,20 +235,35 @@
 
             // Coverage
             if (metrics.coverage !== undefined) {
-                updateMetric('coverage', metrics.coverage, '%',
-                    metrics.coverage >= thresholds.coverage);
+                if (metrics.coverage === null) {
+                    document.getElementById('coverage-value').textContent = 'N/A';
+                    updateStatus('coverage', 'NO DATA', false);
+                } else {
+                    updateMetric('coverage', metrics.coverage, '%',
+                        metrics.coverage >= thresholds.coverage);
+                }
             }
 
             // Branch Coverage
             if (metrics.branch_coverage !== undefined) {
-                updateMetric('branch', metrics.branch_coverage, '%',
-                    metrics.branch_coverage >= thresholds.branch_coverage);
+                if (metrics.branch_coverage === null) {
+                    document.getElementById('branch-value').textContent = 'N/A';
+                    updateStatus('branch', 'NO DATA', false);
+                } else {
+                    updateMetric('branch', metrics.branch_coverage, '%',
+                        metrics.branch_coverage >= thresholds.branch_coverage);
+                }
             }
 
             // Mutation Score
             if (metrics.mutation_score !== undefined) {
-                updateMetric('mutation', metrics.mutation_score, '%',
-                    metrics.mutation_score >= thresholds.mutation_score);
+                if (metrics.mutation_score === null) {
+                    document.getElementById('mutation-value').textContent = 'N/A';
+                    updateStatus('mutation', 'NO DATA', false);
+                } else {
+                    updateMetric('mutation', metrics.mutation_score, '%',
+                        metrics.mutation_score >= thresholds.mutation_score);
+                }
             }
 
             // Complexity
@@ -275,11 +290,16 @@
 
             // Security
             if (metrics.security_issues !== undefined) {
-                const elem = document.getElementById('security-value');
-                elem.textContent = metrics.security_issues;
-                updateStatus('security',
-                    metrics.security_issues === 0 ? 'PASSING' : 'FAILING',
-                    metrics.security_issues === 0);
+                if (metrics.security_issues === null) {
+                    document.getElementById('security-value').textContent = 'N/A';
+                    updateStatus('security', 'NO DATA', false);
+                } else {
+                    const elem = document.getElementById('security-value');
+                    elem.textContent = metrics.security_issues;
+                    updateStatus('security',
+                        metrics.security_issues === 0 ? 'PASSING' : 'FAILING',
+                        metrics.security_issues === 0);
+                }
             }
 
             // Maintainability Index

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -830,20 +830,35 @@ class MetricsGenerator(BaseGenerator):
 
             // Coverage
             if (metrics.coverage !== undefined) {{
-                updateMetric('coverage', metrics.coverage, '%',
-                    metrics.coverage >= thresholds.coverage);
+                if (metrics.coverage === null) {{
+                    document.getElementById('coverage-value').textContent = 'N/A';
+                    updateStatus('coverage', 'NO DATA', false);
+                }} else {{
+                    updateMetric('coverage', metrics.coverage, '%',
+                        metrics.coverage >= thresholds.coverage);
+                }}
             }}
 
             // Branch Coverage
             if (metrics.branch_coverage !== undefined) {{
-                updateMetric('branch', metrics.branch_coverage, '%',
-                    metrics.branch_coverage >= thresholds.branch_coverage);
+                if (metrics.branch_coverage === null) {{
+                    document.getElementById('branch-value').textContent = 'N/A';
+                    updateStatus('branch', 'NO DATA', false);
+                }} else {{
+                    updateMetric('branch', metrics.branch_coverage, '%',
+                        metrics.branch_coverage >= thresholds.branch_coverage);
+                }}
             }}
 
             // Mutation Score
             if (metrics.mutation_score !== undefined) {{
-                updateMetric('mutation', metrics.mutation_score, '%',
-                    metrics.mutation_score >= thresholds.mutation_score);
+                if (metrics.mutation_score === null) {{
+                    document.getElementById('mutation-value').textContent = 'N/A';
+                    updateStatus('mutation', 'NO DATA', false);
+                }} else {{
+                    updateMetric('mutation', metrics.mutation_score, '%',
+                        metrics.mutation_score >= thresholds.mutation_score);
+                }}
             }}
 
             // Complexity
@@ -870,11 +885,16 @@ class MetricsGenerator(BaseGenerator):
 
             // Security
             if (metrics.security_issues !== undefined) {{
-                const elem = document.getElementById('security-value');
-                elem.textContent = metrics.security_issues;
-                updateStatus('security',
-                    metrics.security_issues === 0 ? 'PASSING' : 'FAILING',
-                    metrics.security_issues === 0);
+                if (metrics.security_issues === null) {{
+                    document.getElementById('security-value').textContent = 'N/A';
+                    updateStatus('security', 'NO DATA', false);
+                }} else {{
+                    const elem = document.getElementById('security-value');
+                    elem.textContent = metrics.security_issues;
+                    updateStatus('security',
+                        metrics.security_issues === 0 ? 'PASSING' : 'FAILING',
+                        metrics.security_issues === 0);
+                }}
             }}
 
             // Maintainability Index

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -1615,6 +1615,26 @@ class TestDashboardJavaScript:
         dashboard = self._get_dashboard()
         assert "metrics.tests_failed" in dashboard
 
+    def test_js_handles_null_coverage(self) -> None:
+        """Test JavaScript has null check for coverage (#212)."""
+        dashboard = self._get_dashboard()
+        assert "metrics.coverage === null" in dashboard
+
+    def test_js_handles_null_branch_coverage(self) -> None:
+        """Test JavaScript has null check for branch coverage (#212)."""
+        dashboard = self._get_dashboard()
+        assert "metrics.branch_coverage === null" in dashboard
+
+    def test_js_handles_null_mutation_score(self) -> None:
+        """Test JavaScript has null check for mutation score (#212)."""
+        dashboard = self._get_dashboard()
+        assert "metrics.mutation_score === null" in dashboard
+
+    def test_js_handles_null_security_issues(self) -> None:
+        """Test JavaScript has null check for security issues (#212)."""
+        dashboard = self._get_dashboard()
+        assert "metrics.security_issues === null" in dashboard
+
     def test_js_handles_null_maintainability(self) -> None:
         """Test JavaScript has null check for maintainability."""
         dashboard = self._get_dashboard()


### PR DESCRIPTION
## Summary

- `updateDashboard()` JS crashed at `mutation_score` when it was `null` — the guard `!== undefined` passed but `null.toFixed(2)` threw TypeError
- The `catch` block called `updatePlaceholder()` which overwrote ALL status badges to "NO DATA", including metrics that had already rendered
- Added null guards to `coverage`, `branch_coverage`, `mutation_score`, and `security_issues` handlers, matching the pattern already used by the other 7 metrics
- Fixed in both the template (`generators/metrics.py`) for generated projects AND the deployed file (`docs/dashboard.html`)
- Added 4 regression tests for the null guard checks

Fixes #212

## Test plan

- [x] Gate 1: `pre-commit run --all-files` — all hooks pass
- [ ] Gate 2: CI pipeline green
- [ ] Gate 3: Code review LGTM
- [ ] Verify dashboard shows data for metrics that have values and "N/A" for null metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)