### PR TITLE
fix(cli): deduplicate languages in _get_setup_instructions (#285)

### DIFF
--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1183,7 +1183,7 @@ def _get_setup_instructions(languages: Sequence[str], project_path: Path) -> lis
     common_tail = ["pre-commit install", "./scripts/check-all.sh"]
 
     middle: list[str] = []
-    for lang in languages:
+    for lang in dict.fromkeys(languages):
         middle.extend(_LANG_SETUP_STEPS.get(lang, []))
 
     return [cd, *middle, *common_tail]

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -162,6 +162,23 @@ class TestGetSetupInstructions:
         # Either quoted or escaped
         assert "'" in cd_cmd or "\\" in cd_cmd or '"' in cd_cmd
 
+    def test_duplicate_languages_not_doubled(self) -> None:
+        """Duplicate languages in input should produce a single set of steps."""
+        instructions = _get_setup_instructions(
+            ("python", "python"), Path("/home/user/proj")
+        )
+        assert instructions.count("python -m venv .venv") == 1
+
+    def test_duplicate_languages_preserves_order(self) -> None:
+        """Deduplication should preserve the order of first occurrence."""
+        instructions = _get_setup_instructions(
+            ("typescript", "python", "typescript"), Path("/home/user/proj")
+        )
+        npm_idx = instructions.index("npm install")
+        venv_idx = instructions.index("python -m venv .venv")
+        assert npm_idx < venv_idx
+        assert instructions.count("npm install") == 1
+
     def test_empty_languages_tuple_has_sensible_default(self) -> None:
         """Empty languages tuple should still produce valid instructions."""
         instructions = _get_setup_instructions((), Path("/home/user/proj"))


### PR DESCRIPTION
Use dict.fromkeys() to deduplicate while preserving order, preventing
duplicate setup steps when the same language appears multiple times.

https://claude.ai/code/session_0196L4QnmwpfDDEvpREp9xW3