### PR TITLE
fix(deps): consolidate 8 dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -79,7 +79,7 @@ jobs:
         python-version: ['3.11', '3.12']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -145,7 +145,7 @@ jobs:
           echo "Coverage: $COVERAGE%" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         continue-on-error: true  # Don't fail CI if codecov has issues
         with:
           files: ./coverage.xml
@@ -181,7 +181,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -223,7 +223,7 @@ jobs:
     continue-on-error: true  # Skip if not available (requires GitHub Advanced Security)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
@@ -253,7 +253,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -340,7 +340,7 @@ jobs:
 
       - name: Comment PR with coverage
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           COVERAGE_VALUE: ${{ steps.coverage.outputs.coverage }}
           COVERAGE_STATUS: ${{ steps.coverage.outputs.status }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,7 +39,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.12.0",
     "hypothesis>=6.98.0",
-    "mutmut==2.5.1",  # Pinned: requires Python 3.11-3.13 (pony ORM incompatible with 3.14)
+    "mutmut==3.5.0",  # Pinned: requires Python 3.11-3.13 (pony ORM incompatible with 3.14)
 
     # Pre-commit and git
     "pre-commit>=3.6.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,15 +29,15 @@ tryceratops>=2.3.0,<3.0.0
 refurb>=1.26.0,<3.0.0
 pyupgrade>=3.15.0,<4.0.0
 autoflake>=2.2.1,<3.0.0
-dead>=1.5.0,<2.0.0
+dead>=1.5.0,<3.0.0
 
 # Testing frameworks
 pytest>=9.0.3,<10.0.0
-pytest-cov>=4.1.0,<5.0.0
+pytest-cov>=4.1.0,<8.0.0
 pytest-xdist>=3.5.0,<4.0.0
 pytest-timeout>=2.2.0,<3.0.0
 pytest-randomly>=3.15.0,<5.0.0
-pytest-benchmark>=4.0.0,<5.0.0
+pytest-benchmark>=4.0.0,<6.0.0
 pytest-asyncio>=1.0.0,<2.0.0
 pytest-mock>=3.12.0,<4.0.0
 pyyaml>=6.0.1,<7.0.0
@@ -46,14 +46,14 @@ pyyaml>=6.0.1,<7.0.0
 hypothesis>=6.98.0,<7.0.0
 
 # Mutation testing
-mutmut>=2.4.0,<3.0.0
+mutmut>=2.4.0,<4.0.0
 
 # Pre-commit and git hooks
 pre-commit>=3.6.0,<4.0.0
 commitizen>=3.13.0,<4.0.0
 
 # Documentation
-pdoc>=14.0.0,<15.0.0
+pdoc>=14.0.0,<17.0.0
 sphinx>=7.2.0,<8.0.0
 sphinx-rtd-theme>=2.0.0,<3.0.0
 


### PR DESCRIPTION
Merges the following open dependabot PRs into a single change:
- #291 actions/checkout 4 -> 6 (ci.yml, claude-code-review.yml, claude.yml, metrics.yml)
- #292 actions/github-script 7 -> 9 (ci.yml)
- #272 codecov/codecov-action 3 -> 6 (ci.yml)
- #273 dead <2.0.0 -> <3.0.0 (requirements-dev.txt)
- #274 pytest-cov <5.0.0 -> <8.0.0 (requirements-dev.txt)
- #275 pytest-benchmark <5.0.0 -> <6.0.0 (requirements-dev.txt)
- #276 pdoc <15.0.0 -> <17.0.0 (requirements-dev.txt)
- #277 mutmut 2.5.1 -> 3.5.0 (pyproject.toml, requirements-dev.txt)

Consolidating into one PR avoids eight separate CI runs and cross-PR
rebases, and lets the combined dependency set be validated together.

https://claude.ai/code/session_01F7aTKrVd6Dvs1bYcK94LVh