### PR TITLE
fix(dashboard): remove Mutation Score and Doc Coverage tiles

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -124,17 +124,6 @@
             </div>
 
             <div class="metric-card">
-                <div class="metric-name">Mutation Score</div>
-                <div class="metric-value" id="mutation-value">--</div>
-                <div class="metric-threshold">
-                    Threshold: ≥80%
-                </div>
-                <div class="metric-status status-pass" id="mutation-status">
-                    PASSING
-                </div>
-            </div>
-
-            <div class="metric-card">
                 <div class="metric-name">Cyclomatic Complexity</div>
                 <div class="metric-value" id="complexity-value">--</div>
                 <div class="metric-threshold">
@@ -143,15 +132,6 @@
                 <div class="metric-status status-pass" id="complexity-status">
                     PASSING
                 </div>
-            </div>
-
-            <div class="metric-card">
-                <div class="metric-name">Documentation Coverage</div>
-                <div class="metric-value" id="docs-value">--</div>
-                <div class="metric-threshold">
-                    Threshold: ≥95%
-                </div>
-                <div class="metric-status status-pass" id="docs-status">PASSING</div>
             </div>
 
             <div class="metric-card">
@@ -259,17 +239,6 @@
                 }
             }
 
-            // Mutation Score
-            if (metrics.mutation_score !== undefined) {
-                if (metrics.mutation_score === null) {
-                    document.getElementById('mutation-value').textContent = 'N/A';
-                    updateStatus('mutation', 'N/A', false);
-                } else {
-                    updateMetric('mutation', metrics.mutation_score, '%',
-                        metrics.mutation_score >= thresholds.mutation_score);
-                }
-            }
-
             // Complexity
             if (metrics.complexity_avg !== undefined) {
                 if (metrics.complexity_avg === null) {
@@ -278,17 +247,6 @@
                 } else {
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
-                }
-            }
-
-            // Documentation
-            if (metrics.docs_coverage !== undefined) {
-                if (metrics.docs_coverage === null) {
-                    document.getElementById('docs-value').textContent = 'N/A';
-                    updateStatus('docs', 'N/A', false);
-                } else {
-                    updateMetric('docs', metrics.docs_coverage, '%',
-                        metrics.docs_coverage >= thresholds.docs_coverage);
                 }
             }
 

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -715,17 +715,6 @@ class MetricsGenerator(BaseGenerator):
             </div>
 
             <div class="metric-card">
-                <div class="metric-name">Mutation Score</div>
-                <div class="metric-value" id="mutation-value">--</div>
-                <div class="metric-threshold">
-                    Threshold: ≥{self.config.mutation_threshold}%
-                </div>
-                <div class="metric-status status-pass" id="mutation-status">
-                    PASSING
-                </div>
-            </div>
-
-            <div class="metric-card">
                 <div class="metric-name">Cyclomatic Complexity</div>
                 <div class="metric-value" id="complexity-value">--</div>
                 <div class="metric-threshold">
@@ -734,15 +723,6 @@ class MetricsGenerator(BaseGenerator):
                 <div class="metric-status status-pass" id="complexity-status">
                     PASSING
                 </div>
-            </div>
-
-            <div class="metric-card">
-                <div class="metric-name">Documentation Coverage</div>
-                <div class="metric-value" id="docs-value">--</div>
-                <div class="metric-threshold">
-                    Threshold: ≥{self.config.doc_coverage_threshold}%
-                </div>
-                <div class="metric-status status-pass" id="docs-status">PASSING</div>
             </div>
 
             <div class="metric-card">
@@ -850,17 +830,6 @@ class MetricsGenerator(BaseGenerator):
                 }}
             }}
 
-            // Mutation Score
-            if (metrics.mutation_score !== undefined) {{
-                if (metrics.mutation_score === null) {{
-                    document.getElementById('mutation-value').textContent = 'N/A';
-                    updateStatus('mutation', 'NO DATA', false);
-                }} else {{
-                    updateMetric('mutation', metrics.mutation_score, '%',
-                        metrics.mutation_score >= thresholds.mutation_score);
-                }}
-            }}
-
             // Complexity
             if (metrics.complexity_avg !== undefined) {{
                 if (metrics.complexity_avg === null) {{
@@ -869,17 +838,6 @@ class MetricsGenerator(BaseGenerator):
                 }} else {{
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
-                }}
-            }}
-
-            // Documentation
-            if (metrics.docs_coverage !== undefined) {{
-                if (metrics.docs_coverage === null) {{
-                    document.getElementById('docs-value').textContent = 'N/A';
-                    updateStatus('docs', 'NO DATA', false);
-                }} else {{
-                    updateMetric('docs', metrics.docs_coverage, '%',
-                        metrics.docs_coverage >= thresholds.docs_coverage);
                 }}
             }}
 

--- a/tests/integration/generators/test_metrics_integration.py
+++ b/tests/integration/generators/test_metrics_integration.py
@@ -134,10 +134,10 @@ class TestMetricsGeneratorIntegration:
             )
 
             # Check dashboard includes thresholds
