### PR TITLE
feat(scripts): port pr-status.sh from creek-tools (#211)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,7 @@ When delegating work to subagents, provide:
 - `scripts/security.sh`: Security scanning
 - `scripts/mutation.sh`: Run mutation tests
 - `scripts/complexity.sh`: Analyze code complexity
+- `scripts/pr-status.sh`: Monitor PR merge-readiness (CI + Claude review)
 
 ---
 

--- a/claude/tools.md
+++ b/claude/tools.md
@@ -102,6 +102,19 @@ pre-commit run --all-files
 # This takes several minutes - runs automatically in CI
 ```
 
+**`./scripts/pr-status.sh`** - Monitor PR merge-readiness (CI + Claude review)
+
+```bash
+# Subcommand-based CLI for PR monitoring
+./scripts/pr-status.sh list                    # List recent CI runs
+./scripts/pr-status.sh list --branch feat/foo  # Filter by branch
+./scripts/pr-status.sh view 12345              # View run #12345
+./scripts/pr-status.sh watch 12345 12346       # Watch two runs
+./scripts/pr-status.sh checks 74               # Show PR #74 checks
+./scripts/pr-status.sh status 74               # Full PR verdict (CI + Claude review)
+./scripts/pr-status.sh --version               # Show version
+```
+
 **Other Available Scripts** (used by pre-commit hooks):
 
 - **`./scripts/format.sh`** - Auto-format code (use `pre-commit run --all-files` instead)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,6 +2,11 @@
 # scripts/common.sh - Common utilities for quality scripts
 # Source this file in other scripts to get venv handling
 
+# Disable macOS Keychain prompts from pip/pip-audit.
+# Python's keyring library defaults to macOS Keychain, which triggers
+# 3 separate GUI dialog boxes per pre-commit run when pip accesses PyPI.
+export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+
 # Ensure venv with required dependencies
 # Usage: ensure_venv
 # Sets global variable: TEMP_VENV_CREATED=true if venv was created

--- a/scripts/pr-status.sh
+++ b/scripts/pr-status.sh
@@ -1,373 +1,441 @@
 #!/usr/bin/env bash
-# scripts/pr-status.sh - Monitor PR status, CI checks, and reviews
-# Usage: ./scripts/pr-status.sh [PR_NUMBERS...] [--verbose] [--json] [--watch] [--version] [--help]
+# scripts/pr-status.sh - GitHub Actions workflow monitor for PRs
+# Usage: ./scripts/pr-status.sh <subcommand> [OPTIONS]
 
 set -euo pipefail
 
-VERSION="1.0.0"
-
+VERSION="2.0.0"
 VERBOSE=false
-JSON_OUTPUT=false
-WATCH_MODE=false
-WATCH_INTERVAL=30
-START_TIME=$(date +%s)
 
-# Detect if running in interactive terminal
-IS_INTERACTIVE=false
-if [[ -t 1 ]]; then
-    IS_INTERACTIVE=true
+# Auto-detect repo
+get_repo() {
+    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+# Print usage
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <subcommand> [OPTIONS]
+
+GitHub Actions workflow monitor for PRs.
+
+SUBCOMMANDS:
+    list [--branch NAME] [--limit N]    List recent CI workflow runs
+    view ID [ID...]                      View workflow run conclusions
+    watch ID [ID...]                     Watch runs until complete
+    checks PR_NUMBER                     Show PR check status
+    status PR_NUMBER [--workflow FILE]   Full PR verdict (CI + Claude review)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --version   Show version and exit
+    --help      Display this help message
+
+STATUS OPTIONS:
+    --workflow FILE   CI workflow filename (default: ci.yml)
+
+EXIT CODES:
+    0           Success / ready to merge
+    1           Failure / not ready to merge
+    2           Usage error
+
+EXAMPLES:
+    $(basename "$0") list                    # List recent CI runs
+    $(basename "$0") list --branch feat/foo  # Filter by branch
+    $(basename "$0") view 12345              # View run #12345
+    $(basename "$0") watch 12345 12346       # Watch two runs
+    $(basename "$0") checks 74               # Show PR #74 checks
+    $(basename "$0") status 74               # Full PR #74 verdict
+EOF
+}
+
+# === list subcommand ===
+cmd_list() {
+    local branch=""
+    local limit=10
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --branch)
+                branch="$2"
+                shift 2
+                ;;
+            --limit)
+                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    echo "Error: --limit requires a numeric value, got '$2'" >&2
+                    exit 2
+                fi
+                limit="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for list: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== Recent CI Workflow Runs ==="
+    echo ""
+
+    local args=(run list --repo "$repo" --limit "$limit")
+    if [[ -n "$branch" ]]; then
+        args+=(--branch "$branch")
+    fi
+    args+=(--json "databaseId,headBranch,workflowName,status,conclusion,createdAt")
+    args+=(--jq '.[] | [(.databaseId|tostring), .headBranch, .workflowName, .status, (.conclusion // "—"), .createdAt] | @tsv')
+
+    if $VERBOSE; then
+        echo "Running: gh ${args[*]}"
+    fi
+
+    printf "%-12s %-30s %-20s %-12s %-18s %s\n" "ID" "BRANCH" "WORKFLOW" "STATUS" "CONCLUSION" "CREATED"
+    printf "%-12s %-30s %-20s %-12s %-18s %s\n" "----" "------" "--------" "------" "----------" "-------"
+
+    gh "${args[@]}" | while IFS=$'\t' read -r id branch_name workflow status conclusion created; do
+        printf "%-12s %-30s %-20s %-12s %-18s %s\n" "$id" "$branch_name" "$workflow" "$status" "$conclusion" "$created"
+    done
+}
+
+# === view subcommand ===
+cmd_view() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: view requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Run #${run_id} ==="
+        echo ""
+
+        local run_json
+        run_json="$(gh run view "$run_id" --repo "$repo" --json "status,conclusion,workflowName,headBranch,jobs")"
+
+        if $VERBOSE; then
+            echo "Fetched run data for #${run_id}"
+        fi
+
+        local status conclusion workflow branch
+        read -r workflow branch status conclusion < <(
+            echo "$run_json" | jq -r '[.workflowName, .headBranch, .status, (.conclusion // "—")] | @tsv'
+        )
+
+        echo "Workflow:   $workflow"
+        echo "Branch:     $branch"
+        echo "Status:     $status"
+        echo "Conclusion: $conclusion"
+        echo ""
+
+        echo "Jobs:"
+        echo "$run_json" | jq -r '.jobs[] | "  \(if .conclusion == "success" then "✓" elif .conclusion == "failure" then "✗" elif .conclusion == "skipped" then "—" else "●" end) \(.name): \(.conclusion // .status)"'
+        echo ""
+
+        if [[ "$conclusion" == "failure" ]]; then
+            any_failed=true
+        fi
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === watch subcommand ===
+cmd_watch() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: watch requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Watching Run #${run_id} ==="
+        echo ""
+
+        if $VERBOSE; then
+            echo "Watching run #${run_id} in repo $repo"
+        fi
+
+        if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+            any_failed=true
+            echo "✗ Run #${run_id} failed" >&2
+        else
+            echo "✓ Run #${run_id} passed"
+        fi
+        echo ""
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}
+
+# === checks subcommand ===
+cmd_checks() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: checks requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== PR #${pr_number} Checks ==="
+    echo ""
+
+    if $VERBOSE; then
+        echo "Fetching checks for PR #${pr_number} in repo $repo"
+    fi
+
+    gh pr checks "$pr_number" --repo "$repo"
+}
+
+# === status subcommand ===
+cmd_status() {
+    if [[ $# -eq 0 ]]; then
+        echo "Error: status requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    shift
+    local workflow="ci.yml"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --workflow)
+                workflow="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for status: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    # Get PR info
+    local pr_json
+    pr_json="$(gh pr view "$pr_number" --repo "$repo" --json "title,headRefName,comments")"
+
+    local pr_title pr_branch
+    pr_title="$(echo "$pr_json" | jq -r '.title')"
+    pr_branch="$(echo "$pr_json" | jq -r '.headRefName')"
+
+    echo "=== PR #${pr_number}: ${pr_title} ==="
+    echo ""
+
+    # --- CI Status ---
+    local ci_status="UNKNOWN"
+    local ci_detail=""
+    local ci_pass=false
+
+    local run_json
+    if $VERBOSE; then
+        echo "Looking for workflow: $workflow on branch: $pr_branch"
+    fi
+
+    run_json="$(gh run list --repo "$repo" --branch "$pr_branch" --workflow "$workflow" --limit 1 --json "databaseId,conclusion,status" 2>/dev/null || echo "[]")"
+
+    local run_count
+    run_count="$(echo "$run_json" | jq 'length')"
+
+    if [[ "$run_count" -eq 0 ]]; then
+        ci_status="NO RUNS"
+        ci_detail="No CI runs found for branch $pr_branch"
+        echo "Warning: No runs found for workflow '$workflow' on branch '$pr_branch'." >&2
+        echo "  Check workflow filename or use --workflow <file> to specify." >&2
+    else
+        local run_id run_conclusion run_status
+        run_id="$(echo "$run_json" | jq -r '.[0].databaseId')"
+        run_conclusion="$(echo "$run_json" | jq -r '.[0].conclusion // ""')"
+        run_status="$(echo "$run_json" | jq -r '.[0].status')"
+
+        if [[ "$run_status" != "completed" ]]; then
+            ci_status="IN PROGRESS"
+            ci_detail="Run #${run_id} is ${run_status}"
+        else
+            local jobs_json
+            jobs_json="$(gh run view "$run_id" --repo "$repo" --json jobs)"
+
+            local total_jobs passed_jobs failed_jobs
+            total_jobs="$(echo "$jobs_json" | jq '.jobs | length')"
+            passed_jobs="$(echo "$jobs_json" | jq '[.jobs[] | select(.conclusion == "success")] | length')"
+            failed_jobs="$(echo "$jobs_json" | jq '[.jobs[] | select(.conclusion == "failure")] | length')"
+
+            if [[ "$run_conclusion" == "success" ]]; then
+                ci_status="PASS"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green"
+                ci_pass=true
+            else
+                ci_status="FAIL"
+                ci_detail="${passed_jobs}/${total_jobs} jobs green, ${failed_jobs} failed"
+
+                # Show failed jobs
+                local failed_names
+                failed_names="$(echo "$jobs_json" | jq -r '.jobs[] | select(.conclusion == "failure") | .name')"
+                if [[ -n "$failed_names" ]]; then
+                    ci_detail="${ci_detail}"$'\n'"Failed jobs:"
+                    while IFS= read -r name; do
+                        ci_detail="${ci_detail}"$'\n'"  ✗ ${name}"
+                    done <<< "$failed_names"
+                fi
+            fi
+        fi
+    fi
+
+    # --- Claude Review Status ---
+    local review_status="NO REVIEW"
+    local review_issues=""
+    local review_pass=false
+
+    # Scan comments for Claude review verdicts (latest wins)
+    local comments_count
+    comments_count="$(echo "$pr_json" | jq '.comments | length')"
+
+    if [[ "$comments_count" -gt 0 ]]; then
+        # Search from latest comment backwards for a verdict
+        local i
+        for ((i = comments_count - 1; i >= 0; i--)); do
+            local body
+            body="$(echo "$pr_json" | jq -r ".comments[$i].body")"
+
+            # Check for verdict patterns
+            if echo "$body" | grep -qE '✅\s*LGTM|Verdict:.*LGTM'; then
+                review_status="LGTM"
+                review_pass=true
+                break
+            elif echo "$body" | grep -qE '🔄\s*CHANGES_REQUESTED|Verdict:.*CHANGES_REQUESTED'; then
+                review_status="CHANGES_REQUESTED"
+
+                # Extract problems section
+                review_issues="$(echo "$body" | sed -n '/^## Problems/,/^## [^P]/p' | sed '$d')"
+                if [[ -z "$review_issues" ]]; then
+                    # Try alternate format: lines starting with 🔴
+                    review_issues="$(echo "$body" | grep '🔴' || true)"
+                fi
+                break
+            elif echo "$body" | grep -qE '💬\s*COMMENTS|Verdict:.*COMMENTS'; then
+                review_status="COMMENTS"
+                review_pass=true
+                break
+            fi
+        done
+    fi
+
+    # --- Output ---
+    if $ci_pass; then
+        echo "CI Status:     ✓ ${ci_status}  (${ci_detail})"
+    else
+        echo "CI Status:     ✗ ${ci_status}  (${ci_detail})"
+    fi
+
+    if $review_pass; then
+        echo "Claude Review: ✓ ${review_status}"
+    else
+        echo "Claude Review: ✗ ${review_status}"
+    fi
+
+    if [[ -n "$review_issues" ]]; then
+        echo ""
+        echo "Review Issues:"
+        echo "$review_issues" | while IFS= read -r line; do
+            # Indent if not already indented
+            if [[ "$line" == "  "* ]]; then
+                echo "$line"
+            else
+                echo "  $line"
+            fi
+        done
+    fi
+
+    echo ""
+
+    # --- Verdict ---
+    if $ci_pass && $review_pass; then
+        echo "Verdict: READY TO MERGE"
+        exit 0
+    else
+        echo "Verdict: NOT READY TO MERGE"
+        exit 1
+    fi
+}
+
+# === Main argument parsing ===
+
+# Handle no arguments
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
 fi
 
-# Parse command line arguments
-PR_NUMBERS=()
+# Extract global flags first, collect remaining args
+REMAINING_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --verbose)
             VERBOSE=true
             shift
             ;;
-        --json)
-            JSON_OUTPUT=true
-            shift
-            ;;
-        --watch)
-            WATCH_MODE=true
-            shift
-            ;;
-        --interval)
-            WATCH_INTERVAL="$2"
-            shift 2
-            ;;
         --version)
             echo "$(basename "$0") version $VERSION"
             exit 0
             ;;
-        --help)
-            cat << HELP
-Usage: $(basename "$0") [PR_NUMBERS...] [OPTIONS]
-
-Monitor GitHub PR status including CI checks and Claude reviews.
-
-ARGUMENTS:
-    PR_NUMBERS      One or more PR numbers to check (e.g., 63 64 65)
-                    If not provided, checks all open PRs
-
-OPTIONS:
-    --verbose       Show detailed output
-    --json          Output results in JSON format
-    --watch         Continuously monitor (refresh every 30s)
-                    Note: Auto-detects interactive terminal for optimal display
-    --interval N    Set watch interval to N seconds (default: 30)
-    --version       Show version and exit
-    --help          Display this help message
-
-EXIT CODES:
-    0               All PRs passing or status retrieved successfully
-    1               One or more PRs failing
-    2               Error (missing dependencies, invalid arguments)
-
-WATCH MODE:
-    In interactive terminals: Clears screen between updates
-    In background/captured:   Uses separators with timestamps
-
-EXAMPLES:
-    $(basename "$0") 63 64 65           # Check specific PRs
-    $(basename "$0") --verbose          # Check all open PRs with details
-    $(basename "$0") 63 --watch         # Continuously monitor PR #63
-    $(basename "$0") 63 64 --json       # JSON output for PRs 63 and 64
-
-REQUIREMENTS:
-    - GitHub CLI (gh) must be installed and authenticated
-HELP
+        --help|-h)
+            usage
             exit 0
             ;;
-        -*)
-            echo "Error: Unknown option: $1" >&2
-            exit 2
-            ;;
         *)
-            PR_NUMBERS+=("$1")
+            REMAINING_ARGS+=("$1")
             shift
             ;;
     esac
 done
 
-# Check for gh CLI
-if ! command -v gh &> /dev/null; then
-    echo "Error: GitHub CLI (gh) is not installed" >&2
-    echo "Install: https://cli.github.com/" >&2
+# Restore positional args
+set -- "${REMAINING_ARGS[@]+"${REMAINING_ARGS[@]}"}"
+
+if [[ $# -eq 0 ]]; then
+    usage
     exit 2
 fi
 
-# Get repository info
-REPO_OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || echo "")
-REPO_NAME=$(gh repo view --json name --jq '.name' 2>/dev/null || echo "")
+SUBCOMMAND="$1"
+shift
 
-if [[ -z "$REPO_OWNER" || -z "$REPO_NAME" ]]; then
-    echo "Error: Not in a GitHub repository or gh CLI not authenticated" >&2
-    exit 2
-fi
-
-# If no PR numbers provided, get all open PRs
-if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
-    mapfile -t PR_NUMBERS < <(gh pr list --state open --json number --jq '.[].number')
-    if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
-        echo "No open PRs found"
-        exit 0
-    fi
-fi
-
-# Function to check a single PR
-check_pr() {
-    local pr_number="$1"
-    local pr_data
-    local ci_checks
-    local review_comments
-
-    # Get PR details
-    pr_data=$(gh pr view "$pr_number" --json number,title,state,mergeable,url,author 2>/dev/null || echo "")
-
-    if [[ -z "$pr_data" ]]; then
-        echo "Error: PR #$pr_number not found" >&2
-        return 1
-    fi
-
-    local pr_title
-    local pr_state
-    local pr_mergeable
-    local pr_url
-    local pr_author
-    pr_title=$(echo "$pr_data" | jq -r '.title')
-    pr_state=$(echo "$pr_data" | jq -r '.state')
-    pr_mergeable=$(echo "$pr_data" | jq -r '.mergeable')
-    pr_url=$(echo "$pr_data" | jq -r '.url')
-    pr_author=$(echo "$pr_data" | jq -r '.author.login')
-
-    # Get CI checks
-    ci_checks=$(gh pr checks "$pr_number" 2>&1 || echo "no checks reported")
-
-    # Get Claude review comments
-    review_comments=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$pr_number/comments" \
-        --jq '.[] | select(.user.login == "claude[bot]") | {created_at: .created_at, body: .body}' 2>/dev/null || echo "")
-
-    # Count check statuses
-    local total_checks=0
-    local passing_checks=0
-    local failing_checks=0
-    local pending_checks=0
-
-    if [[ "$ci_checks" != "no checks reported"* ]]; then
-        total_checks=$(echo "$ci_checks" | wc -l | xargs)
-        passing_checks=$(echo "$ci_checks" | grep -c "pass" 2>/dev/null || true)
-        failing_checks=$(echo "$ci_checks" | grep -c "fail" 2>/dev/null || true)
-        pending_checks=$(echo "$ci_checks" | grep -c "pending" 2>/dev/null || true)
-        # Ensure counts are integers
-        passing_checks=${passing_checks:-0}
-        failing_checks=${failing_checks:-0}
-        pending_checks=${pending_checks:-0}
-        total_checks=${total_checks:-0}
-    fi
-
-    # Determine overall status
-    local overall_status="unknown"
-    if [[ "$ci_checks" == "no checks reported"* ]]; then
-        overall_status="no_ci"
-    elif [[ $pending_checks -gt 0 ]]; then
-        overall_status="pending"
-    elif [[ $failing_checks -gt 0 ]]; then
-        overall_status="failing"
-    elif [[ $passing_checks -gt 0 ]]; then
-        overall_status="passing"
-    fi
-
-    # Check for Claude LGTM
-    local claude_lgtm="not_found"
-    if [[ -n "$review_comments" ]]; then
-        if echo "$review_comments" | grep -qi "LGTM\|looks good to merge\|ready to merge\|approved"; then
-            claude_lgtm="approved"
-        else
-            claude_lgtm="commented"
-        fi
-    fi
-
-    # Output based on format
-    if $JSON_OUTPUT; then
-        cat << JSON
-{
-  "pr_number": $pr_number,
-  "title": $(echo "$pr_title" | jq -R .),
-  "state": "$pr_state",
-  "mergeable": "$pr_mergeable",
-  "url": "$pr_url",
-  "author": "$pr_author",
-  "ci_status": {
-    "overall": "$overall_status",
-    "total_checks": $total_checks,
-    "passing": $passing_checks,
-    "failing": $failing_checks,
-    "pending": $pending_checks
-  },
-  "claude_review": "$claude_lgtm"
-}
-JSON
-    else
-        echo ""
-        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-        echo "PR #$pr_number: $pr_title"
-        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-        echo "Author:    $pr_author"
-        echo "State:     $pr_state"
-        echo "Mergeable: $pr_mergeable"
-        echo "URL:       $pr_url"
-        echo ""
-
-        # CI Status
-        echo "CI Status: "
-        case $overall_status in
-            passing)
-                echo "  ✅ ALL CHECKS PASSING ($passing_checks/$total_checks)"
-                ;;
-            failing)
-                echo "  ❌ CHECKS FAILING ($failing_checks failures, $passing_checks passing)"
-                ;;
-            pending)
-                echo "  ⏳ CHECKS PENDING ($pending_checks pending, $passing_checks passing)"
-                ;;
-            no_ci)
-                echo "  ⏸️  NO CI CHECKS REPORTED YET"
-                ;;
-            *)
-                echo "  ❓ UNKNOWN STATUS"
-                ;;
-        esac
-
-        # Show individual checks in verbose mode
-        if $VERBOSE && [[ "$ci_checks" != "no checks reported"* ]]; then
-            echo ""
-            echo "Check Details:"
-            echo "$ci_checks" | while IFS=$'\t' read -r name status time _; do
-                case $status in
-                    pass)
-                        echo "  ✅ $name ($time)"
-                        ;;
-                    fail)
-                        echo "  ❌ $name"
-                        ;;
-                    pending)
-                        echo "  ⏳ $name"
-                        ;;
-                    *)
-                        echo "  ⏸️  $name ($status)"
-                        ;;
-                esac
-            done
-        fi
-
-        # Claude Review Status
-        echo ""
-        echo "Claude Review:"
-        case $claude_lgtm in
-            approved)
-                echo "  ✅ LGTM - Ready to merge"
-                ;;
-            commented)
-                echo "  💬 Comments provided (review details)"
-                ;;
-            not_found)
-                echo "  ⏳ No review yet"
-                ;;
-        esac
-
-        # Show review comments in verbose mode
-        if $VERBOSE && [[ -n "$review_comments" ]]; then
-            echo ""
-            echo "Review Comments:"
-            echo "$review_comments" | jq -r '.body' | head -20 | sed 's/^/  │ /'
-            echo "  └─ [truncated, see PR for full review]"
-        fi
-
-        echo ""
-    fi
-
-    # Return failure if checks are failing
-    if [[ "$overall_status" == "failing" ]]; then
-        return 1
-    fi
-
-    return 0
-}
-
-# Main execution
-main() {
-    local exit_code=0
-    local iteration=1
-
-    while true; do
-        if $WATCH_MODE && [[ $iteration -gt 1 ]]; then
-            # Only clear screen in interactive mode
-            if $IS_INTERACTIVE; then
-                clear
-                echo "🔄 Refreshing... (Iteration $iteration, Interval: ${WATCH_INTERVAL}s)"
-            else
-                # In non-interactive mode (background/capture), use separator with timestamp
-                echo ""
-                echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-                echo "🔄 Refresh #$iteration at $(date '+%H:%M:%S') (every ${WATCH_INTERVAL}s)"
-                echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-            fi
-            echo ""
-        fi
-
-        if ! $JSON_OUTPUT; then
-            echo "Monitoring ${#PR_NUMBERS[@]} PR(s) in $REPO_OWNER/$REPO_NAME"
-        fi
-
-        if $JSON_OUTPUT; then
-            echo "["
-        fi
-
-        local first=true
-        for pr in "${PR_NUMBERS[@]}"; do
-            if $JSON_OUTPUT && ! $first; then
-                echo ","
-            fi
-
-            if ! check_pr "$pr"; then
-                exit_code=1
-            fi
-
-            first=false
-        done
-
-        if $JSON_OUTPUT; then
-            echo "]"
-        fi
-
-        # Show timing in verbose mode
-        if $VERBOSE && ! $JSON_OUTPUT; then
-            local end_time
-            local duration
-            end_time=$(date +%s)
-            duration=$((end_time - START_TIME))
-            echo "Execution time: ${duration}s"
-        fi
-
-        # Break if not in watch mode
-        if ! $WATCH_MODE; then
-            break
-        fi
-
-        # Wait before next iteration
-        if ! $JSON_OUTPUT; then
-            echo ""
-            echo "⏰ Waiting ${WATCH_INTERVAL}s before next check... (Press Ctrl+C to stop)"
-        fi
-        sleep "$WATCH_INTERVAL"
-        iteration=$((iteration + 1))
-    done
-
-    return $exit_code
-}
-
-# Run main function
-main
+case "$SUBCOMMAND" in
+    list)
+        cmd_list "$@"
+        ;;
+    view)
+        cmd_view "$@"
+        ;;
+    watch)
+        cmd_watch "$@"
+        ;;
+    checks)
+        cmd_checks "$@"
+        ;;
+    status)
+        cmd_status "$@"
+        ;;
+    *)
+        echo "Error: Unknown subcommand: $SUBCOMMAND" >&2
+        echo "Run '$(basename "$0") --help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -102,6 +102,12 @@ class ScriptsGenerator:
             # Fallback to Python scripts for unknown languages
             scripts.update(self._generate_python_scripts())
 
+        # Language-agnostic scripts
+        scripts["pr-status.sh"] = self._write_script(
+            "pr-status.sh",
+            self._pr_status_script(),
+        )
+
         return scripts
 
     def _generate_python_scripts(self) -> dict[str, Path]:
@@ -2630,6 +2636,490 @@ fi
 
 echo "✓ Tests passed"
 exit 0
+"""
+
+    # Language-agnostic script generators
+
+    def _pr_status_script(self) -> str:
+        """Generate pr-status.sh script for PR merge-readiness monitoring.
+
+        Returns:
+            Shell script content for the pr-status.sh CLI tool.
+        """
+        return f"""#!/usr/bin/env bash
+# scripts/pr-status.sh - GitHub Actions workflow monitor for PRs
+# Usage: ./scripts/pr-status.sh <subcommand> [OPTIONS]
+
+set -euo pipefail
+
+VERSION="1.0.0"
+VERBOSE=false
+
+# Auto-detect repo
+get_repo() {{
+    gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}}
+
+# Print usage
+usage() {{
+    cat << EOF
+Usage: $(basename "$0") <subcommand> [OPTIONS]
+
+GitHub Actions workflow monitor for PRs ({self.config.package_name}).
+
+SUBCOMMANDS:
+    list [--branch NAME] [--limit N]    List recent CI workflow runs
+    view ID [ID...]                      View workflow run conclusions
+    watch ID [ID...]                     Watch runs until complete
+    checks PR_NUMBER                     Show PR check status
+    status PR_NUMBER [--workflow FILE]   Full PR verdict (CI + Claude review)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --version   Show version and exit
+    --help      Display this help message
+
+STATUS OPTIONS:
+    --workflow FILE   CI workflow filename (default: ci.yml)
+
+EXIT CODES:
+    0           Success / ready to merge
+    1           Failure / not ready to merge
+    2           Usage error
+
+EXAMPLES:
+    $(basename "$0") list                    # List recent CI runs
+    $(basename "$0") list --branch feat/foo  # Filter by branch
+    $(basename "$0") view 12345              # View run #12345
+    $(basename "$0") watch 12345 12346       # Watch two runs
+    $(basename "$0") checks 74               # Show PR #74 checks
+    $(basename "$0") status 74               # Full PR #74 verdict
+EOF
+}}
+
+# === list subcommand ===
+cmd_list() {{
+    local branch=""
+    local limit=10
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --branch)
+                branch="$2"
+                shift 2
+                ;;
+            --limit)
+                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+                    echo "Error: --limit requires a numeric value, got '$2'" >&2
+                    exit 2
+                fi
+                limit="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for list: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== Recent CI Workflow Runs ==="
+    echo ""
+
+    local args=(run list --repo "$repo" --limit "$limit")
+    if [[ -n "$branch" ]]; then
+        args+=(--branch "$branch")
+    fi
+    args+=(--json "databaseId,headBranch,workflowName,status,conclusion,createdAt")
+    local jqexpr='.[] | [(.databaseId|tostring),'
+    jqexpr+=' .headBranch, .workflowName, .status,'
+    jqexpr+=' (.conclusion // "—"), .createdAt] | @tsv'
+    args+=(--jq "$jqexpr")
+
+    if $VERBOSE; then
+        echo "Running: gh ${{args[*]}}"
+    fi
+
+    local fmt="%-12s %-30s %-20s %-12s %-18s %s\\n"
+    printf "$fmt" "ID" "BRANCH" "WORKFLOW" \\
+        "STATUS" "CONCLUSION" "CREATED"
+    printf "$fmt" "----" "------" "--------" \\
+        "------" "----------" "-------"
+
+    gh "${{args[@]}}" | while IFS=$'\\t' \\
+        read -r id branch_name workflow status conclusion created; do
+        printf "$fmt" "$id" "$branch_name" \\
+            "$workflow" "$status" "$conclusion" "$created"
+    done
+}}
+
+# === view subcommand ===
+cmd_view() {{
+    if [[ $# -eq 0 ]]; then
+        echo "Error: view requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Run #${{run_id}} ==="
+        echo ""
+
+        local run_json
+        local fields="status,conclusion,workflowName"
+        fields+=",headBranch,jobs"
+        run_json="$(gh run view "$run_id" \\
+            --repo "$repo" --json "$fields")"
+
+        if $VERBOSE; then
+            echo "Fetched run data for #${{run_id}}"
+        fi
+
+        local status conclusion workflow branch
+        local jq_tsv='[.workflowName, .headBranch,'
+        jq_tsv+=' .status, (.conclusion // "—")] | @tsv'
+        read -r workflow branch status conclusion < <(
+            echo "$run_json" | jq -r "$jq_tsv"
+        )
+
+        echo "Workflow:   $workflow"
+        echo "Branch:     $branch"
+        echo "Status:     $status"
+        echo "Conclusion: $conclusion"
+        echo ""
+
+        echo "Jobs:"
+        local jq_jobs='.jobs[] | "  '
+        jq_jobs+='\\(if .conclusion == "success" then "✓"'
+        jq_jobs+=' elif .conclusion == "failure" then "✗"'
+        jq_jobs+=' elif .conclusion == "skipped" then "—"'
+        jq_jobs+=' else "●" end)'
+        jq_jobs+=' \\(.name): \\(.conclusion // .status)"'
+        echo "$run_json" | jq -r "$jq_jobs"
+        echo ""
+
+        if [[ "$conclusion" == "failure" ]]; then
+            any_failed=true
+        fi
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}}
+
+# === watch subcommand ===
+cmd_watch() {{
+    if [[ $# -eq 0 ]]; then
+        echo "Error: watch requires at least one run ID" >&2
+        exit 2
+    fi
+
+    local repo
+    repo="$(get_repo)"
+    local any_failed=false
+
+    for run_id in "$@"; do
+        echo "=== Watching Run #${{run_id}} ==="
+        echo ""
+
+        if $VERBOSE; then
+            echo "Watching run #${{run_id}} in repo $repo"
+        fi
+
+        if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+            any_failed=true
+            echo "✗ Run #${{run_id}} failed" >&2
+        else
+            echo "✓ Run #${{run_id}} passed"
+        fi
+        echo ""
+    done
+
+    if $any_failed; then
+        exit 1
+    fi
+}}
+
+# === checks subcommand ===
+cmd_checks() {{
+    if [[ $# -eq 0 ]]; then
+        echo "Error: checks requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    local repo
+    repo="$(get_repo)"
+
+    echo "=== PR #${{pr_number}} Checks ==="
+    echo ""
+
+    if $VERBOSE; then
+        echo "Fetching checks for PR #${{pr_number}} in repo $repo"
+    fi
+
+    gh pr checks "$pr_number" --repo "$repo"
+}}
+
+# === status subcommand ===
+cmd_status() {{
+    if [[ $# -eq 0 ]]; then
+        echo "Error: status requires a PR number" >&2
+        exit 2
+    fi
+
+    local pr_number="$1"
+    shift
+    local workflow="ci.yml"
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --workflow)
+                workflow="$2"
+                shift 2
+                ;;
+            *)
+                echo "Error: Unknown option for status: $1" >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    local repo
+    repo="$(get_repo)"
+
+    # Get PR info
+    local pr_json
+    pr_json="$(gh pr view "$pr_number" \\
+        --repo "$repo" \\
+        --json "title,headRefName,comments")"
+
+    local pr_title pr_branch
+    pr_title="$(echo "$pr_json" | jq -r '.title')"
+    pr_branch="$(echo "$pr_json" | jq -r '.headRefName')"
+
+    echo "=== PR #${{pr_number}}: ${{pr_title}} ==="
+    echo ""
+
+    # --- CI Status ---
+    local ci_status="UNKNOWN"
+    local ci_detail=""
+    local ci_pass=false
+
+    local run_json
+    if $VERBOSE; then
+        echo "Looking for workflow: $workflow on branch: $pr_branch"
+    fi
+
+    run_json="$(gh run list --repo "$repo" \\
+        --branch "$pr_branch" \\
+        --workflow "$workflow" --limit 1 \\
+        --json "databaseId,conclusion,status" \\
+        2>/dev/null || echo "[]")"
+
+    local run_count
+    run_count="$(echo "$run_json" | jq 'length')"
+
+    if [[ "$run_count" -eq 0 ]]; then
+        ci_status="NO RUNS"
+        ci_detail="No CI runs found for branch $pr_branch"
+        echo "Warning: No runs found for workflow" \\
+            "'$workflow' on branch '$pr_branch'." >&2
+        echo "  Check workflow filename or" \\
+            "use --workflow <file> to specify." >&2
+    else
+        local run_id run_conclusion run_status
+        run_id="$(echo "$run_json" | jq -r '.[0].databaseId')"
+        run_conclusion="$(echo "$run_json" | jq -r '.[0].conclusion // ""')"
+        run_status="$(echo "$run_json" | jq -r '.[0].status')"
+
+        if [[ "$run_status" != "completed" ]]; then
+            ci_status="IN PROGRESS"
+            ci_detail="Run #${{run_id}} is ${{run_status}}"
+        else
+            local jobs_json
+            jobs_json="$(gh run view "$run_id" --repo "$repo" --json jobs)"
+
+            local total_jobs passed_jobs failed_jobs
+            total_jobs="$(echo "$jobs_json" | jq '.jobs | length')"
+            passed_jobs="$(echo "$jobs_json" | \\
+                jq '[.jobs[] | select(.conclusion == "success")] | length')"
+            failed_jobs="$(echo "$jobs_json" | \\
+                jq '[.jobs[] | select(.conclusion == "failure")] | length')"
+
+            if [[ "$run_conclusion" == "success" ]]; then
+                ci_status="PASS"
+                ci_detail="${{passed_jobs}}/${{total_jobs}} jobs green"
+                ci_pass=true
+            else
+                ci_status="FAIL"
+                ci_detail="${{passed_jobs}}/${{total_jobs}} jobs green,"
+                ci_detail="${{ci_detail}} ${{failed_jobs}} failed"
+
+                # Show failed jobs
+                local failed_names
+                failed_names="$(echo "$jobs_json" | \\
+                    jq -r '.jobs[] | select(.conclusion == "failure") | .name')"
+                if [[ -n "$failed_names" ]]; then
+                    ci_detail="${{ci_detail}}"$'\\n'"Failed jobs:"
+                    while IFS= read -r name; do
+                        ci_detail="${{ci_detail}}"$'\\n'"  ✗ ${{name}}"
+                    done <<< "$failed_names"
+                fi
+            fi
+        fi
+    fi
+
+    # --- Claude Review Status ---
+    local review_status="NO REVIEW"
+    local review_issues=""
+    local review_pass=false
+
+    # Scan comments for Claude review verdicts (latest wins)
+    local comments_count
+    comments_count="$(echo "$pr_json" | jq '.comments | length')"
+
+    if [[ "$comments_count" -gt 0 ]]; then
+        # Search from latest comment backwards for a verdict
+        local i
+        for ((i = comments_count - 1; i >= 0; i--)); do
+            local body
+            body="$(echo "$pr_json" | jq -r ".comments[$i].body")"
+
+            # Check for verdict patterns
+            if echo "$body" | grep -qE '✅\\s*LGTM|Verdict:.*LGTM'; then
+                review_status="LGTM"
+                review_pass=true
+                break
+            elif echo "$body" | \\
+                grep -qE '🔄\\s*CHANGES_REQUESTED|Verdict:.*CHANGES_REQUESTED'; then
+                review_status="CHANGES_REQUESTED"
+
+                # Extract problems section
+                review_issues="$(echo "$body" | \\
+                    sed -n '/^## Problems/,/^## [^P]/p' | sed '$d')"
+                if [[ -z "$review_issues" ]]; then
+                    # Try alternate format: lines starting with 🔴
+                    review_issues="$(echo "$body" | grep '🔴' || true)"
+                fi
+                break
+            elif echo "$body" | grep -qE '💬\\s*COMMENTS|Verdict:.*COMMENTS'; then
+                review_status="COMMENTS"
+                review_pass=true
+                break
+            fi
+        done
+    fi
+
+    # --- Output ---
+    if $ci_pass; then
+        echo "CI Status:     ✓ ${{ci_status}}  (${{ci_detail}})"
+    else
+        echo "CI Status:     ✗ ${{ci_status}}  (${{ci_detail}})"
+    fi
+
+    if $review_pass; then
+        echo "Claude Review: ✓ ${{review_status}}"
+    else
+        echo "Claude Review: ✗ ${{review_status}}"
+    fi
+
+    if [[ -n "$review_issues" ]]; then
+        echo ""
+        echo "Review Issues:"
+        echo "$review_issues" | while IFS= read -r line; do
+            # Indent if not already indented
+            if [[ "$line" == "  "* ]]; then
+                echo "$line"
+            else
+                echo "  $line"
+            fi
+        done
+    fi
+
+    echo ""
+
+    # --- Verdict ---
+    if $ci_pass && $review_pass; then
+        echo "Verdict: READY TO MERGE"
+        exit 0
+    else
+        echo "Verdict: NOT READY TO MERGE"
+        exit 1
+    fi
+}}
+
+# === Main argument parsing ===
+
+# Handle no arguments
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+# Extract global flags first, collect remaining args
+REMAINING_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --version)
+            echo "$(basename "$0") version $VERSION"
+            exit 0
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            REMAINING_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Restore positional args
+set -- "${{REMAINING_ARGS[@]+"${{REMAINING_ARGS[@]}}"}}"
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+
+SUBCOMMAND="$1"
+shift
+
+case "$SUBCOMMAND" in
+    list)
+        cmd_list "$@"
+        ;;
+    view)
+        cmd_view "$@"
+        ;;
+    watch)
+        cmd_watch "$@"
+        ;;
+    checks)
+        cmd_checks "$@"
+        ;;
+    status)
+        cmd_status "$@"
+        ;;
+    *)
+        echo "Error: Unknown subcommand: $SUBCOMMAND" >&2
+        echo "Run '$(basename "$0") --help' for usage." >&2
+        exit 2
+        ;;
+esac
 """
 
     def _write_script(self, filename: str, content: str) -> Path:

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -695,11 +695,11 @@ class TestMutationKillers:
             assert "clippy" in content
 
     def test_generated_scripts_exact_count_python(self) -> None:
-        """Test Python generator creates EXACTLY 9 scripts.
+        """Test Python generator creates EXACTLY 12 scripts.
 
         Kills mutations in script count logic.
         Scripts: check-all, format, lint, test, fix-all, security, complexity,
-        mutation, analyze_mutations.py
+        mutation, analyze_mutations.py, typecheck, coverage, pr-status
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ScriptConfig(
@@ -709,9 +709,9 @@ class TestMutationKillers:
             generator = ScriptsGenerator(Path(tmpdir), config)
             scripts = generator.generate()
 
-            assert len(scripts) == 11
-            assert len(scripts) > 10
-            assert len(scripts) < 12
+            assert len(scripts) == 12
+            assert len(scripts) > 11
+            assert len(scripts) < 13
 
     def test_generated_scripts_exact_count_typescript(self) -> None:
         """Test TypeScript generator creates EXACTLY 6 scripts."""
@@ -723,9 +723,9 @@ class TestMutationKillers:
             generator = ScriptsGenerator(Path(tmpdir), config)
             scripts = generator.generate()
 
-            assert len(scripts) == 6
-            assert len(scripts) > 5
-            assert len(scripts) < 7
+            assert len(scripts) == 7
+            assert len(scripts) > 6
+            assert len(scripts) < 8
 
     def test_script_file_executable_permission_exact(self) -> None:
         """Test generated scripts have EXACT executable permission (0o755).
@@ -1328,6 +1328,18 @@ class TestTypeScriptTypecheckScript:
             content = scripts["check-all.sh"].read_text()
             assert "typecheck.sh" in content
 
+    def test_pr_status_script_generated_for_typescript(self) -> None:
+        """Test pr-status.sh is included in TypeScript generated scripts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="typescript",
+                package_name="my_app",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            assert "pr-status.sh" in scripts
+
     def test_typescript_test_script_handles_empty_jest_args(self) -> None:
         """Test TypeScript test.sh uses safe empty-array expansion for JEST_ARGS."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1341,3 +1353,150 @@ class TestTypeScriptTypecheckScript:
             content = scripts["test.sh"].read_text()
             # Should use safe expansion pattern, not bare "${JEST_ARGS[@]}"
             assert '${JEST_ARGS[@]+"${JEST_ARGS[@]}"}' in content
+
+
+class TestPrStatusScript:
+    """Test pr-status.sh script generation (language-agnostic)."""
+
+    def test_pr_status_script_generated_for_python(self) -> None:
+        """Test pr-status.sh is included in Python generated scripts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            assert "pr-status.sh" in scripts
+            assert scripts["pr-status.sh"].exists()
+
+    def test_pr_status_script_generated_for_all_languages(self) -> None:
+        """Test pr-status.sh is generated for all supported languages."""
+        languages = ["python", "typescript", "go", "rust"]
+        for lang in languages:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config = ScriptConfig(
+                    language=lang,
+                    package_name="test_pkg",
+                )
+                generator = ScriptsGenerator(Path(tmpdir), config)
+                scripts = generator.generate()
+
+                assert "pr-status.sh" in scripts, f"Missing for {lang}"
+
+    def test_pr_status_script_has_subcommands(self) -> None:
+        """Test pr-status.sh contains all subcommand case patterns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "list)" in content
+            assert "view)" in content
+            assert "watch)" in content
+            assert "checks)" in content
+            assert "status)" in content
+
+    def test_pr_status_script_is_executable(self) -> None:
+        """Test pr-status.sh has executable permissions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            script_path = scripts["pr-status.sh"]
+            assert script_path.stat().st_mode & 0o111
+
+    def test_pr_status_script_has_version_flag(self) -> None:
+        """Test pr-status.sh supports --version flag."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "--version)" in content
+            assert "VERSION=" in content
+
+    def test_pr_status_script_has_bash_safety(self) -> None:
+        """Test pr-status.sh has set -euo pipefail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "set -euo pipefail" in content
+            assert "#!/usr/bin/env bash" in content
+
+    def test_pr_status_script_has_help_text(self) -> None:
+        """Test pr-status.sh has comprehensive help output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "SUBCOMMANDS:" in content
+            assert "EXAMPLES:" in content
+            assert "EXIT CODES:" in content
+            assert "--help" in content
+
+    def test_pr_status_script_has_claude_review_parsing(self) -> None:
+        """Test pr-status.sh status subcommand parses Claude review verdicts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "LGTM" in content
+            assert "CHANGES_REQUESTED" in content
+            assert "Verdict:" in content
+            assert "READY TO MERGE" in content
+
+    def test_pr_status_script_defaults_to_ci_yml_workflow(self) -> None:
+        """Test pr-status.sh defaults to ci.yml for workflow filename."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_package",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert 'workflow="ci.yml"' in content
+
+    def test_pr_status_script_interpolates_package_name(self) -> None:
+        """Test pr-status.sh includes the project package name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="python",
+                package_name="my_special_project",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            content = scripts["pr-status.sh"].read_text()
+            assert "my_special_project" in content


### PR DESCRIPTION
## Summary

- **Replace `scripts/pr-status.sh`** with the creek-tools subcommand CLI (`list`, `view`, `watch`, `checks`, `status`) plus `--version` flag — provides full PR merge-readiness verdicts (CI + Claude review parsing)
- **Add `_pr_status_script()` to `ScriptsGenerator`** as a language-agnostic script generated for all target languages (Python, TypeScript, Go, Rust)
- **Fix macOS Keychain popup spam** — set `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` in `scripts/common.sh` to prevent 3 GUI dialog boxes per pre-commit run caused by pip/pip-audit querying the macOS Keychain

## Changes

| File | Change |
|------|--------|
| `scripts/pr-status.sh` | Replaced with creek-tools subcommand CLI + `--version` flag |
| `scripts/common.sh` | Added `PYTHON_KEYRING_BACKEND` export to suppress keychain prompts |
| `start_green_stay_green/generators/scripts.py` | Added `_pr_status_script()` method + wired into `generate()` |
| `tests/unit/generators/test_scripts.py` | 10 new tests in `TestPrStatusScript`, updated count assertions (97 total) |
| `claude/tools.md` | Added pr-status.sh subcommand documentation |
| `CLAUDE.md` | Added pr-status.sh to Appendix B scripts listing |

## Test plan

- [x] `./scripts/pr-status.sh --help` shows subcommand usage
- [x] `./scripts/pr-status.sh --version` shows `2.0.0`
- [x] 97 unit tests pass including 10 new pr-status tests
- [x] Generated script includes all 5 subcommands for all 4 languages
- [x] `pre-commit run --all-files` — all 31 hooks pass
- [ ] CI pipeline green (Gate 2)
- [ ] No macOS Keychain popups during pre-commit run

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)