### PR TITLE
fix(ci): ignore pip CVE-2026-3219 in pip-audit (no fix available)

### DIFF
--- a/.pip-audit-known-vulnerabilities
+++ b/.pip-audit-known-vulnerabilities
@@ -6,3 +6,4 @@
 
 CVE-2025-14009    # nltk - transitive dep, no fix available yet - #203
 CVE-2026-4539     # pygments 2.19.2 - no fix version available yet - #265
+CVE-2026-3219     # pip 26.0.1 - latest version, no fix available yet

--- a/.pip-audit-known-vulnerabilities
+++ b/.pip-audit-known-vulnerabilities
@@ -6,4 +6,4 @@
 
 CVE-2025-14009    # nltk - transitive dep, no fix available yet - #203
 CVE-2026-4539     # pygments 2.19.2 - no fix version available yet - #265
-CVE-2026-3219     # pip 26.0.1 - latest version, no fix available yet
+CVE-2026-3219     # pip 26.0.1 - latest version, no fix available yet - #302

--- a/.pip-audit-known-vulnerabilities
+++ b/.pip-audit-known-vulnerabilities
@@ -6,4 +6,4 @@
 
 CVE-2025-14009    # nltk - transitive dep, no fix available yet - #203
 CVE-2026-4539     # pygments 2.19.2 - no fix version available yet - #265
-CVE-2026-3219     # pip 26.0.1 - latest version, no fix available yet - #302
+CVE-2026-3219     # pip 26.0.1 - no fix available, added 2026-04-25 - #302


### PR DESCRIPTION
## Summary
- Scheduled CI on main failed (run 24920448620) because `pip 26.0.1` has CVE-2026-3219 with no fix version released
- Add CVE-2026-3219 to `.pip-audit-known-vulnerabilities` to unblock nightly CI
- pip 26.0.1 is the latest available version — no upgrade path exists yet
- Created tracking issue #302 for removal when fix ships

## Test plan
- [x] `./scripts/security.sh` passes locally with pip 26.0.1 installed
- [x] `pre-commit run --all-files` passes locally
- [x] CI pipeline passes (Security Scanning + Code Quality jobs)
- [ ] Remove entry when pip releases a fix (tracked in #302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)