### PR TITLE
fix(deps): upgrade pyupgrade and refurb for Python 3.14 compatibility (#281)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
 
   # Upgrade Python syntax
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ['--py311-plus']
@@ -179,7 +179,7 @@ repos:
 
   # Modern Python suggestions
   - repo: https://github.com/dosisod/refurb
-    rev: v2.2.0
+    rev: v2.3.1
     hooks:
       - id: refurb
         additional_dependencies: ['pydantic>=2.0.0']

--- a/reference/MAXIMUM_QUALITY_ENGINEERING.md
+++ b/reference/MAXIMUM_QUALITY_ENGINEERING.md
@@ -347,7 +347,7 @@ repos:
 
   # Upgrade syntax
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ['--py311-plus']
@@ -373,7 +373,7 @@ repos:
 
   # Modern Python suggestions
   - repo: https://github.com/dosisod/refurb
-    rev: v1.26.0
+    rev: v2.3.1
     hooks:
       - id: refurb
 

--- a/scripts/mutation-enhanced.sh
+++ b/scripts/mutation-enhanced.sh
@@ -129,7 +129,7 @@ ensure_mutation_venv() {
 }
 
 # Cleanup mutation venv
-# shellcheck disable=SC2329  # Function called via trap, not directly
+# shellcheck disable=SC2317,SC2329  # Function called via trap, not directly
 cleanup_mutation_venv() {
     if [ "${MUTATION_VENV_CREATED:-false}" = "true" ] && [ -n "${MUTATION_VENV_DIR:-}" ]; then
         if [ "${VERBOSE:-false}" = "true" ]; then

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -130,7 +130,7 @@ PYEOF
 fi
 
 # Cleanup function to remove stale cache on interrupt
-# shellcheck disable=SC2329  # Function is used in trap below
+# shellcheck disable=SC2317,SC2329  # Function is used in trap below
 cleanup_mutation_cache() {
     if [ -f .mutmut-cache ]; then
         echo "Cleaning up mutation cache..." >&2

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -477,7 +477,7 @@ def _warn_if_cli_api_key(source: str) -> None:
 
 def _lazy_api_key_sources(
     api_key_arg: str | None,
-) -> Generator[tuple[str | None, str], None, None]:
+) -> Generator[tuple[str | None, str]]:
     """Yield API key sources lazily to avoid unnecessary keychain prompts.
 
     Each source is only evaluated when iterated, so keyring is never

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -130,7 +130,7 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
             },
             {
                 "repo": "https://github.com/asottile/pyupgrade",
-                "rev": "v3.15.0",
+                "rev": "v3.21.2",
                 "hooks": [
                     {"id": "pyupgrade", "args": ["--py311-plus"]},
                 ],
@@ -160,7 +160,7 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
             },
             {
                 "repo": "https://github.com/dosisod/refurb",
-                "rev": "v1.26.0",
+                "rev": "v2.3.1",
                 "hooks": [
                     {"id": "refurb"},
                 ],

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -1087,7 +1087,7 @@ class TestMutationKillers:
     def test_python_pyupgrade_rev_exact(self) -> None:
         """Test Python pyupgrade rev is exact."""
         repo = LANGUAGE_CONFIGS["python"]["hooks"][9]
-        assert repo["rev"] == "v3.15.0"
+        assert repo["rev"] == "v3.21.2"
 
     def test_python_autoflake_repo_url_exact(self) -> None:
         """Test Python autoflake repo URL is exact."""
@@ -1117,7 +1117,7 @@ class TestMutationKillers:
     def test_python_refurb_rev_exact(self) -> None:
         """Test Python refurb rev is exact."""
         repo = LANGUAGE_CONFIGS["python"]["hooks"][12]
-        assert repo["rev"] == "v1.26.0"
+        assert repo["rev"] == "v2.3.1"
 
     def test_python_vulture_repo_url_exact(self) -> None:
         """Test Python vulture repo URL is exact."""


### PR DESCRIPTION
Upgrade pyupgrade v3.15.0 → v3.21.2 (fixes tokenize.cookie_re bytes-only
TypeError) and refurb v1.26.0/v2.2.0 → v2.3.1 (fixes mypy Options
allow_redefinition AttributeError). Apply pyupgrade auto-fix to cli.py
Generator type hint. Suppress shellcheck SC2317 false positives on trap
handler functions.

https://claude.ai/code/session_014RpybxnSwTKZ8Ht2h2Mox2