### PR TITLE
fix(ci): allow dependabot in claude-review workflow (#270)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot[bot]"
           prompt:  |
             Please review this pull request and provide feedback using the following template:
 


### PR DESCRIPTION
## Summary

- Add `allowed_bots: "dependabot[bot]"` to the `claude-code-action` configuration in `claude-code-review.yml`
- This fixes the `claude-review` check failing on all dependabot PRs with "non-human actor" error

Closes #270

## Test plan

- [x] YAML syntax valid
- [ ] Next dependabot PR should have `claude-review` pass instead of fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)