+            # (mutation ≥75% and docs ≥92% removed — tiles deferred)
             dashboard_content = artifacts["dashboard"].read_text()
             assert "≥85%" in dashboard_content
             assert "≥80%" in dashboard_content
-            assert "≥75%" in dashboard_content
 
     def test_ci_integration_config_completeness(self) -> None:
         """Test that CI integration config is complete and usable."""
@@ -517,9 +517,7 @@ class TestDashboardSync:
     EXPECTED_VALUE_IDS: ClassVar[list[str]] = [
         "coverage-value",
         "branch-value",
-        "mutation-value",
         "complexity-value",
-        "docs-value",
         "security-value",
         "maintainability-value",
         "lint-value",
@@ -530,9 +528,7 @@ class TestDashboardSync:
     EXPECTED_STATUS_IDS: ClassVar[list[str]] = [
         "coverage-status",
         "branch-status",
-        "mutation-status",
         "complexity-status",
-        "docs-status",
         "security-status",
         "maintainability-status",
         "lint-status",
@@ -612,9 +608,7 @@ class TestDashboardSync:
         expected_js_keys = [
             "metrics.coverage",
             "metrics.branch_coverage",
-            "metrics.mutation_score",
             "metrics.complexity_avg",
-            "metrics.docs_coverage",
             "metrics.security_issues",
             "metrics.maintainability_avg",
             "metrics.lint_violations",

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -937,7 +937,6 @@ class TestDashboardGeneration:
         assert dashboard is not None
         assert "≥85%" in dashboard  # coverage
         assert "≥80%" in dashboard  # branch coverage
-        assert "≥75%" in dashboard  # mutation
 
     def test_dashboard_has_metric_cards(self) -> None:
         """Test that dashboard has metric card structure."""
@@ -1489,16 +1488,14 @@ class TestDashboardNewCards:
         assert dashboard is not None
         return dashboard
 
-    def test_all_ten_card_ids_exist(self) -> None:
-        """Test that all 10 metric card IDs exist in generated HTML."""
+    def test_all_eight_card_ids_exist(self) -> None:
+        """Test that all 8 metric card IDs exist in generated HTML."""
         dashboard = self._get_dashboard()
 
         expected_ids = [
             "coverage-value",
             "branch-value",
-            "mutation-value",
             "complexity-value",
-            "docs-value",
             "security-value",
             "maintainability-value",
             "lint-value",
@@ -1508,16 +1505,14 @@ class TestDashboardNewCards:
         for card_id in expected_ids:
             assert card_id in dashboard, f"Missing card ID: {card_id}"
 
-    def test_all_ten_status_ids_exist(self) -> None:
-        """Test that all 10 status element IDs exist in generated HTML."""
+    def test_all_eight_status_ids_exist(self) -> None:
+        """Test that all 8 status element IDs exist in generated HTML."""
         dashboard = self._get_dashboard()
 
         expected_ids = [
             "coverage-status",
             "branch-status",
-            "mutation-status",
             "complexity-status",
-            "docs-status",
             "security-status",
             "maintainability-status",
             "lint-status",
@@ -1562,13 +1557,13 @@ class TestDashboardNewCards:
         assert "Test Count" in dashboard
         assert "tests-value" in dashboard
 
-    def test_dashboard_has_ten_metric_cards(self) -> None:
-        """Test dashboard has exactly 10 metric cards."""
+    def test_dashboard_has_eight_metric_cards(self) -> None:
+        """Test dashboard has exactly 8 metric cards."""
         dashboard = self._get_dashboard()
 
         # Count metric-card div occurrences
         card_count = dashboard.count('class="metric-card"')
-        assert card_count == 10
+        assert card_count == 8
 
 
 class TestDashboardJavaScript:
@@ -1624,11 +1619,6 @@ class TestDashboardJavaScript:
         """Test JavaScript has null check for branch coverage (#212)."""
         dashboard = self._get_dashboard()
         assert "metrics.branch_coverage === null" in dashboard
-
-    def test_js_handles_null_mutation_score(self) -> None:
-        """Test JavaScript has null check for mutation score (#212)."""
-        dashboard = self._get_dashboard()
-        assert "metrics.mutation_score === null" in dashboard
 
     def test_js_handles_null_security_issues(self) -> None:
         """Test JavaScript has null check for security issues (#212)."""


### PR DESCRIPTION
## Summary

- Remove **Mutation Score** tile — mutmut is expensive/periodic, `.mutmut-cache` doesn't exist in CI
- Remove **Documentation Coverage** tile — `docs-report.txt` only generated locally, not in metrics CI workflow
- Dashboard goes from 10 tiles to 8 (the data-backed ones)
- Metrics collection (`collect_metrics.py`) still gathers these values — tiles can be re-added when CI supports them

## Test plan

- [x] 1459 tests pass (1 skipped)
- [x] All 32 pre-commit hooks pass
- [x] Card count assertions updated: 10 → 8
- [x] Integration test ID lists updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)