### PR TITLE
fix(cli): parse comma-separated --language, use script subdirs (#261, #262)

### DIFF
--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -639,20 +639,34 @@ def _generate_scripts_step(
     project_name: str,
     language: str,
     file_writer: FileWriter | None = None,
+    subdirectory: str | None = None,
 ) -> None:
-    """Generate quality scripts."""
-    with console.status("Generating scripts..."):
+    """Generate quality scripts.
+
+    Args:
+        project_path: Project root directory.
+        project_name: Name of the project.
+        language: Programming language for scripts.
+        file_writer: Optional FileWriter for additive behavior.
+        subdirectory: If set, write to scripts/{subdirectory}/ instead
+            of scripts/. Used for multi-language projects.
+    """
+    scripts_dir = project_path / "scripts"
+    if subdirectory:
+        scripts_dir = scripts_dir / subdirectory
+
+    with console.status(f"Generating {language} scripts..."):
         scripts_config = ScriptConfig(
             language=language,
             package_name=project_name.replace("-", "_"),
         )
         scripts_generator = ScriptsGenerator(
-            output_dir=project_path / "scripts",
+            output_dir=scripts_dir,
             config=scripts_config,
             file_writer=file_writer,
         )
         scripts_generator.generate()
-    console.print("[green]✓[/green] Generated scripts")
+    console.print(f"[green]✓[/green] Generated {language} scripts")
 
 
 def _generate_precommit_step(
@@ -1028,6 +1042,8 @@ def _generate_project_files(
     """
     primary_language = languages[0]
 
+    multi_language = len(languages) > 1
+
     try:
         # Per-language generation
         for language in languages:
@@ -1036,7 +1052,13 @@ def _generate_project_files(
                 project_path, project_name, language, file_writer
             )
             _generate_tests_step(project_path, project_name, language, file_writer)
-            _generate_scripts_step(project_path, project_name, language, file_writer)
+            _generate_scripts_step(
+                project_path,
+                project_name,
+                language,
+                file_writer,
+                subdirectory=language if multi_language else None,
+            )
             _generate_precommit_step(project_path, project_name, language, file_writer)
 
         # Shared steps (run once, using primary language)
@@ -1106,6 +1128,20 @@ def _finalize_init(
         )
 
 
+def _split_language_values(language: list[str]) -> tuple[str, ...]:
+    """Split comma-separated language values into individual languages.
+
+    Args:
+        language: List of language strings, possibly comma-separated.
+
+    Returns:
+        Tuple of individual language strings, stripped of whitespace.
+    """
+    return tuple(
+        lang.strip() for item in language for lang in item.split(",") if lang.strip()
+    )
+
+
 def _resolve_language_param(
     language: list[str] | None,
     config_data: dict[str, str],
@@ -1126,7 +1162,7 @@ def _resolve_language_param(
         typer.Exit: If languages are invalid or missing in non-interactive mode.
     """
     if language:
-        raw = tuple(language)
+        raw = _split_language_values(language)
     elif config_data.get("language"):
         raw = (config_data["language"],)
     elif no_interactive:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -14,6 +14,7 @@ import pytest
 
 from start_green_stay_green import cli as cli_mod
 from start_green_stay_green.cli import _generate_project_files
+from start_green_stay_green.cli import _resolve_language_param
 from start_green_stay_green.cli import _resolve_languages
 
 _STEP_NAMES = [
@@ -79,6 +80,30 @@ class TestResolveLanguages:
         assert result == ("python", "go")
 
 
+class TestCommaDelimitedLanguages:
+    """Test comma-separated language parsing (#261)."""
+
+    def test_comma_separated_split(self) -> None:
+        """Test 'python,go' is split into two languages."""
+        result = _resolve_language_param(["python,go"], {}, no_interactive=True)
+        assert result == ("python", "go")
+
+    def test_comma_with_spaces(self) -> None:
+        """Test 'python, go' with spaces is handled."""
+        result = _resolve_language_param(["python, go"], {}, no_interactive=True)
+        assert result == ("python", "go")
+
+    def test_mixed_comma_and_repeated(self) -> None:
+        """Test mixing comma-separated and repeated flags."""
+        result = _resolve_language_param(["python,go", "rust"], {}, no_interactive=True)
+        assert result == ("python", "go", "rust")
+
+    def test_single_language_no_comma(self) -> None:
+        """Test single language without comma still works."""
+        result = _resolve_language_param(["python"], {}, no_interactive=True)
+        assert result == ("python",)
+
+
 class TestMultiLanguageGeneration:
     """Test _generate_project_files with multiple languages."""
 
@@ -125,3 +150,31 @@ class TestMultiLanguageGeneration:
             calls = _get_mock("_generate_structure_step").call_args_list
             assert calls[0][0][2] == "python"
             assert calls[1][0][2] == "go"
+
+
+class TestMultiLanguageScriptsDir:
+    """Test multi-language scripts use subdirectories (#262)."""
+
+    def test_multi_language_scripts_get_subdirectories(self) -> None:
+        """Test scripts_step receives subdirectory for each language."""
+        with _patch_all_steps():
+            _generate_project_files(
+                MagicMock(), "my-project", ("python", "go"), None, MagicMock()
+            )
+
+            calls = _get_mock("_generate_scripts_step").call_args_list
+            assert len(calls) == 2
+            # Both get subdirectory=language for multi-language
+            assert calls[0].kwargs.get("subdirectory") == "python"
+            assert calls[1].kwargs.get("subdirectory") == "go"
+
+    def test_single_language_no_subdirectory(self) -> None:
+        """Test single language scripts go to scripts/ (no subdirectory)."""
+        with _patch_all_steps():
+            _generate_project_files(
+                MagicMock(), "my-project", ("python",), None, MagicMock()
+            )
+
+            calls = _get_mock("_generate_scripts_step").call_args_list
+            assert len(calls) == 1
+            assert calls[0].kwargs.get("subdirectory") is None


### PR DESCRIPTION
## Summary

**Bug 1 (#261)**: `--language python,go` now works. Comma-separated values are split before validation, supporting both `-l python,go` and `-l python -l go` syntax.

**Bug 2 (#262)**: Multi-language projects write scripts to `scripts/{language}/` subdirectories (e.g., `scripts/python/test.sh`, `scripts/go/test.sh`), preventing language-specific scripts from shadowing each other. Single-language projects keep scripts in `scripts/` (backward compat).

Closes #261, closes #262

## Test plan

- [x] 6 new tests: comma parsing (split, spaces, mixed, single), script subdirs (multi, single)
- [x] Full test suite: all pass
- [x] All 28 pre-commit hooks pass
- [x] Coverage ≥90%, complexity all A grade

🤖 Generated with [Claude Code](https://claude.com/claude-code)