### PR TITLE
docs: update docs for additive init epic, groom backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ Start Green Stay Green is a meta-tool for generating quality-controlled, AI-read
 - Pre-commit hooks configuration
 - Comprehensive documentation
 
+**Additive Init**: `green init` is safe to re-run in existing directories.
+Existing files are preserved by default. Supports `--force`, `--interactive`
+conflict resolution, YAML-aware pre-commit merging, and multi-language
+`-l python -l typescript` projects.
+
 ---
 
 ## 🏗️ Architecture

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Start Green Stay Green is a meta-tool that scaffolds new software projects with 
 - **Multi-Language Support**: Python, TypeScript, Go, Rust, and more
 - **Architecture Enforcement**: Import-linter (Python) and dependency-cruiser (TypeScript)
 - **Complete CI/CD**: GitHub Actions workflows with quality gates
+- **Additive Init**: Safe to re-run in existing directories — preserves your files
 - **Developer Experience**: Rich console output, interactive prompts, dry-run mode
 
 ### What Gets Generated
@@ -126,8 +127,10 @@ start-green-stay-green init [OPTIONS]
 **Options:**
 
 - `--project-name, -n TEXT`: Name of the project to generate
-- `--language, -l TEXT`: Primary programming language (python, typescript, go, rust)
+- `--language, -l TEXT`: Programming language(s). Repeat for multi-language: `-l python -l typescript`
 - `--output-dir, -o PATH`: Output directory for generated project (default: current directory)
+- `--force, -f`: Overwrite all existing files without prompting
+- `--interactive`: Prompt per-file when conflicts exist (skip/overwrite/diff)
 - `--dry-run`: Preview what would be generated without creating files
 - `--no-interactive`: Run in non-interactive mode (requires all options)
 - `--config, --config-file PATH`: Path to configuration file (YAML or TOML)
@@ -141,11 +144,20 @@ start-green-stay-green init
 # Non-interactive with all options
 start-green-stay-green init -n my-app -l python --no-interactive
 
+# Multi-language project
+start-green-stay-green init -n fullstack-app -l python -l typescript
+
+# Re-run safely in existing project (skips existing files)
+start-green-stay-green init -n my-app -l python
+
+# Force overwrite everything
+start-green-stay-green init -n my-app -l python --force
+
+# Interactively choose per file
+start-green-stay-green init -n my-app -l python --interactive
+
 # Dry run to preview
 start-green-stay-green init -n my-app -l typescript --dry-run
-
-# With config file
-start-green-stay-green init --config project-config.yaml
 ```
 
 ### `version` - Display Version Information
@@ -533,16 +545,13 @@ All contributions must:
 - ✅ Skills generation (Claude Code slash commands)
 - ✅ Subagents generation (AI development profiles)
 - ✅ CLAUDE.md generation
-
-### In Progress
-
-- 🚧 Full generator orchestration (Issue #106)
-- 🚧 YAML/TOML config file parsing
-- 🚧 Claude API integration for code review (Issue #102)
+- ✅ Additive init — safe to re-run in existing directories (#250)
+- ✅ `--force` and `--interactive` conflict resolution (#252)
+- ✅ YAML-aware pre-commit config merging (#253)
+- ✅ Multi-language `--language` support (#254)
 
 ### Planned
 
-- 📋 Additional language support (Go, Rust, Swift)
 - 📋 Template customization
 - 📋 Plugin system for custom generators
 - 📋 Project upgrade command

--- a/plan/2026-03-22_BACKLOG_GROOMING.md
+++ b/plan/2026-03-22_BACKLOG_GROOMING.md
@@ -1,0 +1,50 @@
+# Backlog Grooming — 2026-03-22
+
+## PRs Analyzed
+
+| PR | Title | Merged | Issues Closed |
+|----|-------|--------|---------------|
+| #259 | Multi-language --language support | 2026-03-22 | #254 |
+| #258 | YAML-aware pre-commit merge | 2026-03-22 | #253 |
+| #257 | --force and --interactive flags | 2026-03-19 | #252 |
+| #255 | Additive green init (skip existing) | 2026-03-19 | #251 |
+| #247 | Remove docs.yml and .readthedocs.yml | 2026-03-11 | — |
+| #236 | Security hardening audit | 2026-03-11 | #220-#235 |
+| #219 | Remove interrogate dependency | 2026-03-11 | #218 |
+
+## Issues Closed This Session
+
+| Issue | Title | Resolution |
+|-------|-------|------------|
+| #250 | Epic: additive green init | All 4 tracers merged |
+| #221-#235 | 15 security hardening issues | Resolved in PR #236, not auto-closed |
+| #203 | pip-audit vulnerabilities | Fixed in PR #255 (black upgrade, authlib removal) |
+
+**Total closed: 17 issues**
+
+## Remaining Open Issues (11)
+
+### Active Work
+- **#256** — perf(ci): remove --html from coverage.sh (P2, from epic)
+- **#193** — bug: TypeScript Prettier formatting OOB (P1)
+
+### Dashboard/Metrics
+- **#217** — Re-add Mutation Score and Doc Coverage tiles
+- **#206** — Unify threshold computation convention
+- **#159** — Add CI Status metric to dashboard
+- **#154** — Add Pre-Commit Status metric to dashboard
+
+### Cleanup
+- **#202** — Clean up planning/cruft files from project root
+- **#201** — Move RCA files to docs/rca/
+
+### Feature Work
+- **#200** — Add pip-audit suppression to generated security.sh
+- **#131** — Update templates from self-hosting learnings
+- **#152** — v1.0.0 release readiness manual testing
+
+## Backlog Health
+
+- **Before**: 28 open issues (17 stale/resolved)
+- **After**: 11 open issues (all valid)
+- **Improvement**: 60% reduction in open issues


### PR DESCRIPTION
## Summary

- Update README.md: add `--force`, `--interactive`, multi-language docs to CLI reference; update roadmap (move 4 completed items, remove stale In Progress)
- Update CLAUDE.md: add additive init feature summary to project overview
- Backlog grooming: close 17 issues (epic #250, 15 security issues #221-#235, pip-audit #203)
- Add grooming progress report

## Backlog Stats

- **Before**: 28 open issues (17 stale/resolved)
- **After**: 11 open issues (all valid)
- **Closed**: 17 issues

## Test plan

- [x] No code changes — docs only
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)