### PR TITLE
perf(init): execute Phases 0-2 of optimization roadmap

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -5,7 +5,7 @@
 **Branch**: `claude/optimize-green-init-performance-Lsf7Y`
 **Status**: In progress — Phases 0, 1, and 2 (subagent parallelism) shipped on
 `claude/execute-optimization-roadmap-Fhfnu`. Remaining work: prompt caching
-+ tool_use parsing (Phase 2c), the two-pass split + ``green enhance``
++ tool_use parsing (Phase 2c), the two-pass split + `green enhance`
 (Phase 3), prompt cleanup (Phase 4), batch mode (Phase 5), UX/docs (Phase 6).
 
 ---

--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -494,13 +494,11 @@ Restructure `green init` into Pass 1 (scaffold, no API needed) and Pass 2
 **Why**: the `PromptManager` infrastructure exists but is unused; inline
 prompts in generators duplicate boilerplate; the system prompt is generic.
 
-**Follow-up from Phase 2 review (tracked as issue #306):** while
-migrating tuner prompts into `PromptManager`, also migrate
-`ContentTuner`'s tests away from `create_autospec(AIOrchestrator)` to
-a single canonical test double (e.g. an `AsyncMock` against a
-`Protocol`). That lets us delete the "autospec mis-reports
-iscoroutinefunction" branch in `ai/tuner.py:_await_or_offload`,
-which currently exists only to keep ~14 legacy tests working.
+(Phase 2's "test-only branch in `_await_or_offload`" follow-up was
+resolved in PR #305 itself: the affected `ContentTuner` tests were
+migrated from `create_autospec(AIOrchestrator)` to
+`MagicMock(spec=AIOrchestrator)` and the branch was deleted. Issue
+#306 is closed.)
 
 #### Role
 You are a prompt engineer applying the 6-component framework

--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -494,6 +494,14 @@ Restructure `green init` into Pass 1 (scaffold, no API needed) and Pass 2
 **Why**: the `PromptManager` infrastructure exists but is unused; inline
 prompts in generators duplicate boilerplate; the system prompt is generic.
 
+**Follow-up from Phase 2 review:** while migrating tuner prompts into
+`PromptManager`, also migrate `ContentTuner`'s tests away from
+`create_autospec(AIOrchestrator)` to a single canonical test double
+(e.g. an `AsyncMock` against a `Protocol`). That lets us delete the
+"autospec mis-reports iscoroutinefunction" branch in
+`ai/tuner.py:_await_or_offload`, which currently exists only to keep
+~14 legacy tests working.
+
 #### Role
 You are a prompt engineer applying the 6-component framework
 (`Role / Goal / Context / Format / Examples / Requirements`) to all

--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -3,7 +3,10 @@
 **Created**: 2026-05-03
 **Owner**: Performance / AI Orchestration
 **Branch**: `claude/optimize-green-init-performance-Lsf7Y`
-**Status**: Proposed — awaiting review
+**Status**: In progress — Phases 0, 1, and 2 (subagent parallelism) shipped on
+`claude/execute-optimization-roadmap-Fhfnu`. Remaining work: prompt caching
++ tool_use parsing (Phase 2c), the two-pass split + ``green enhance``
+(Phase 3), prompt cleanup (Phase 4), batch mode (Phase 5), UX/docs (Phase 6).
 
 ---
 

--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -494,13 +494,13 @@ Restructure `green init` into Pass 1 (scaffold, no API needed) and Pass 2
 **Why**: the `PromptManager` infrastructure exists but is unused; inline
 prompts in generators duplicate boilerplate; the system prompt is generic.
 
-**Follow-up from Phase 2 review:** while migrating tuner prompts into
-`PromptManager`, also migrate `ContentTuner`'s tests away from
-`create_autospec(AIOrchestrator)` to a single canonical test double
-(e.g. an `AsyncMock` against a `Protocol`). That lets us delete the
-"autospec mis-reports iscoroutinefunction" branch in
-`ai/tuner.py:_await_or_offload`, which currently exists only to keep
-~14 legacy tests working.
+**Follow-up from Phase 2 review (tracked as issue #306):** while
+migrating tuner prompts into `PromptManager`, also migrate
+`ContentTuner`'s tests away from `create_autospec(AIOrchestrator)` to
+a single canonical test double (e.g. an `AsyncMock` against a
+`Protocol`). That lets us delete the "autospec mis-reports
+iscoroutinefunction" branch in `ai/tuner.py:_await_or_offload`,
+which currently exists only to keep ~14 legacy tests working.
 
 #### Role
 You are a prompt engineer applying the 6-component framework

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -22,6 +22,8 @@ from start_green_stay_green.utils.timing import get_active_report
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from start_green_stay_green.utils.timing import TimingReport
+
 
 class GenerationError(Exception):
     """Raised when AI generation fails.
@@ -319,7 +321,7 @@ class AIOrchestrator:
 
     @staticmethod
     def _record_call(
-        report: object | None,
+        report: TimingReport | None,
         start: float,
         retries: int,
         result: GenerationResult | None,
@@ -327,14 +329,14 @@ class AIOrchestrator:
         """Record a completed call (success or failure) on the active report."""
         if report is None:
             return
-        record = APICallRecord(
-            latency_s=time.perf_counter() - start,
-            retries=retries,
-            input_tokens=result.token_usage.input_tokens if result else 0,
-            output_tokens=result.token_usage.output_tokens if result else 0,
+        report.record_api_call(
+            APICallRecord(
+                latency_s=time.perf_counter() - start,
+                retries=retries,
+                input_tokens=result.token_usage.input_tokens if result else 0,
+                output_tokens=result.token_usage.output_tokens if result else 0,
+            )
         )
-        # Type narrows via duck-typing — get_active_report returns TimingReport | None.
-        report.record_api_call(record)  # type: ignore[attr-defined]
 
     def generate(
         self,

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import time
 from typing import Final
 from typing import Literal
+from typing import TYPE_CHECKING
 
 from anthropic import Anthropic
 from anthropic import AsyncAnthropic
@@ -17,6 +18,9 @@ from anthropic.types import TextBlock
 
 from start_green_stay_green.utils.timing import APICallRecord
 from start_green_stay_green.utils.timing import get_active_report
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class GenerationError(Exception):
@@ -91,6 +95,14 @@ class GenerationResult:
     token_usage: TokenUsage
     model: str
     message_id: str
+
+
+@dataclass(frozen=True)
+class _AttemptOutcome:
+    """Internal helper: success result or captured retryable error."""
+
+    result: GenerationResult | None
+    error: Exception | None
 
 
 class AIOrchestrator:
@@ -257,44 +269,53 @@ class AIOrchestrator:
         prompt: str,
         output_format: str,
     ) -> GenerationResult:
-        """Retry API call with exponential backoff.
+        """Retry API call with exponential backoff (sync).
 
-        Args:
-            client: Anthropic API client.
-            prompt: Generation prompt.
-            output_format: Desired output format.
-
-        Returns:
-            GenerationResult on success.
-
-        Raises:
-            GenerationError: If all retries exhausted.
+        Telemetry is recorded by the call site once after the loop
+        terminates (success or exhaustion). Failure paths never miss a
+        recording because both branches end with ``_record_call``.
         """
-        last_error: Exception | None = None
         report = get_active_report()
         call_started = time.perf_counter()
-        retries = 0
 
-        for attempt in range(self.max_retries + 1):
-            try:
-                result = self._call_api(client, prompt, output_format)
-            except GenerationError:
-                self._record_call(report, call_started, retries, None)
-                raise
-            except Exception as e:  # noqa: BLE001
-                last_error = e
-                if attempt < self.max_retries:
-                    retries += 1
-                    delay = self.retry_delay * (2**attempt)
-                    time.sleep(delay)
-                    continue
-            else:
-                self._record_call(report, call_started, retries, result)
-                return result
+        for attempt, sleep_s in self._retry_schedule():
+            outcome = self._attempt_sync(client, prompt, output_format)
+            if outcome.result is not None:
+                self._record_call(report, call_started, attempt, outcome.result)
+                return outcome.result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=outcome.error) from outcome.error
+            time.sleep(sleep_s)
 
-        self._record_call(report, call_started, retries, None)
+        # ``_retry_schedule`` always yields at least one entry, so this
+        # is unreachable; keep mypy/coverage happy.
         msg = "Failed to generate content"
-        raise GenerationError(msg, cause=last_error) from last_error
+        raise GenerationError(msg)
+
+    def _retry_schedule(self) -> Iterator[tuple[int, float | None]]:
+        """Yield ``(attempt_index, sleep_before_next_or_None)`` pairs."""
+        for attempt in range(self.max_retries + 1):
+            is_last = attempt == self.max_retries
+            yield attempt, None if is_last else self.retry_delay * (2**attempt)
+
+    def _attempt_sync(
+        self,
+        client: Anthropic,
+        prompt: str,
+        output_format: str,
+    ) -> _AttemptOutcome:
+        """Run one sync attempt; return the result or capture the error."""
+        try:
+            return _AttemptOutcome(
+                result=self._call_api(client, prompt, output_format),
+                error=None,
+            )
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return _AttemptOutcome(result=None, error=e)
 
     @staticmethod
     def _record_call(
@@ -391,31 +412,39 @@ class AIOrchestrator:
         output_format: str,
     ) -> GenerationResult:
         """Async retry loop matching the sync semantics of ``_retry_with_backoff``."""
-        last_error: Exception | None = None
         report = get_active_report()
         call_started = time.perf_counter()
-        retries = 0
 
-        for attempt in range(self.max_retries + 1):
-            try:
-                result = await self._call_api_async(client, prompt, output_format)
-            except GenerationError:
-                self._record_call(report, call_started, retries, None)
-                raise
-            except Exception as e:  # noqa: BLE001
-                last_error = e
-                if attempt < self.max_retries:
-                    retries += 1
-                    delay = self.retry_delay * (2**attempt)
-                    await asyncio.sleep(delay)
-                    continue
-            else:
-                self._record_call(report, call_started, retries, result)
-                return result
+        for attempt, sleep_s in self._retry_schedule():
+            outcome = await self._attempt_async(client, prompt, output_format)
+            if outcome.result is not None:
+                self._record_call(report, call_started, attempt, outcome.result)
+                return outcome.result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=outcome.error) from outcome.error
+            await asyncio.sleep(sleep_s)
 
-        self._record_call(report, call_started, retries, None)
         msg = "Failed to generate content"
-        raise GenerationError(msg, cause=last_error) from last_error
+        raise GenerationError(msg)
+
+    async def _attempt_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> _AttemptOutcome:
+        """Run one async attempt; return the result or capture the error."""
+        try:
+            return _AttemptOutcome(
+                result=await self._call_api_async(client, prompt, output_format),
+                error=None,
+            )
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return _AttemptOutcome(result=None, error=e)
 
     async def generate_async(
         self,

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -323,16 +323,29 @@ class AIOrchestrator:
     def _record_call(
         report: TimingReport | None,
         start: float,
-        retries: int,
+        attempt: int,
         result: GenerationResult | None,
     ) -> None:
-        """Record a completed call (success or failure) on the active report."""
+        """Record a completed call (success or failure) on the active report.
+
+        Args:
+            report: Active timing collector, or ``None`` when telemetry is off.
+            start: ``perf_counter`` value captured before the first attempt.
+            attempt: Zero-indexed attempt number from
+                :meth:`_retry_schedule`. ``attempt=0`` means the first
+                try succeeded with no retries; ``attempt=N`` means
+                ``N`` retries were used. Stored as ``retries`` on the
+                resulting :class:`APICallRecord` because that's the
+                telemetry consumer's preferred naming.
+            result: Successful :class:`GenerationResult`, or ``None``
+                when the call failed (so token counts default to 0).
+        """
         if report is None:
             return
         report.record_api_call(
             APICallRecord(
                 latency_s=time.perf_counter() - start,
-                retries=retries,
+                retries=attempt,
                 input_tokens=result.token_usage.input_tokens if result else 0,
                 output_tokens=result.token_usage.output_tokens if result else 0,
             )

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -377,7 +377,16 @@ class AIOrchestrator:
             return self._retry_with_backoff(client, prompt, output_format)
 
     def _get_async_client(self) -> AsyncAnthropic:
-        """Return the cached ``AsyncAnthropic`` client, creating it once."""
+        """Return the cached ``AsyncAnthropic`` client, creating it once.
+
+        The check-then-set pattern is *not* thread-safe in the abstract,
+        but it is safe under asyncio: there is no ``await`` between the
+        ``is None`` check and the assignment, so no other coroutine can
+        run between them on the same event loop. This method is only
+        ever called from coroutines on a single event loop, never from
+        a thread pool, so adding a lock would be over-engineering. Do
+        *not* call this from ``ThreadPoolExecutor``.
+        """
         if self._async_client is None:
             self._async_client = AsyncAnthropic(api_key=self._api_key)
         return self._async_client

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -5,13 +5,18 @@ Coordinates AI-powered generation tasks using Claude API.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import time
 from typing import Final
 from typing import Literal
 
 from anthropic import Anthropic
+from anthropic import AsyncAnthropic
 from anthropic.types import TextBlock
+
+from start_green_stay_green.utils.timing import APICallRecord
+from start_green_stay_green.utils.timing import get_active_report
 
 
 class GenerationError(Exception):
@@ -127,6 +132,10 @@ class AIOrchestrator:
         self.model = model
         self.max_retries = max_retries
         self.retry_delay = retry_delay
+        # Lazily-created long-lived async client. Reusing one client across
+        # all calls in an init run lets us share the underlying httpx pool,
+        # which matters once Phase 2 fans out subagent tunings concurrently.
+        self._async_client: AsyncAnthropic | None = None
 
     @staticmethod
     def _validate_api_key(api_key: str) -> None:
@@ -262,28 +271,56 @@ class AIOrchestrator:
             GenerationError: If all retries exhausted.
         """
         last_error: Exception | None = None
+        report = get_active_report()
+        call_started = time.perf_counter()
+        retries = 0
 
         for attempt in range(self.max_retries + 1):
             try:
-                return self._call_api(client, prompt, output_format)
+                result = self._call_api(client, prompt, output_format)
             except GenerationError:
+                self._record_call(report, call_started, retries, None)
                 raise
             except Exception as e:  # noqa: BLE001
                 last_error = e
                 if attempt < self.max_retries:
+                    retries += 1
                     delay = self.retry_delay * (2**attempt)
                     time.sleep(delay)
                     continue
+            else:
+                self._record_call(report, call_started, retries, result)
+                return result
 
+        self._record_call(report, call_started, retries, None)
         msg = "Failed to generate content"
         raise GenerationError(msg, cause=last_error) from last_error
+
+    @staticmethod
+    def _record_call(
+        report: object | None,
+        start: float,
+        retries: int,
+        result: GenerationResult | None,
+    ) -> None:
+        """Record a completed call (success or failure) on the active report."""
+        if report is None:
+            return
+        record = APICallRecord(
+            latency_s=time.perf_counter() - start,
+            retries=retries,
+            input_tokens=result.token_usage.input_tokens if result else 0,
+            output_tokens=result.token_usage.output_tokens if result else 0,
+        )
+        # Type narrows via duck-typing — get_active_report returns TimingReport | None.
+        report.record_api_call(record)  # type: ignore[attr-defined]
 
     def generate(
         self,
         prompt: str,
         output_format: Literal["yaml", "toml", "markdown", "bash"],
     ) -> GenerationResult:
-        """Generate content using Claude API.
+        """Generate content using Claude API (synchronous).
 
         Args:
             prompt: Prompt describing what to generate.
@@ -302,3 +339,108 @@ class AIOrchestrator:
         # Use context manager to ensure httpx client is properly closed
         with Anthropic(api_key=self._api_key) as client:
             return self._retry_with_backoff(client, prompt, output_format)
+
+    def _get_async_client(self) -> AsyncAnthropic:
+        """Return the cached ``AsyncAnthropic`` client, creating it once."""
+        if self._async_client is None:
+            self._async_client = AsyncAnthropic(api_key=self._api_key)
+        return self._async_client
+
+    async def _call_api_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Async counterpart of :meth:`_call_api`."""
+        response = await client.messages.create(
+            model=self.model,
+            max_tokens=4096,
+            system=(
+                f"Generate {output_format} output. "
+                "Follow the instructions precisely."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        )
+
+        first_block = response.content[0]
+        if not isinstance(first_block, TextBlock):
+            msg = "Expected TextBlock in response"
+            raise GenerationError(msg)
+
+        return GenerationResult(
+            content=first_block.text,
+            format=output_format,
+            token_usage=TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            model=response.model,
+            message_id=response.id,
+        )
+
+    async def _retry_with_backoff_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Async retry loop matching the sync semantics of ``_retry_with_backoff``."""
+        last_error: Exception | None = None
+        report = get_active_report()
+        call_started = time.perf_counter()
+        retries = 0
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                result = await self._call_api_async(client, prompt, output_format)
+            except GenerationError:
+                self._record_call(report, call_started, retries, None)
+                raise
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                if attempt < self.max_retries:
+                    retries += 1
+                    delay = self.retry_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+                    continue
+            else:
+                self._record_call(report, call_started, retries, result)
+                return result
+
+        self._record_call(report, call_started, retries, None)
+        msg = "Failed to generate content"
+        raise GenerationError(msg, cause=last_error) from last_error
+
+    async def generate_async(
+        self,
+        prompt: str,
+        output_format: Literal["yaml", "toml", "markdown", "bash"],
+    ) -> GenerationResult:
+        """Async equivalent of :meth:`generate`.
+
+        Reuses a single long-lived ``AsyncAnthropic`` client per
+        orchestrator instance so concurrent calls share the httpx
+        connection pool. Callers should ``await`` :meth:`aclose` when
+        the orchestrator is no longer needed.
+        """
+        self._validate_prompt(prompt)
+        self._validate_output_format(output_format)
+
+        client = self._get_async_client()
+        return await self._retry_with_backoff_async(client, prompt, output_format)
+
+    async def aclose(self) -> None:
+        """Release the cached async client, if any.
+
+        Idempotent. Safe to call from a finally block even when no async
+        calls were made.
+        """
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -39,27 +39,47 @@ async def _await_or_offload(
 ) -> _T:
     """Invoke ``call`` and return its result, awaitable or otherwise.
 
-    Three cases must be handled correctly so concurrent tunings actually
-    overlap on real API calls without breaking the mock-based tests:
+    Production semantics
+    --------------------
+    The only production caller is :class:`ContentTuner`, which dispatches
+    :meth:`AIOrchestrator.generate` (synchronous, hundreds of ms of HTTP
+    work). The synchronous path offloads to a worker thread via
+    :func:`asyncio.to_thread` so concurrent tunings actually overlap
+    instead of serializing on the event loop. This is the only branch
+    that runs against a real orchestrator.
 
-    * **Real sync orchestrator** (``Anthropic`` client): offload to a
-      worker thread via :func:`asyncio.to_thread` so a hundreds-of-ms
-      HTTP round-trip does not block the event loop while siblings wait.
-    * **AsyncMock** in tests: returns a coroutine when called; we await
-      the returned awaitable directly.
-    * **``create_autospec`` MagicMock** in tests: ``iscoroutinefunction``
-      reports ``True`` for these even when the spec'd method is sync, so
-      a plain "is the result awaitable?" check is the correct dispatch.
+    Test compatibility
+    ------------------
+    ``ContentTuner`` is exercised heavily with :class:`unittest.mock`
+    doubles. Two mock styles produce different runtime shapes:
+
+    * :class:`AsyncMock` returns a coroutine when called; the helper
+      awaits it directly. (``iscoroutinefunction`` is ``True``.)
+    * :func:`unittest.mock.create_autospec` over a sync method returns
+      a plain :class:`MagicMock` whose ``iscoroutinefunction`` is also
+      reported ``True`` — even though the spec'd method is sync — and
+      whose call returns the configured ``return_value`` synchronously.
+      That second branch (``isawaitable(result)`` is False) exists
+      solely to keep that test idiom working.
+
+    The autospec accommodation is intentionally narrow and clearly
+    labeled rather than refactored away because rewriting every
+    affected ``ContentTuner`` test (~14 sites) would dwarf the value
+    of removing this single ``isawaitable`` check. A follow-up issue
+    is filed in plans/2026-05-03-claude-init-optimization-roadmap.md
+    (Phase 4 prompt cleanup) to migrate to a single test-double type
+    and delete the branch.
     """
     if asyncio.iscoroutinefunction(call):
         result = call(*args, **kwargs)
         if inspect.isawaitable(result):
             return await cast("Awaitable[_T]", result)
-        # Autospec MagicMock falls through to here.
+        # Test-only branch: ``create_autospec`` MagicMock — a sync mock
+        # that ``iscoroutinefunction`` mis-reports as async. Its call
+        # returns the configured value synchronously.
         return cast("_T", result)
-    # Real sync orchestrator: actually do the work off-thread. ``cast``
-    # on the function narrows ``T | Awaitable[T]`` to ``T`` for the
-    # signature ``asyncio.to_thread`` expects.
+    # Production path. Cast narrows ``T | Awaitable[T]`` to ``T`` for
+    # the signature :func:`asyncio.to_thread` expects.
     sync_call = cast("Callable[..., _T]", call)
     return await asyncio.to_thread(sync_call, *args, **kwargs)
 

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-import inspect
 import logging
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -39,46 +38,28 @@ async def _await_or_offload(
 ) -> _T:
     """Invoke ``call`` and return its result, awaitable or otherwise.
 
-    Production semantics
-    --------------------
-    The only production caller is :class:`ContentTuner`, which dispatches
-    :meth:`AIOrchestrator.generate` (synchronous, hundreds of ms of HTTP
-    work). The synchronous path offloads to a worker thread via
-    :func:`asyncio.to_thread` so concurrent tunings actually overlap
-    instead of serializing on the event loop. This is the only branch
-    that runs against a real orchestrator.
+    Two cases, both real:
 
-    Test compatibility
-    ------------------
-    ``ContentTuner`` is exercised heavily with :class:`unittest.mock`
-    doubles. Two mock styles produce different runtime shapes:
+    * **Async callable** (``asyncio.iscoroutinefunction`` is ``True``):
+      call it, await the resulting coroutine. This covers both real
+      :class:`anthropic.AsyncAnthropic` paths and :class:`AsyncMock`
+      doubles in tests.
+    * **Sync callable** (the default for :meth:`AIOrchestrator.generate`):
+      offload to a worker thread via :func:`asyncio.to_thread` so a
+      hundreds-of-ms HTTP round-trip does not block the event loop while
+      sibling tunings wait. Tests using ``MagicMock(spec=AIOrchestrator)``
+      land here too — :func:`asyncio.to_thread` happily runs the mock
+      and returns the configured value.
 
-    * :class:`AsyncMock` returns a coroutine when called; the helper
-      awaits it directly. (``iscoroutinefunction`` is ``True``.)
-    * :func:`unittest.mock.create_autospec` over a sync method returns
-      a plain :class:`MagicMock` whose ``iscoroutinefunction`` is also
-      reported ``True`` — even though the spec'd method is sync — and
-      whose call returns the configured ``return_value`` synchronously.
-      That second branch (``isawaitable(result)`` is False) exists
-      solely to keep that test idiom working.
-
-    The autospec accommodation is intentionally narrow and clearly
-    labeled rather than refactored away because rewriting every
-    affected ``ContentTuner`` test (~14 sites) would dwarf the value
-    of removing this single ``isawaitable`` check. Tracked in
-    issue #306 — the cleanup migrates the affected tests onto a
-    single canonical async double and deletes the test-only branch.
+    The previous "autospec MagicMock falls through" branch was removed
+    when the corresponding tests were migrated from
+    ``create_autospec(AIOrchestrator)`` to ``MagicMock(spec=...)``;
+    issue #306 closed.
     """
     if asyncio.iscoroutinefunction(call):
-        result = call(*args, **kwargs)
-        if inspect.isawaitable(result):
-            return await cast("Awaitable[_T]", result)
-        # Test-only branch: ``create_autospec`` MagicMock — a sync mock
-        # that ``iscoroutinefunction`` mis-reports as async. Its call
-        # returns the configured value synchronously.
-        return cast("_T", result)
-    # Production path. Cast narrows ``T | Awaitable[T]`` to ``T`` for
-    # the signature :func:`asyncio.to_thread` expects.
+        return await cast("Awaitable[_T]", call(*args, **kwargs))
+    # Sync path: cast narrows ``T | Awaitable[T]`` to ``T`` for the
+    # signature :func:`asyncio.to_thread` expects.
     sync_call = cast("Callable[..., _T]", call)
     return await asyncio.to_thread(sync_call, *args, **kwargs)
 

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -65,10 +65,9 @@ async def _await_or_offload(
     The autospec accommodation is intentionally narrow and clearly
     labeled rather than refactored away because rewriting every
     affected ``ContentTuner`` test (~14 sites) would dwarf the value
-    of removing this single ``isawaitable`` check. A follow-up issue
-    is filed in plans/2026-05-03-claude-init-optimization-roadmap.md
-    (Phase 4 prompt cleanup) to migrate to a single test-double type
-    and delete the branch.
+    of removing this single ``isawaitable`` check. Tracked in
+    issue #306 — the cleanup migrates the affected tests onto a
+    single canonical async double and deletes the test-only branch.
     """
     if asyncio.iscoroutinefunction(call):
         result = call(*args, **kwargs)

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -9,13 +9,15 @@ import asyncio
 from dataclasses import dataclass
 import inspect
 import logging
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import cast
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from collections.abc import Callable
     from collections.abc import Sequence
 
@@ -25,12 +27,16 @@ logger = logging.getLogger(__name__)
 # Constants for response parsing
 _CHANGES_SECTION_PARTS = 2
 
+# Generic over the result type so callers get a precise return type back
+# instead of a blanket ``Any``.
+_T = TypeVar("_T")
+
 
 async def _await_or_offload(
-    call: Callable[..., Any],
-    *args: Any,  # noqa: ANN401 — pass-through wrapper
-    **kwargs: Any,  # noqa: ANN401 — pass-through wrapper
-) -> Any:  # noqa: ANN401 — pass-through wrapper
+    call: Callable[..., _T | Awaitable[_T]],
+    *args: object,
+    **kwargs: object,
+) -> _T:
     """Invoke ``call`` and return its result, awaitable or otherwise.
 
     Three cases must be handled correctly so concurrent tunings actually
@@ -48,11 +54,14 @@ async def _await_or_offload(
     if asyncio.iscoroutinefunction(call):
         result = call(*args, **kwargs)
         if inspect.isawaitable(result):
-            return await result
+            return await cast("Awaitable[_T]", result)
         # Autospec MagicMock falls through to here.
-        return result
-    # Real sync orchestrator: actually do the work off-thread.
-    return await asyncio.to_thread(call, *args, **kwargs)
+        return cast("_T", result)
+    # Real sync orchestrator: actually do the work off-thread. ``cast``
+    # on the function narrows ``T | Awaitable[T]`` to ``T`` for the
+    # signature ``asyncio.to_thread`` expects.
+    sync_call = cast("Callable[..., _T]", call)
+    return await asyncio.to_thread(sync_call, *args, **kwargs)
 
 
 @dataclass(frozen=True)

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -5,7 +5,9 @@ Uses Claude Sonnet to adapt copied content while preserving structure.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+import inspect
 import logging
 from typing import TYPE_CHECKING
 
@@ -20,6 +22,31 @@ logger = logging.getLogger(__name__)
 
 # Constants for response parsing
 _CHANGES_SECTION_PARTS = 2
+
+
+async def _await_or_offload(call, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN202, ANN002, ANN003
+    """Invoke ``call`` and return its result, awaitable or otherwise.
+
+    Three cases must be handled correctly so concurrent tunings actually
+    overlap on real API calls without breaking the mock-based tests:
+
+    * **Real sync orchestrator** (``Anthropic`` client): offload to a
+      worker thread via :func:`asyncio.to_thread` so a hundreds-of-ms
+      HTTP round-trip does not block the event loop while siblings wait.
+    * **AsyncMock** in tests: returns a coroutine when called; we await
+      the returned awaitable directly.
+    * **``create_autospec`` MagicMock** in tests: ``iscoroutinefunction``
+      reports ``True`` for these even when the spec'd method is sync, so
+      a plain "is the result awaitable?" check is the correct dispatch.
+    """
+    if asyncio.iscoroutinefunction(call):
+        result = call(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        # Autospec MagicMock falls through to here.
+        return result
+    # Real sync orchestrator: actually do the work off-thread.
+    return await asyncio.to_thread(call, *args, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -245,7 +272,11 @@ CHANGES:
         )
 
         try:
-            result = self.orchestrator.generate(prompt, "markdown")
+            result = await _await_or_offload(
+                self.orchestrator.generate,
+                prompt,
+                "markdown",
+            )
         except GenerationError:
             logger.exception("Tuning failed")
             raise

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -9,12 +9,14 @@ import asyncio
 from dataclasses import dataclass
 import inspect
 import logging
+from typing import Any
 from typing import TYPE_CHECKING
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Sequence
 
 
@@ -24,7 +26,11 @@ logger = logging.getLogger(__name__)
 _CHANGES_SECTION_PARTS = 2
 
 
-async def _await_or_offload(call, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN202, ANN002, ANN003
+async def _await_or_offload(
+    call: Callable[..., Any],
+    *args: Any,  # noqa: ANN401 — pass-through wrapper
+    **kwargs: Any,  # noqa: ANN401 — pass-through wrapper
+) -> Any:  # noqa: ANN401 — pass-through wrapper
     """Invoke ``call`` and return its result, awaitable or otherwise.
 
     Three cases must be handled correctly so concurrent tunings actually

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -51,6 +51,8 @@ from start_green_stay_green.generators.skills import REFERENCE_SKILLS_DIR
 from start_green_stay_green.generators.skills import REQUIRED_SKILLS
 from start_green_stay_green.generators.structure import StructureConfig
 from start_green_stay_green.generators.structure import StructureGenerator
+from start_green_stay_green.generators.subagents import REFERENCE_AGENTS_DIR
+from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 from start_green_stay_green.generators.subagents import SubagentsGenerator
 from start_green_stay_green.generators.tests_gen import TestsConfig
 from start_green_stay_green.generators.tests_gen import TestsGenerator
@@ -58,6 +60,9 @@ from start_green_stay_green.utils.async_bridge import run_async
 from start_green_stay_green.utils.credentials import get_api_key_from_keyring
 from start_green_stay_green.utils.credentials import store_api_key_in_keyring
 from start_green_stay_green.utils.file_writer import FileWriter
+from start_green_stay_green.utils.timing import TimingReport
+from start_green_stay_green.utils.timing import set_active_report
+from start_green_stay_green.utils.timing import step_timer
 from start_green_stay_green.utils.yaml_merge import merge_precommit_configs
 
 # Version information
@@ -581,6 +586,39 @@ def _copy_reference_skills(
             shutil.copytree(source_dir, target_skill_dir, dirs_exist_ok=True)
 
 
+def _copy_reference_subagents(
+    target_dir: Path,
+    file_writer: FileWriter | None = None,
+) -> None:
+    """Copy reference subagent profiles to ``target_dir`` verbatim.
+
+    Used by the no-API path of ``_generate_subagents_step``. Each
+    required agent in ``REQUIRED_AGENTS`` is copied from the source
+    file declared in the mapping to ``<agent_name>.md`` so the file
+    layout matches what the AI-tuned path produces.
+
+    Args:
+        target_dir: Destination ``.claude/agents`` directory.
+        file_writer: Optional ``FileWriter`` for additive behaviour
+            (handles --force / --interactive conflict resolution).
+
+    Raises:
+        FileNotFoundError: If a required reference agent is missing.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for agent_name, source_file in REQUIRED_AGENTS.items():
+        source_path = REFERENCE_AGENTS_DIR / source_file
+        if not source_path.exists():
+            msg = f"Reference subagent not found: {source_file}"
+            raise FileNotFoundError(msg)
+        target_path = target_dir / f"{agent_name}.md"
+        content = source_path.read_text()
+        if file_writer is not None:
+            file_writer.write_file(target_path, content)
+        else:
+            target_path.write_text(content)
+
+
 def _generate_structure_step(
     project_path: Path,
     project_name: str,
@@ -588,7 +626,7 @@ def _generate_structure_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate source code structure."""
-    with console.status("Generating source structure..."):
+    with step_timer("structure"), console.status("Generating source structure..."):
         config = StructureConfig(
             project_name=project_name,
             language=language,
@@ -606,7 +644,7 @@ def _generate_dependencies_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate dependencies files."""
-    with console.status("Generating dependencies..."):
+    with step_timer("dependencies"), console.status("Generating dependencies..."):
         config = DependencyConfig(
             project_name=project_name,
             language=language,
@@ -624,7 +662,7 @@ def _generate_tests_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate tests directory."""
-    with console.status("Generating tests..."):
+    with step_timer("tests"), console.status("Generating tests..."):
         config = TestsConfig(
             project_name=project_name,
             language=language,
@@ -642,7 +680,7 @@ def _generate_readme_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate README.md."""
-    with console.status("Generating README..."):
+    with step_timer("readme"), console.status("Generating README..."):
         config = ReadmeConfig(
             project_name=project_name,
             language=language,
@@ -710,7 +748,7 @@ def _generate_scripts_step(
     elif _scripts_dir_has_other_language(scripts_dir, language):
         scripts_dir = scripts_dir / language
 
-    with console.status(f"Generating {language} scripts..."):
+    with step_timer("scripts"), console.status(f"Generating {language} scripts..."):
         scripts_config = ScriptConfig(
             language=language,
             package_name=project_name.replace("-", "_"),
@@ -731,7 +769,7 @@ def _generate_precommit_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate pre-commit configuration, merging with existing if present."""
-    with console.status("Generating pre-commit config..."):
+    with step_timer("precommit"), console.status("Generating pre-commit config..."):
         precommit_config = GenerationConfig(
             project_name=project_name,
             language=language,
@@ -807,7 +845,7 @@ def _generate_skills_step(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate Claude skills."""
-    with console.status("Generating skills..."):
+    with step_timer("skills"), console.status("Generating skills..."):
         skills_dir = project_path / ".claude" / "skills"
         _copy_reference_skills(skills_dir, file_writer=file_writer)
     console.print("[green]✓[/green] Generated skills")
@@ -819,43 +857,47 @@ def _generate_ci_step(
     orchestrator: AIOrchestrator | None,
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate CI pipeline or skip if no orchestrator."""
-    if orchestrator:
-        with console.status("Generating CI pipeline..."):
-            ci_generator = CIGenerator(orchestrator, language)
-            workflow = ci_generator.generate_workflow()
-            workflows_dir = project_path / ".github" / "workflows"
-            workflows_dir.mkdir(parents=True, exist_ok=True)
-            ci_file = workflows_dir / "ci.yml"
-            if file_writer is not None:
-                file_writer.write_file(ci_file, workflow.content)
-            else:
-                ci_file.write_text(workflow.content)
-        console.print("[green]✓[/green] Generated CI pipeline")
-    else:
-        console.print("[yellow]⊘[/yellow] Skipped CI (no API key)")
+    """Generate the CI pipeline.
+
+    Always runs the deterministic template path so a project is never
+    missing CI just because the user has no API key. ``orchestrator`` is
+    only used to opt into the legacy AI-tuned path for backward
+    compatibility.
+    """
+    with step_timer("ci"), console.status("Generating CI pipeline..."):
+        ci_generator = CIGenerator(orchestrator, language)
+        workflow = ci_generator.generate_workflow()
+        workflows_dir = project_path / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        ci_file = workflows_dir / "ci.yml"
+        if file_writer is not None:
+            file_writer.write_file(ci_file, workflow.content)
+        else:
+            ci_file.write_text(workflow.content)
+    console.print("[green]✓[/green] Generated CI pipeline")
 
 
 def _generate_review_step(
     project_path: Path,
-    orchestrator: AIOrchestrator | None,
+    orchestrator: AIOrchestrator | None,  # noqa: ARG001 — preserved for source compat
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate GitHub Actions code review or skip if no orchestrator."""
-    if orchestrator:
-        with console.status("Generating GitHub Actions review..."):
-            review_generator = GitHubActionsReviewGenerator(orchestrator)
-            review_result = review_generator.generate()
-            workflows_dir = project_path / ".github" / "workflows"
-            workflows_dir.mkdir(parents=True, exist_ok=True)
-            workflow_file = workflows_dir / "code-review.yml"
-            if file_writer is not None:
-                file_writer.write_file(workflow_file, review_result["workflow_content"])
-            else:
-                workflow_file.write_text(review_result["workflow_content"])
-        console.print("[green]✓[/green] Generated GitHub Actions review")
-    else:
-        console.print("[yellow]⊘[/yellow] Skipped code review (no API key)")
+    """Generate the GitHub Actions code review workflow.
+
+    The generator is fully template-based; the ``orchestrator`` argument
+    is kept only so the call site signature does not churn.
+    """
+    with step_timer("review"), console.status("Generating GitHub Actions review..."):
+        review_generator = GitHubActionsReviewGenerator()
+        review_result = review_generator.generate()
+        workflows_dir = project_path / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        workflow_file = workflows_dir / "code-review.yml"
+        if file_writer is not None:
+            file_writer.write_file(workflow_file, review_result["workflow_content"])
+        else:
+            workflow_file.write_text(review_result["workflow_content"])
+    console.print("[green]✓[/green] Generated GitHub Actions review")
 
 
 def _generate_claude_md_step(
@@ -865,58 +907,61 @@ def _generate_claude_md_step(
     orchestrator: AIOrchestrator | None,
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate CLAUDE.md or skip if no orchestrator."""
-    if orchestrator:
-        with console.status("Generating CLAUDE.md..."):
-            claude_md_generator = ClaudeMdGenerator(orchestrator)
-            project_config = {
-                "project_name": project_name,
-                "language": language,
-                "scripts": [
-                    "check-all.sh",
-                    "test.sh",
-                    "lint.sh",
-                    "format.sh",
-                    "security.sh",
-                    "mutation.sh",
-                ],
-                "skills": REQUIRED_SKILLS.copy(),
-            }
-            claude_md_result = claude_md_generator.generate(project_config)
-            claude_md_file = project_path / "CLAUDE.md"
-            if file_writer is not None:
-                file_writer.write_file(claude_md_file, claude_md_result.content)
-            else:
-                claude_md_file.write_text(claude_md_result.content)
-        console.print("[green]✓[/green] Generated CLAUDE.md")
-    else:
-        console.print("[yellow]⊘[/yellow] Skipped CLAUDE.md (no API key)")
+    """Generate CLAUDE.md.
+
+    Always runs: with no orchestrator the deterministic baseline is
+    rendered (Phase 1 of the optimization roadmap); with one, the legacy
+    AI-tuned generator is used.
+    """
+    with step_timer("claude_md"), console.status("Generating CLAUDE.md..."):
+        claude_md_generator = ClaudeMdGenerator(orchestrator)
+        project_config = {
+            "project_name": project_name,
+            "language": language,
+            "scripts": [
+                "check-all.sh",
+                "test.sh",
+                "lint.sh",
+                "format.sh",
+                "security.sh",
+                "mutation.sh",
+            ],
+            "skills": REQUIRED_SKILLS.copy(),
+        }
+        claude_md_result = claude_md_generator.generate(project_config)
+        claude_md_file = project_path / "CLAUDE.md"
+        if file_writer is not None:
+            file_writer.write_file(claude_md_file, claude_md_result.content)
+        else:
+            claude_md_file.write_text(claude_md_result.content)
+    console.print("[green]✓[/green] Generated CLAUDE.md")
 
 
 def _generate_architecture_step(
     project_path: Path,
     project_name: str,
     language: str,
-    orchestrator: AIOrchestrator | None,
+    orchestrator: AIOrchestrator | None,  # noqa: ARG001 — preserved for source compat
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate architecture rules or skip if no orchestrator."""
-    if not orchestrator:
-        console.print("[yellow]⊘[/yellow] Skipped architecture rules (no API key)")
+    """Generate architecture rules.
+
+    Architecture configuration is fully deterministic (import-linter for
+    Python, dependency-cruiser for TypeScript). Runs regardless of API
+    key availability; only Python and TypeScript projects produce output.
+    """
+    if language not in {"python", "typescript"}:
+        # The generator only supports these two; silently skip rather
+        # than raise — other languages are valid project targets.
         return
 
     arch_dir = project_path / "plans" / "architecture"
-    # ArchitectureEnforcementGenerator writes files internally;
-    # skip the entire step if the output directory already has content.
     if file_writer is not None and file_writer.skip_existing_dir(arch_dir):
         console.print("[green]✓[/green] Architecture rules (preserved existing)")
         return
 
-    with console.status("Generating architecture rules..."):
-        arch_generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=arch_dir,
-        )
+    with step_timer("architecture"), console.status("Generating architecture rules..."):
+        arch_generator = ArchitectureEnforcementGenerator(output_dir=arch_dir)
         arch_generator.generate(language=language, project_name=project_name)
     console.print("[green]✓[/green] Generated architecture rules")
 
@@ -928,29 +973,39 @@ def _generate_subagents_step(
     orchestrator: AIOrchestrator | None,
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate subagents or skip if no orchestrator."""
-    if orchestrator:
-        with console.status("Generating subagents..."):
-            subagents_generator = SubagentsGenerator(orchestrator)
-            project_config_for_agents = (
-                f"Project: {project_name}, "
-                f"Language: {language}, "
-                f"Type: quality-control-tool"
-            )
-            results = run_async(
-                subagents_generator.generate_all_agents(project_config_for_agents)
-            )
-            subagents_output_dir = project_path / ".claude" / "agents"
-            subagents_output_dir.mkdir(parents=True, exist_ok=True)
-            for agent_name, result in results.items():
-                agent_file = subagents_output_dir / f"{agent_name}.md"
-                if file_writer is not None:
-                    file_writer.write_file(agent_file, result.content)
-                else:
-                    agent_file.write_text(result.content)
-        console.print("[green]✓[/green] Generated subagents")
-    else:
-        console.print("[yellow]⊘[/yellow] Skipped subagents (no API key)")
+    """Generate subagents.
+
+    With an orchestrator: tunes each reference subagent for the target
+    project (currently in parallel, see Phase 2). Without an orchestrator:
+    falls back to copying the reference subagents verbatim so a project
+    is never missing its agent profiles.
+    """
+    subagents_output_dir = project_path / ".claude" / "agents"
+    subagents_output_dir.mkdir(parents=True, exist_ok=True)
+
+    if orchestrator is None:
+        with step_timer("subagents"), console.status("Copying reference subagents..."):
+            _copy_reference_subagents(subagents_output_dir, file_writer=file_writer)
+        console.print("[green]✓[/green] Copied reference subagents")
+        return
+
+    with step_timer("subagents"), console.status("Generating subagents..."):
+        subagents_generator = SubagentsGenerator(orchestrator)
+        project_config_for_agents = (
+            f"Project: {project_name}, "
+            f"Language: {language}, "
+            f"Type: quality-control-tool"
+        )
+        results = run_async(
+            subagents_generator.generate_all_agents(project_config_for_agents)
+        )
+        for agent_name, result in results.items():
+            agent_file = subagents_output_dir / f"{agent_name}.md"
+            if file_writer is not None:
+                file_writer.write_file(agent_file, result.content)
+            else:
+                agent_file.write_text(result.content)
+    console.print("[green]✓[/green] Generated subagents")
 
 
 def _generate_metrics_dashboard_step(
@@ -959,7 +1014,7 @@ def _generate_metrics_dashboard_step(
     language: str,
 ) -> None:
     """Generate live metrics dashboard and workflow."""
-    with console.status("Generating metrics dashboard..."):
+    with step_timer("metrics"), console.status("Generating metrics dashboard..."):
         config = MetricsGenerationConfig(
             language=language,
             project_name=project_name,
@@ -1402,6 +1457,16 @@ def init(  # noqa: PLR0913
             help="Generate live metrics dashboard with auto-updating workflow.",
         ),
     ] = False,
+    timing_json: Annotated[
+        Path | None,
+        typer.Option(
+            "--timing-json",
+            help=(
+                "Write a structured timing/telemetry report to PATH "
+                "(JSON). No effect on default output."
+            ),
+        ),
+    ] = None,
     config: config_file_option = None,
 ) -> None:
     """Initialize a new project with quality controls.
@@ -1422,6 +1487,7 @@ def init(  # noqa: PLR0913
         no_interactive: Non-interactive mode.
         api_key: Optional Claude API key for AI features.
         enable_live_dashboard: Generate live metrics dashboard with workflow.
+        timing_json: Optional path to write a timing/telemetry JSON report.
         config: Configuration file path.
 
     Raises:
@@ -1484,21 +1550,36 @@ def init(  # noqa: PLR0913
         console=console,
     )
 
-    # Generate all project files (handles errors internally)
-    _generate_project_files(
-        project_path,
-        resolved_project_name,
-        resolved_languages,
-        orchestrator,
-        file_writer,
+    # Install a timing collector if the user asked for one. The collector is
+    # process-local; cleared in ``finally`` so back-to-back invocations stay
+    # isolated.
+    timing_report: TimingReport | None = (
+        TimingReport() if timing_json is not None else None
     )
+    if timing_report is not None:
+        set_active_report(timing_report)
 
-    _finalize_init(
-        project_path,
-        resolved_project_name,
-        resolved_languages,
-        enable_live_dashboard=enable_live_dashboard,
-    )
+    try:
+        # Generate all project files (handles errors internally)
+        _generate_project_files(
+            project_path,
+            resolved_project_name,
+            resolved_languages,
+            orchestrator,
+            file_writer,
+        )
+
+        _finalize_init(
+            project_path,
+            resolved_project_name,
+            resolved_languages,
+            enable_live_dashboard=enable_live_dashboard,
+        )
+    finally:
+        if timing_report is not None and timing_json is not None:
+            timing_json.parent.mkdir(parents=True, exist_ok=True)
+            timing_report.write_json(timing_json)
+            set_active_report(None)
 
 
 def cli_main() -> None:

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -930,15 +930,14 @@ def _generate_ci_step(
 
 def _generate_review_step(
     project_path: Path,
-    orchestrator: (
-        AIOrchestrator | None
-    ),  # noqa: ARG001 — Phase 3 cleanup; see plans/2026-05-03-claude-init-optimization-roadmap.md
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate the GitHub Actions code review workflow.
 
-    The generator is fully template-based; the ``orchestrator`` argument
-    is kept only so the call site signature does not churn.
+    The generator is fully template-based — no orchestrator parameter
+    needed. (The orchestrator was previously passed but never used; it
+    has been dropped from this private helper, so the historical
+    ``orchestrator`` argument is gone entirely.)
     """
     with step_timer("review"), console.status("Generating GitHub Actions review..."):
         review_generator = GitHubActionsReviewGenerator()
@@ -949,7 +948,9 @@ def _generate_review_step(
         if file_writer is not None:
             file_writer.write_file(workflow_file, review_result["workflow_content"])
         else:
-            workflow_file.write_text(review_result["workflow_content"])
+            workflow_file.write_text(
+                review_result["workflow_content"], encoding="utf-8"
+            )
     console.print("[green]✓[/green] Generated GitHub Actions review")
 
 
@@ -994,9 +995,6 @@ def _generate_architecture_step(
     project_path: Path,
     project_name: str,
     language: str,
-    orchestrator: (
-        AIOrchestrator | None
-    ),  # noqa: ARG001 — Phase 3 cleanup; see plans/2026-05-03-claude-init-optimization-roadmap.md
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate architecture rules.
@@ -1004,6 +1002,8 @@ def _generate_architecture_step(
     Architecture configuration is fully deterministic (import-linter for
     Python, dependency-cruiser for TypeScript). Runs regardless of API
     key availability; only Python and TypeScript projects produce output.
+    The previous ``orchestrator`` argument was unused and has been
+    removed from this private helper.
     """
     if language not in {"python", "typescript"}:
         # The generator only supports these two; surface a dim info line
@@ -1179,13 +1179,11 @@ def _generate_with_orchestrator(
 ) -> None:
     """Generate AI-powered artifacts (CI, CLAUDE.md, etc.) with progress indicators."""
     _generate_ci_step(project_path, language, orchestrator, file_writer)
-    _generate_review_step(project_path, orchestrator, file_writer)
+    _generate_review_step(project_path, file_writer)
     _generate_claude_md_step(
         project_path, project_name, language, orchestrator, file_writer
     )
-    _generate_architecture_step(
-        project_path, project_name, language, orchestrator, file_writer
-    )
+    _generate_architecture_step(project_path, project_name, language, file_writer)
     _generate_subagents_step(
         project_path, project_name, language, orchestrator, file_writer
     )

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -16,9 +16,12 @@ import shlex
 import shutil
 import sys
 from typing import Annotated
+from typing import Any
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
     from collections.abc import Generator
     from collections.abc import Sequence
 
@@ -71,6 +74,9 @@ __version__ = "1.0.0"
 
 # Constants
 MAX_PROJECT_NAME_LENGTH = 100
+
+# Generic return type for the orchestrator-close coroutine wrapper.
+_R = TypeVar("_R")
 
 # Create Typer app with rich markup enabled
 app = typer.Typer(
@@ -613,11 +619,14 @@ def _copy_reference_subagents(
             msg = f"Reference subagent not found: {source_file}"
             raise FileNotFoundError(msg)
         target_path = target_dir / f"{agent_name}.md"
-        content = source_path.read_text()
+        # Pin UTF-8 explicitly: agent prose contains characters
+        # (✓, ⊘, em-dashes) that would corrupt under a non-UTF-8 locale
+        # default on Windows.
+        content = source_path.read_text(encoding="utf-8")
         if file_writer is not None:
             file_writer.write_file(target_path, content)
         else:
-            target_path.write_text(content)
+            target_path.write_text(content, encoding="utf-8")
 
 
 @contextmanager
@@ -641,6 +650,24 @@ def _maybe_collect_timing(
         timing_json.parent.mkdir(parents=True, exist_ok=True)
         report.write_json(timing_json)
         set_active_report(None)
+
+
+async def _run_with_orchestrator_close(
+    orchestrator: AIOrchestrator,
+    coro: Coroutine[Any, Any, _R],
+) -> _R:
+    """Await ``coro`` and release the orchestrator's async client on exit.
+
+    ``AIOrchestrator`` lazily allocates an :class:`AsyncAnthropic` (and
+    therefore an httpx pool) when ``generate_async`` is first invoked.
+    Without an explicit ``aclose`` the pool would leak across calls in
+    long-lived contexts. ``aclose`` is idempotent, so this is safe even
+    when the async client was never created.
+    """
+    try:
+        return await coro
+    finally:
+        await orchestrator.aclose()
 
 
 def _generate_structure_step(
@@ -975,8 +1002,13 @@ def _generate_architecture_step(
     key availability; only Python and TypeScript projects produce output.
     """
     if language not in {"python", "typescript"}:
-        # The generator only supports these two; silently skip rather
-        # than raise — other languages are valid project targets.
+        # The generator only supports these two; surface a dim info line
+        # so users understand why no architecture rules were generated
+        # for, e.g., a Go or Rust project rather than seeing silence.
+        console.print(
+            f"[dim]Architecture rules unavailable for {language} "
+            "(supported: python, typescript)[/dim]"
+        )
         return
 
     arch_dir = project_path / "plans" / "architecture"
@@ -1020,15 +1052,21 @@ def _generate_subagents_step(
             f"Language: {language}, "
             f"Type: quality-control-tool"
         )
+        # ``_run_with_orchestrator_close`` guarantees the lazily-created
+        # ``AsyncAnthropic`` client is released on the way out, even if
+        # one of the parallel tunings raises.
         results = run_async(
-            subagents_generator.generate_all_agents(project_config_for_agents)
+            _run_with_orchestrator_close(
+                orchestrator,
+                subagents_generator.generate_all_agents(project_config_for_agents),
+            )
         )
         for agent_name, result in results.items():
             agent_file = subagents_output_dir / f"{agent_name}.md"
             if file_writer is not None:
                 file_writer.write_file(agent_file, result.content)
             else:
-                agent_file.write_text(result.content)
+                agent_file.write_text(result.content, encoding="utf-8")
     console.print("[green]✓[/green] Generated subagents")
 
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -930,7 +930,9 @@ def _generate_ci_step(
 
 def _generate_review_step(
     project_path: Path,
-    orchestrator: AIOrchestrator | None,  # noqa: ARG001 — preserved for source compat
+    orchestrator: (
+        AIOrchestrator | None
+    ),  # noqa: ARG001 — Phase 3 cleanup; see plans/2026-05-03-claude-init-optimization-roadmap.md
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate the GitHub Actions code review workflow.
@@ -992,7 +994,9 @@ def _generate_architecture_step(
     project_path: Path,
     project_name: str,
     language: str,
-    orchestrator: AIOrchestrator | None,  # noqa: ARG001 — preserved for source compat
+    orchestrator: (
+        AIOrchestrator | None
+    ),  # noqa: ARG001 — Phase 3 cleanup; see plans/2026-05-03-claude-init-optimization-roadmap.md
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate architecture rules.

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -904,6 +904,7 @@ def _generate_skills_step(
 
 def _generate_ci_step(
     project_path: Path,
+    project_name: str,
     language: str,
     orchestrator: AIOrchestrator | None,
     file_writer: FileWriter | None = None,
@@ -913,10 +914,16 @@ def _generate_ci_step(
     Always runs the deterministic template path so a project is never
     missing CI just because the user has no API key. ``orchestrator`` is
     only used to opt into the legacy AI-tuned path for backward
-    compatibility.
+    compatibility. ``project_name`` is forwarded to the template
+    renderer so any ``<<% project_name %>>`` placeholder lands with
+    the real value rather than the empty string.
     """
     with step_timer("ci"), console.status("Generating CI pipeline..."):
-        ci_generator = CIGenerator(orchestrator, language)
+        ci_generator = CIGenerator(
+            orchestrator,
+            language,
+            project_name=project_name,
+        )
         workflow = ci_generator.generate_workflow()
         workflows_dir = project_path / ".github" / "workflows"
         workflows_dir.mkdir(parents=True, exist_ok=True)
@@ -1181,7 +1188,7 @@ def _generate_with_orchestrator(
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate AI-powered artifacts (CI, CLAUDE.md, etc.) with progress indicators."""
-    _generate_ci_step(project_path, language, orchestrator, file_writer)
+    _generate_ci_step(project_path, project_name, language, orchestrator, file_writer)
     _generate_review_step(project_path, file_writer)
     _generate_claude_md_step(
         project_path, project_name, language, orchestrator, file_writer

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -924,7 +924,7 @@ def _generate_ci_step(
         if file_writer is not None:
             file_writer.write_file(ci_file, workflow.content)
         else:
-            ci_file.write_text(workflow.content)
+            ci_file.write_text(workflow.content, encoding="utf-8")
     console.print("[green]✓[/green] Generated CI pipeline")
 
 
@@ -987,7 +987,7 @@ def _generate_claude_md_step(
         if file_writer is not None:
             file_writer.write_file(claude_md_file, claude_md_result.content)
         else:
-            claude_md_file.write_text(claude_md_result.content)
+            claude_md_file.write_text(claude_md_result.content, encoding="utf-8")
     console.print("[green]✓[/green] Generated CLAUDE.md")
 
 
@@ -1126,7 +1126,10 @@ def _generate_metrics_dashboard_step(
                 "security_status": "pass",
             },
         }
-        initial_metrics_path.write_text(json.dumps(initial_metrics, indent=2))
+        initial_metrics_path.write_text(
+            json.dumps(initial_metrics, indent=2),
+            encoding="utf-8",
+        )
 
         workflows_dir = project_path / ".github" / "workflows"
         workflows_dir.mkdir(parents=True, exist_ok=True)
@@ -1138,11 +1141,11 @@ def _generate_metrics_dashboard_step(
         if sgsg_workflow.exists():
             target_workflow = workflows_dir / "metrics.yml"
             shutil.copy(sgsg_workflow, target_workflow)
-            workflow_content = target_workflow.read_text()
+            workflow_content = target_workflow.read_text(encoding="utf-8")
             workflow_content = workflow_content.replace(
                 "start-green-stay-green", project_name
             )
-            target_workflow.write_text(workflow_content)
+            target_workflow.write_text(workflow_content, encoding="utf-8")
         else:
             missing_workflow = True
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -5,6 +5,7 @@ Implements the command-line interface using Typer with rich output formatting.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import UTC
 from datetime import datetime
 import json
@@ -617,6 +618,29 @@ def _copy_reference_subagents(
             file_writer.write_file(target_path, content)
         else:
             target_path.write_text(content)
+
+
+@contextmanager
+def _maybe_collect_timing(
+    timing_json: Path | None,
+) -> Generator[None, None, None]:
+    """Optionally install a :class:`TimingReport` for the wrapped block.
+
+    When ``timing_json`` is ``None`` the manager is a no-op; otherwise a
+    fresh report is installed as the active collector for the duration of
+    the block and written to disk on exit (success or failure).
+    """
+    if timing_json is None:
+        yield
+        return
+    report = TimingReport()
+    set_active_report(report)
+    try:
+        yield
+    finally:
+        timing_json.parent.mkdir(parents=True, exist_ok=True)
+        report.write_json(timing_json)
+        set_active_report(None)
 
 
 def _generate_structure_step(
@@ -1550,17 +1574,7 @@ def init(  # noqa: PLR0913
         console=console,
     )
 
-    # Install a timing collector if the user asked for one. The collector is
-    # process-local; cleared in ``finally`` so back-to-back invocations stay
-    # isolated.
-    timing_report: TimingReport | None = (
-        TimingReport() if timing_json is not None else None
-    )
-    if timing_report is not None:
-        set_active_report(timing_report)
-
-    try:
-        # Generate all project files (handles errors internally)
+    with _maybe_collect_timing(timing_json):
         _generate_project_files(
             project_path,
             resolved_project_name,
@@ -1568,18 +1582,12 @@ def init(  # noqa: PLR0913
             orchestrator,
             file_writer,
         )
-
         _finalize_init(
             project_path,
             resolved_project_name,
             resolved_languages,
             enable_live_dashboard=enable_live_dashboard,
         )
-    finally:
-        if timing_report is not None and timing_json is not None:
-            timing_json.parent.mkdir(parents=True, exist_ok=True)
-            timing_report.write_json(timing_json)
-            set_active_report(None)
 
 
 def cli_main() -> None:

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+import warnings
 
 if TYPE_CHECKING:
     from start_green_stay_green.ai.orchestrator import AIOrchestrator
@@ -53,9 +54,22 @@ class ArchitectureEnforcementGenerator:
             orchestrator: Deprecated. The architecture generator is fully
                 deterministic; this parameter is retained for source
                 compatibility and ignored. New code should omit it.
+                Passing a non-``None`` value emits a
+                :class:`DeprecationWarning` so callers can find the
+                stale wiring before the parameter is removed in the
+                Phase 3 cleanup of the optimization roadmap.
             output_dir: Output directory for generated files.
                 Defaults to plans/architecture.
         """
+        if orchestrator is not None:
+            warnings.warn(
+                "ArchitectureEnforcementGenerator's 'orchestrator' parameter "
+                "is deprecated and will be removed in Phase 3 of the "
+                "optimization roadmap. The generator is fully "
+                "deterministic; pass nothing instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.orchestrator = orchestrator
         self.output_dir = output_dir or Path("plans/architecture")
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -43,14 +43,16 @@ class ArchitectureEnforcementGenerator:
 
     def __init__(
         self,
-        orchestrator: AIOrchestrator,
+        orchestrator: AIOrchestrator | None = None,
         *,
         output_dir: Path | None = None,
     ) -> None:
         """Initialize Architecture Enforcement Generator.
 
         Args:
-            orchestrator: AI orchestrator for content generation.
+            orchestrator: Deprecated. The architecture generator is fully
+                deterministic; this parameter is retained for source
+                compatibility and ignored. New code should omit it.
             output_dir: Output directory for generated files.
                 Defaults to plans/architecture.
         """

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -242,7 +242,7 @@ class CIGenerator(BaseGenerator):
         # render unchanged unless a maintainer opts in to a placeholder.
         # autoescape stays off because the rendered output is YAML, not
         # HTML — the Jinja XSS warning does not apply.
-        env = Environment(
+        env = Environment(  # nosec B701 — YAML output, no HTML/XSS surface
             variable_start_string="<<%",
             variable_end_string="%>>",
             block_start_string="<%",

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -209,9 +209,11 @@ class CIGenerator(BaseGenerator):
         Reads ``reference/ci/<language>.yml`` and runs it through Jinja2 so
         callers can substitute the project name (or any future
         placeholders). The reference templates are valid YAML even before
-        rendering — Jinja syntax is only used for ``{{ project_name }}``
-        and similar substitutions, so files without placeholders are
-        returned essentially verbatim.
+        rendering — Jinja syntax uses the custom delimiters
+        ``<<% project_name %>>`` (see the ``Environment`` configuration
+        below) so existing GitHub Actions ``${{ … }}`` expressions in
+        the templates pass through verbatim. Files without placeholders
+        are returned essentially unchanged.
 
         Args:
             project_name: Optional project name to substitute into any

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -1,17 +1,24 @@
 """CI pipeline generator for target projects.
 
 Generates GitHub Actions workflows customized to target project language
-and framework. Integrates reference CI configurations and quality standards
-from MAXIMUM_QUALITY_ENGINEERING.md.
+and framework.
+
+Default path: render the deterministic, version-controlled YAML templates
+in ``reference/ci/<language>.yml`` through Jinja2, substituting the
+project name. The optional Claude-powered path is reserved for the
+``green enhance`` flow (Phase 3 of the optimization roadmap) and only
+runs when an :class:`AIOrchestrator` is provided.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import io
+from pathlib import Path
 from typing import Any
 from typing import TYPE_CHECKING
 
+from jinja2 import Environment
 import yaml
 
 from start_green_stay_green.generators.base import BaseGenerator
@@ -20,6 +27,13 @@ from start_green_stay_green.utils.yaml_utils import strip_markdown_fences
 if TYPE_CHECKING:
     from start_green_stay_green.ai.orchestrator import AIOrchestrator
     from start_green_stay_green.ai.orchestrator import GenerationResult
+
+
+# Reference CI templates ship with the package. Each ``<language>.yml`` is
+# a deterministic baseline that ``green init`` renders without calling
+# Claude. The directory is resolved relative to the package root rather
+# than CWD so the generator works whether installed or run in-tree.
+REFERENCE_CI_DIR = Path(__file__).parent.parent.parent / "reference" / "ci"
 
 # Supported languages and their configurations
 LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
@@ -118,18 +132,25 @@ class CIGenerator(BaseGenerator):
 
     def __init__(
         self,
-        orchestrator: AIOrchestrator,
-        language: str,
+        orchestrator: AIOrchestrator | None = None,
+        language: str = "python",
         *,
         framework: str | None = None,
+        reference_dir: Path | None = None,
     ) -> None:
         """Initialize CI Generator.
 
         Args:
-            orchestrator: AIOrchestrator instance for generation.
+            orchestrator: Optional AIOrchestrator for the legacy
+                Claude-generated path. Default :data:`None` selects the
+                deterministic template-based path
+                (``generate_workflow_from_template``).
             language: Target language (python, typescript, go, rust, java,
                 csharp, ruby).
             framework: Optional framework (e.g., FastAPI, Express, Gin).
+            reference_dir: Directory containing ``<language>.yml``
+                reference templates. Defaults to ``reference/ci/`` shipped
+                with the package.
 
         Raises:
             ValueError: If language is not supported.
@@ -147,21 +168,27 @@ class CIGenerator(BaseGenerator):
         config = LANGUAGE_CONFIGS[language]
         self.test_framework = config["test_framework"]
         self.supported_versions = config["supported_versions"]
+        self.reference_dir = reference_dir or REFERENCE_CI_DIR
 
     def generate_workflow(self) -> CIWorkflow:
-        """Generate customized CI workflow.
+        """Generate a customized CI workflow.
 
-        Creates a complete GitHub Actions workflow file adapted to the target
-        language and framework. Includes quality checks, testing matrix, coverage
-        analysis, and optional mutation testing.
+        By default this renders the deterministic ``reference/ci/<language>.yml``
+        baseline through Jinja2 (no API call). If an
+        :class:`AIOrchestrator` was passed at construction time the legacy
+        Claude-generated path is used instead, preserving backward
+        compatibility for callers that rely on AI tuning.
 
         Returns:
             CIWorkflow with generated YAML content and validation status.
 
         Raises:
-            GenerationError: If AI generation fails or output is invalid.
-            ValueError: If validation fails.
+            GenerationError: If AI generation fails (orchestrator path).
+            ValueError: If validation fails or template missing.
         """
+        if self.orchestrator is None:
+            return self.generate_workflow_from_template()
+
         # Build context for AI generation
         language_config = LANGUAGE_CONFIGS[self.language]
         context = self._build_generation_context(language_config)
@@ -171,6 +198,66 @@ class CIGenerator(BaseGenerator):
 
         # Validate generated workflow
         return self._validate_and_parse(result.content)
+
+    def generate_workflow_from_template(
+        self,
+        *,
+        project_name: str | None = None,
+    ) -> CIWorkflow:
+        """Render the deterministic CI template for the configured language.
+
+        Reads ``reference/ci/<language>.yml`` and runs it through Jinja2 so
+        callers can substitute the project name (or any future
+        placeholders). The reference templates are valid YAML even before
+        rendering — Jinja syntax is only used for ``{{ project_name }}``
+        and similar substitutions, so files without placeholders are
+        returned essentially verbatim.
+
+        Args:
+            project_name: Optional project name to substitute in the
+                workflow header. Falls back to the language-specific
+                default present in the reference template.
+
+        Returns:
+            ``CIWorkflow`` with the rendered, validated YAML.
+
+        Raises:
+            FileNotFoundError: If no reference template exists for the
+                language.
+            ValueError: If the rendered YAML fails structural validation.
+        """
+        template_path = self.reference_dir / f"{self.language}.yml"
+        if not template_path.exists():
+            msg = (
+                f"No reference CI template for language '{self.language}': "
+                f"expected {template_path}"
+            )
+            raise FileNotFoundError(msg)
+
+        raw = template_path.read_text()
+
+        # The reference YAMLs already contain GitHub Actions ``${{ }}``
+        # expressions, which collide with Jinja2's default delimiters.
+        # Use custom delimiters (``<<%`` / ``%>>``) so existing templates
+        # render unchanged unless a maintainer opts in to a placeholder.
+        # autoescape stays off because the rendered output is YAML, not
+        # HTML — the Jinja XSS warning does not apply.
+        env = Environment(
+            variable_start_string="<<%",
+            variable_end_string="%>>",
+            block_start_string="<%",
+            block_end_string="%>",
+            comment_start_string="<#",
+            comment_end_string="#>",
+            autoescape=False,  # noqa: S701 — YAML output
+            keep_trailing_newline=True,
+        )
+        rendered = env.from_string(raw).render(
+            project_name=project_name,
+            language=self.language,
+        )
+
+        return self._validate_and_parse(rendered)
 
     def _build_generation_context(
         self,

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -234,7 +234,7 @@ class CIGenerator(BaseGenerator):
             )
             raise FileNotFoundError(msg)
 
-        raw = template_path.read_text()
+        raw = template_path.read_text(encoding="utf-8")
 
         # The reference YAMLs already contain GitHub Actions ``${{ }}``
         # expressions, which collide with Jinja2's default delimiters.

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -138,6 +138,7 @@ class CIGenerator(BaseGenerator):
         *,
         framework: str | None = None,
         reference_dir: Path | None = None,
+        project_name: str | None = None,
     ) -> None:
         """Initialize CI Generator.
 
@@ -152,6 +153,11 @@ class CIGenerator(BaseGenerator):
             reference_dir: Directory containing ``<language>.yml``
                 reference templates. Defaults to ``reference/ci/`` shipped
                 with the package.
+            project_name: Optional project name forwarded to
+                :meth:`generate_workflow_from_template` so any
+                ``<<% project_name %>>`` placeholder in the reference
+                template renders with the real value. ``None`` is
+                coerced to ``""`` at render time.
 
         Raises:
             ValueError: If language is not supported.
@@ -166,6 +172,7 @@ class CIGenerator(BaseGenerator):
 
         self.language = language
         self.framework = framework
+        self.project_name = project_name
         config = LANGUAGE_CONFIGS[language]
         self.test_framework = config["test_framework"]
         self.supported_versions = config["supported_versions"]
@@ -188,7 +195,9 @@ class CIGenerator(BaseGenerator):
             ValueError: If validation fails or template missing.
         """
         if self.orchestrator is None:
-            return self.generate_workflow_from_template()
+            return self.generate_workflow_from_template(
+                project_name=self.project_name,
+            )
 
         # Build context for AI generation
         language_config = LANGUAGE_CONFIGS[self.language]

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -214,9 +214,17 @@ class CIGenerator(BaseGenerator):
         returned essentially verbatim.
 
         Args:
-            project_name: Optional project name to substitute in the
-                workflow header. Falls back to the language-specific
-                default present in the reference template.
+            project_name: Optional project name to substitute into any
+                ``<<% project_name %>>`` placeholders. The reference
+                templates currently ship *without* such placeholders,
+                so omitting this argument or passing ``None`` produces
+                output identical to the on-disk template — there is no
+                language-specific default to fall back to. If a
+                template is later updated to include a placeholder and
+                the caller does not pass a value, Jinja will substitute
+                the literal string ``"None"``; that is intentional so
+                the caller's mistake is loudly visible rather than
+                silently absorbed.
 
         Returns:
             ``CIWorkflow`` with the rendered, validated YAML.

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -19,6 +19,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from jinja2 import Environment
+from jinja2 import StrictUndefined
 import yaml
 
 from start_green_stay_green.generators.base import BaseGenerator
@@ -217,16 +218,9 @@ class CIGenerator(BaseGenerator):
 
         Args:
             project_name: Optional project name to substitute into any
-                ``<<% project_name %>>`` placeholders. The reference
-                templates currently ship *without* such placeholders,
-                so omitting this argument or passing ``None`` produces
-                output identical to the on-disk template — there is no
-                language-specific default to fall back to. If a
-                template is later updated to include a placeholder and
-                the caller does not pass a value, Jinja will substitute
-                the literal string ``"None"``; that is intentional so
-                the caller's mistake is loudly visible rather than
-                silently absorbed.
+                ``<<% project_name %>>`` placeholders. ``None`` is
+                coerced to ``""`` so the literal string ``"None"`` is
+                never baked into the rendered YAML.
 
         Returns:
             ``CIWorkflow`` with the rendered, validated YAML.
@@ -234,6 +228,10 @@ class CIGenerator(BaseGenerator):
         Raises:
             FileNotFoundError: If no reference template exists for the
                 language.
+            jinja2.UndefinedError: If a template references a
+                placeholder that has not been wired through this
+                method's ``render(...)`` kwargs (raised eagerly thanks
+                to ``StrictUndefined``).
             ValueError: If the rendered YAML fails structural validation.
         """
         template_path = self.reference_dir / f"{self.language}.yml"
@@ -261,9 +259,15 @@ class CIGenerator(BaseGenerator):
             comment_end_string="#>",
             autoescape=False,  # noqa: S701 — YAML output
             keep_trailing_newline=True,
+            undefined=StrictUndefined,
         )
+        # Coerce ``project_name=None`` to "" so a template that references
+        # the placeholder does not get the literal string "None" silently
+        # baked into the output. ``StrictUndefined`` makes any *other*
+        # placeholder added later but not passed here raise loudly at
+        # render time instead of silently emitting the empty string.
         rendered = env.from_string(raw).render(
-            project_name=project_name,
+            project_name=project_name or "",
             language=self.language,
         )
 

--- a/start_green_stay_green/generators/claude_md.py
+++ b/start_green_stay_green/generators/claude_md.py
@@ -104,7 +104,7 @@ class ClaudeMdGenerator:
             FileNotFoundError: If CLAUDE.md reference file not found.
         """
         claude_md_path = self.reference_dir / "CLAUDE.md"
-        return claude_md_path.read_text()
+        return claude_md_path.read_text(encoding="utf-8")
 
     def _load_quality_reference(self) -> str:
         """Load MAXIMUM_QUALITY_ENGINEERING.md reference.
@@ -115,7 +115,7 @@ class ClaudeMdGenerator:
         Raises:
             FileNotFoundError: If quality reference file not found.
         """
-        return self.quality_ref_path.read_text()
+        return self.quality_ref_path.read_text(encoding="utf-8")
 
     def _build_generation_prompt(
         self,

--- a/start_green_stay_green/generators/claude_md.py
+++ b/start_green_stay_green/generators/claude_md.py
@@ -211,7 +211,20 @@ Start with the H1 title and include all sections from the reference template.
             raise ValueError(msg)
 
     @staticmethod
+    def _baseline_substitutions(project_config: dict[str, Any]) -> dict[str, str]:
+        """Build the token → replacement map for ``_render_baseline``."""
+        scripts = project_config.get("scripts") or []
+        skills = project_config.get("skills") or []
+        return {
+            "{{PROJECT_NAME}}": str(project_config.get("project_name", "your-project")),
+            "{{LANGUAGE}}": str(project_config.get("language", "python")),
+            "{{SCRIPTS}}": "\n".join(f"- {s}" for s in scripts),
+            "{{SKILLS}}": "\n".join(f"- {s}" for s in skills),
+        }
+
+    @classmethod
     def _render_baseline(
+        cls,
         reference: str,
         project_config: dict[str, Any],
     ) -> str:
@@ -221,28 +234,9 @@ Start with the H1 title and include all sections from the reference template.
         ``{{PROJECT_NAME}}``. This is a deterministic, dependency-free
         substitution: unknown tokens are left intact so the resulting file
         is always inspectable for "what was the user supposed to fill in?".
-
-        Args:
-            reference: Raw reference template content.
-            project_config: Project configuration with at minimum
-                ``project_name`` and ``language``. Extra keys are ignored.
-
-        Returns:
-            Rendered baseline content.
         """
-        project_name = str(project_config.get("project_name", "your-project"))
-        language = str(project_config.get("language", "python"))
-        scripts = project_config.get("scripts", []) or []
-        skills = project_config.get("skills", []) or []
-
-        substitutions = {
-            "{{PROJECT_NAME}}": project_name,
-            "{{LANGUAGE}}": language,
-            "{{SCRIPTS}}": "\n".join(f"- {s}" for s in scripts),
-            "{{SKILLS}}": "\n".join(f"- {s}" for s in skills),
-        }
         rendered = reference
-        for token, value in substitutions.items():
+        for token, value in cls._baseline_substitutions(project_config).items():
             rendered = rendered.replace(token, value)
         return rendered
 

--- a/start_green_stay_green/generators/claude_md.py
+++ b/start_green_stay_green/generators/claude_md.py
@@ -43,7 +43,7 @@ class ClaudeMdGenerator:
 
     def __init__(
         self,
-        orchestrator: AIOrchestrator,
+        orchestrator: AIOrchestrator | None = None,
         *,
         reference_dir: Path | None = None,
         quality_ref_path: Path | None = None,
@@ -51,7 +51,8 @@ class ClaudeMdGenerator:
         """Initialize ClaudeMdGenerator.
 
         Args:
-            orchestrator: AI orchestrator for generation.
+            orchestrator: Optional AI orchestrator. When ``None``, only the
+                deterministic ``generate_baseline`` path is available.
             reference_dir: Directory with CLAUDE.md reference
                 (default: reference/claude).
             quality_ref_path: Path to quality reference
@@ -209,8 +210,80 @@ Start with the H1 title and include all sections from the reference template.
             msg = "Generated CLAUDE.md is missing H1 title"
             raise ValueError(msg)
 
+    @staticmethod
+    def _render_baseline(
+        reference: str,
+        project_config: dict[str, Any],
+    ) -> str:
+        """Substitute ``{{PLACEHOLDER}}`` tokens in the reference template.
+
+        The reference CLAUDE.md uses double-brace tokens like
+        ``{{PROJECT_NAME}}``. This is a deterministic, dependency-free
+        substitution: unknown tokens are left intact so the resulting file
+        is always inspectable for "what was the user supposed to fill in?".
+
+        Args:
+            reference: Raw reference template content.
+            project_config: Project configuration with at minimum
+                ``project_name`` and ``language``. Extra keys are ignored.
+
+        Returns:
+            Rendered baseline content.
+        """
+        project_name = str(project_config.get("project_name", "your-project"))
+        language = str(project_config.get("language", "python"))
+        scripts = project_config.get("scripts", []) or []
+        skills = project_config.get("skills", []) or []
+
+        substitutions = {
+            "{{PROJECT_NAME}}": project_name,
+            "{{LANGUAGE}}": language,
+            "{{SCRIPTS}}": "\n".join(f"- {s}" for s in scripts),
+            "{{SKILLS}}": "\n".join(f"- {s}" for s in skills),
+        }
+        rendered = reference
+        for token, value in substitutions.items():
+            rendered = rendered.replace(token, value)
+        return rendered
+
+    def generate_baseline(
+        self,
+        project_config: dict[str, Any],
+    ) -> ClaudeMdGenerationResult:
+        """Render a CLAUDE.md baseline without any API calls.
+
+        This is the fast, deterministic path used by Pass 1 of the new
+        two-pass init. The result is a complete, valid CLAUDE.md based on
+        the reference template with ``{{PROJECT_NAME}}``-style tokens
+        substituted.
+
+        Args:
+            project_config: Project configuration with keys
+                ``project_name``, ``language``, ``scripts``, ``skills``.
+
+        Returns:
+            ``ClaudeMdGenerationResult`` with zero token usage.
+
+        Raises:
+            ValueError: If the rendered baseline lacks a valid H1 title.
+            FileNotFoundError: If reference files are missing.
+        """
+        self._validate_reference_dir()
+        reference = self._load_claude_md_reference()
+        rendered = self._render_baseline(reference, project_config)
+        self._validate_markdown_structure(rendered)
+        return ClaudeMdGenerationResult(
+            content=rendered,
+            token_usage_input=0,
+            token_usage_output=0,
+        )
+
     def generate(self, project_config: dict[str, Any]) -> ClaudeMdGenerationResult:
         """Generate customized CLAUDE.md for target project.
+
+        When an orchestrator is configured this dispatches to the legacy
+        AI-tuned path. Otherwise it falls back to ``generate_baseline``,
+        guaranteeing a complete file in offline mode.
 
         Args:
             project_config: Project configuration dictionary with keys:
@@ -226,6 +299,9 @@ Start with the H1 title and include all sections from the reference template.
             ValueError: If reference files are invalid.
             FileNotFoundError: If reference files are missing.
         """
+        if self.orchestrator is None:
+            return self.generate_baseline(project_config)
+
         # Validate and load references
         self._validate_reference_dir()
         claude_md_reference = self._load_claude_md_reference()

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -276,13 +276,28 @@ class MetricsGenerator(BaseGenerator):
             orchestrator: Deprecated. The metrics generator is fully
                 deterministic; this parameter is retained for source
                 compatibility and ignored. New code should omit it.
-            config: Configuration for metrics generation.
+            config: Configuration for metrics generation. Required;
+                ``None`` is accepted only for source-compatibility with
+                the historical positional-orchestrator signature, and
+                will raise. The default will be removed in the Phase 3
+                cleanup of plans/2026-05-03-claude-init-optimization-
+                roadmap.md.
 
         Raises:
-            ValueError: If configuration is missing or invalid.
+            ValueError: If ``config`` is omitted (default ``None``) or
+                otherwise invalid.
         """
         if config is None:
-            msg = "MetricsGenerator requires a MetricsGenerationConfig"
+            # Defaulting to None is a transitional shim for callers that
+            # used to write ``MetricsGenerator(None, my_config)`` —
+            # removing the default entirely would break them. A future
+            # release will tighten the signature to ``config: ...``
+            # (no default).
+            msg = (
+                "MetricsGenerator requires a MetricsGenerationConfig; "
+                "passing config=None is a transitional shim that will "
+                "be removed when the orchestrator parameter is dropped"
+            )
             raise ValueError(msg)
         self.orchestrator = orchestrator
         self.config = config

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import re
 from typing import Any
 from typing import TYPE_CHECKING
+import warnings
 
 import yaml
 
@@ -277,8 +278,9 @@ class MetricsGenerator(BaseGenerator):
                 deterministic; this parameter is retained for source
                 compatibility (every existing caller passes either an
                 orchestrator or :data:`None` here as the first
-                positional arg) and is ignored. The parameter will be
-                removed in the Phase 3 cleanup of
+                positional arg) and is ignored. Passing a non-``None``
+                value emits a :class:`DeprecationWarning`. The parameter
+                will be removed in the Phase 3 cleanup of
                 plans/2026-05-03-claude-init-optimization-roadmap.md.
             config: Configuration for metrics generation. Required;
                 the type system enforces that callers pass a real
@@ -288,6 +290,15 @@ class MetricsGenerator(BaseGenerator):
             ValueError: If ``config`` fails its own validation
                 (:meth:`_validate_config`).
         """
+        if orchestrator is not None:
+            warnings.warn(
+                "MetricsGenerator's 'orchestrator' parameter is "
+                "deprecated and will be removed in Phase 3 of the "
+                "optimization roadmap. The generator is fully "
+                "deterministic; pass None instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.orchestrator = orchestrator
         self.config = config
         self._validate_config()

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -267,18 +267,23 @@ class MetricsGenerator(BaseGenerator):
 
     def __init__(
         self,
-        orchestrator: AIOrchestrator | None,
-        config: MetricsGenerationConfig,
+        orchestrator: AIOrchestrator | None = None,
+        config: MetricsGenerationConfig | None = None,
     ) -> None:
         """Initialize MetricsGenerator.
 
         Args:
-            orchestrator: Optional AI orchestrator for generation.
+            orchestrator: Deprecated. The metrics generator is fully
+                deterministic; this parameter is retained for source
+                compatibility and ignored. New code should omit it.
             config: Configuration for metrics generation.
 
         Raises:
-            ValueError: If configuration is invalid.
+            ValueError: If configuration is missing or invalid.
         """
+        if config is None:
+            msg = "MetricsGenerator requires a MetricsGenerationConfig"
+            raise ValueError(msg)
         self.orchestrator = orchestrator
         self.config = config
         self._validate_config()

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -267,38 +267,27 @@ class MetricsGenerator(BaseGenerator):
 
     def __init__(
         self,
-        orchestrator: AIOrchestrator | None = None,
-        config: MetricsGenerationConfig | None = None,
+        orchestrator: AIOrchestrator | None,
+        config: MetricsGenerationConfig,
     ) -> None:
         """Initialize MetricsGenerator.
 
         Args:
             orchestrator: Deprecated. The metrics generator is fully
                 deterministic; this parameter is retained for source
-                compatibility and ignored. New code should omit it.
+                compatibility (every existing caller passes either an
+                orchestrator or :data:`None` here as the first
+                positional arg) and is ignored. The parameter will be
+                removed in the Phase 3 cleanup of
+                plans/2026-05-03-claude-init-optimization-roadmap.md.
             config: Configuration for metrics generation. Required;
-                ``None`` is accepted only for source-compatibility with
-                the historical positional-orchestrator signature, and
-                will raise. The default will be removed in the Phase 3
-                cleanup of plans/2026-05-03-claude-init-optimization-
-                roadmap.md.
+                the type system enforces that callers pass a real
+                :class:`MetricsGenerationConfig`.
 
         Raises:
-            ValueError: If ``config`` is omitted (default ``None``) or
-                otherwise invalid.
+            ValueError: If ``config`` fails its own validation
+                (:meth:`_validate_config`).
         """
-        if config is None:
-            # Defaulting to None is a transitional shim for callers that
-            # used to write ``MetricsGenerator(None, my_config)`` —
-            # removing the default entirely would break them. A future
-            # release will tighten the signature to ``config: ...``
-            # (no default).
-            msg = (
-                "MetricsGenerator requires a MetricsGenerationConfig; "
-                "passing config=None is a transitional shim that will "
-                "be removed when the orchestrator parameter is dropped"
-            )
-            raise ValueError(msg)
         self.orchestrator = orchestrator
         self.config = config
         self._validate_config()

--- a/start_green_stay_green/generators/subagents.py
+++ b/start_green_stay_green/generators/subagents.py
@@ -6,6 +6,7 @@ tuning them for the target project context, and preserving YAML frontmatter stru
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 import re
@@ -14,6 +15,10 @@ from typing import TYPE_CHECKING
 
 from start_green_stay_green.ai.tuner import ContentTuner
 from start_green_stay_green.generators.base import BaseGenerator
+
+# Bounded concurrency keeps us under Anthropic's per-tier rate limits even
+# when the user has eight subagents (or more, post-Phase 3) to tune.
+DEFAULT_MAX_CONCURRENCY = 8
 
 if TYPE_CHECKING:
     from start_green_stay_green.ai.orchestrator import AIOrchestrator
@@ -83,6 +88,7 @@ class SubagentsGenerator(BaseGenerator):
         *,
         reference_dir: Path | None = None,
         dry_run: bool = False,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
     ) -> None:
         """Initialize SubagentsGenerator.
 
@@ -91,11 +97,15 @@ class SubagentsGenerator(BaseGenerator):
             reference_dir: Directory containing reference agents.
                 Defaults to .claude/agents/ in project root.
             dry_run: If True, skip actual tuning (for testing).
+            max_concurrency: Upper bound on concurrent agent tunings.
+                ``asyncio.Semaphore`` enforces this so a slow network or
+                tight Anthropic rate limit does not produce burst-failures.
         """
         self.orchestrator = orchestrator
         self.tuner = ContentTuner(orchestrator, dry_run=dry_run)
         self.reference_dir = reference_dir or REFERENCE_AGENTS_DIR
         self.dry_run = dry_run
+        self.max_concurrency = max_concurrency
         self._validate_reference_dir()
 
     def _check_directory_exists(self) -> None:
@@ -268,19 +278,31 @@ class SubagentsGenerator(BaseGenerator):
         self,
         target_context: str,
     ) -> dict[str, SubagentGenerationResult]:
-        """Generate all required subagents for target project.
+        """Generate every required subagent concurrently.
+
+        Each agent is tuned in its own task; ``asyncio.gather`` waits for
+        all of them. A bounded ``Semaphore`` keeps the in-flight count at
+        or below ``self.max_concurrency`` so we don't trip the Anthropic
+        rate limiter.
 
         Args:
             target_context: Description of target project context.
 
         Returns:
-            Dictionary mapping agent names to generation results.
+            Dictionary mapping agent names to generation results, in the
+            order declared in :data:`REQUIRED_AGENTS`.
         """
-        results = {}
-        for agent_name in REQUIRED_AGENTS:
-            result = await self.generate_agent(agent_name, target_context)
-            results[agent_name] = result
-        return results
+        agent_names = list(REQUIRED_AGENTS)
+        semaphore = asyncio.Semaphore(self.max_concurrency)
+
+        async def _run_one(name: str) -> SubagentGenerationResult:
+            async with semaphore:
+                return await self.generate_agent(name, target_context)
+
+        results_list = await asyncio.gather(
+            *(_run_one(name) for name in agent_names),
+        )
+        return dict(zip(agent_names, results_list, strict=True))
 
     def generate(self) -> dict[str, Any]:
         """Generate subagents synchronously (not supported).

--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -71,8 +71,14 @@ class TimingReport:
     started_at: float = field(default_factory=time.perf_counter)
     steps: list[StepTiming] = field(default_factory=list)
     api_calls: list[APICallRecord] = field(default_factory=list)
-    _stack: list[StepTiming] = field(default_factory=list)
-    _lock: threading.Lock = field(default_factory=threading.Lock)
+    # Internal bookkeeping fields are excluded from ``__repr__`` and
+    # ``__eq__``: ``threading.Lock`` has no meaningful equality so two
+    # otherwise-identical reports would compare unequal, and the stack
+    # is ephemeral state that should not appear in debug output.
+    _stack: list[StepTiming] = field(default_factory=list, repr=False, compare=False)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, repr=False, compare=False
+    )
 
     def begin_step(self, name: str) -> StepTiming:
         """Push a new step onto the active stack and return its record.

--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -192,6 +192,11 @@ class TimingReport:
         )
 
 
+# Process-global active report. Correct for both sequential ``green init``
+# and the Phase 2 ``asyncio.gather`` fan-out (every concurrent subagent
+# task should accumulate into the same report). Issue #307 tracks
+# migrating this to ``contextvars.ContextVar`` before Phase 3 / Phase 5
+# introduce per-task timing scopes that need independent reports.
 _active_report: TimingReport | None = None
 _active_lock = threading.Lock()
 

--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -92,14 +92,27 @@ class TimingReport:
     def end_step(self, record: StepTiming, duration_s: float) -> None:
         """Mark a step as complete with the given duration.
 
+        Pops everything from the active stack down to and including
+        ``record``. This makes the collector resilient to out-of-order
+        completion: if a child step's ``__exit__`` is skipped (e.g. its
+        ``begin_step`` succeeded but the surrounding context manager
+        bailed before ``end_step``), the parent will still be popped
+        when its own ``end_step`` runs, instead of leaving a stale
+        entry that would mis-attribute later API calls.
+
         Args:
             record: The record returned by ``begin_step``.
             duration_s: Wall-clock duration in seconds.
         """
         with self._lock:
             record.duration_s = duration_s
-            if self._stack and self._stack[-1] is record:
-                self._stack.pop()
+            # Pop down to ``record`` (inclusive) if it's in the stack;
+            # otherwise leave the stack alone so other in-flight steps
+            # are unaffected.
+            for index in range(len(self._stack) - 1, -1, -1):
+                if self._stack[index] is record:
+                    del self._stack[index:]
+                    return
 
     def record_api_call(self, call: APICallRecord) -> None:
         """Record a single API call; attribute it to the active step (if any).

--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -177,7 +177,13 @@ class TimingReport:
         Args:
             path: Destination file path. Parent directories must exist.
         """
-        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True))
+        # Pin UTF-8 so the report is portable across locales (the report
+        # contains step names and any future free-form fields that may
+        # include non-ASCII characters).
+        path.write_text(
+            json.dumps(self.to_dict(), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
 
 
 _active_report: TimingReport | None = None

--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -1,0 +1,225 @@
+"""Timing and telemetry collection for ``green init``.
+
+Provides a ``step_timer`` context manager that records named step durations
+and a ``TimingReport`` collector that also accumulates Claude API call
+metadata (latency, retries, token usage). The collector is intentionally
+process-local: telemetry is only persisted when the user passes a path.
+
+Phase 0 of the optimization roadmap relies on this module to baseline
+``green init`` so that subsequent phases can be measured.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from dataclasses import field
+import json
+import threading
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@dataclass
+class StepTiming:
+    """Timing record for a single named step.
+
+    Attributes:
+        name: Logical step identifier (matches the CLI status string).
+        duration_s: Wall-clock duration in seconds.
+        api_calls: Number of API calls dispatched during this step.
+    """
+
+    name: str
+    duration_s: float
+    api_calls: int = 0
+
+
+@dataclass
+class APICallRecord:
+    """Telemetry for a single Claude API call.
+
+    Attributes:
+        latency_s: Wall-clock duration of the call in seconds.
+        retries: Number of retry attempts (0 if first attempt succeeded).
+        input_tokens: Tokens billed as input (prompt + cache reads).
+        output_tokens: Tokens billed as output.
+        cache_read_tokens: Tokens served from prompt cache, if reported.
+    """
+
+    latency_s: float
+    retries: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+
+
+@dataclass
+class TimingReport:
+    """Process-local collector for step and API telemetry.
+
+    Use ``step_timer`` to record steps and ``record_api_call`` to log
+    individual API requests. Steps and API calls are correlated by an
+    internal stack: an API call recorded inside a ``step_timer`` block
+    counts toward that step's ``api_calls`` total.
+    """
+
+    started_at: float = field(default_factory=time.perf_counter)
+    steps: list[StepTiming] = field(default_factory=list)
+    api_calls: list[APICallRecord] = field(default_factory=list)
+    _stack: list[StepTiming] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def begin_step(self, name: str) -> StepTiming:
+        """Push a new step onto the active stack and return its record.
+
+        Args:
+            name: Logical step identifier.
+
+        Returns:
+            The newly created ``StepTiming`` record (still 0 duration).
+        """
+        record = StepTiming(name=name, duration_s=0.0)
+        with self._lock:
+            self.steps.append(record)
+            self._stack.append(record)
+        return record
+
+    def end_step(self, record: StepTiming, duration_s: float) -> None:
+        """Mark a step as complete with the given duration.
+
+        Args:
+            record: The record returned by ``begin_step``.
+            duration_s: Wall-clock duration in seconds.
+        """
+        with self._lock:
+            record.duration_s = duration_s
+            if self._stack and self._stack[-1] is record:
+                self._stack.pop()
+
+    def record_api_call(self, call: APICallRecord) -> None:
+        """Record a single API call; attribute it to the active step (if any).
+
+        Args:
+            call: Telemetry for the call.
+        """
+        with self._lock:
+            self.api_calls.append(call)
+            if self._stack:
+                self._stack[-1].api_calls += 1
+
+    @property
+    def wall_clock_s(self) -> float:
+        """Wall-clock time elapsed since the report was created."""
+        return time.perf_counter() - self.started_at
+
+    @property
+    def api_seconds(self) -> float:
+        """Sum of all API call latencies (NOT wall-clock — sequential or not)."""
+        return sum(c.latency_s for c in self.api_calls)
+
+    @property
+    def total_input_tokens(self) -> int:
+        """Total input tokens across all API calls."""
+        return sum(c.input_tokens for c in self.api_calls)
+
+    @property
+    def total_output_tokens(self) -> int:
+        """Total output tokens across all API calls."""
+        return sum(c.output_tokens for c in self.api_calls)
+
+    @property
+    def total_cache_read_tokens(self) -> int:
+        """Total tokens served from the prompt cache."""
+        return sum(c.cache_read_tokens for c in self.api_calls)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the report to a JSON-friendly dict."""
+        return {
+            "wall_clock_s": round(self.wall_clock_s, 4),
+            "api_calls": len(self.api_calls),
+            "api_seconds": round(self.api_seconds, 4),
+            "steps": [
+                {
+                    "name": s.name,
+                    "duration_s": round(s.duration_s, 4),
+                    "api_calls": s.api_calls,
+                }
+                for s in self.steps
+            ],
+            "tokens": {
+                "input": self.total_input_tokens,
+                "output": self.total_output_tokens,
+                "cache_read": self.total_cache_read_tokens,
+            },
+        }
+
+    def write_json(self, path: Path) -> None:
+        """Write the report as pretty-printed JSON.
+
+        Args:
+            path: Destination file path. Parent directories must exist.
+        """
+        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True))
+
+
+_active_report: TimingReport | None = None
+_active_lock = threading.Lock()
+
+
+def get_active_report() -> TimingReport | None:
+    """Return the currently active ``TimingReport``, if any."""
+    with _active_lock:
+        return _active_report
+
+
+def set_active_report(report: TimingReport | None) -> None:
+    """Install ``report`` as the active collector for this process.
+
+    Pass ``None`` to disable collection. Calling this from concurrent
+    threads is safe; the most recent caller wins.
+
+    Args:
+        report: The report to install, or ``None`` to clear.
+    """
+    global _active_report  # noqa: PLW0603 — module-level singleton by design
+    with _active_lock:
+        _active_report = report
+
+
+@contextmanager
+def step_timer(name: str) -> Iterator[StepTiming]:
+    """Time a named step and attribute API calls dispatched inside it.
+
+    Args:
+        name: Logical step identifier (matches the CLI status string).
+
+    Yields:
+        The ``StepTiming`` record for the step, mutated in place.
+
+    Example:
+        >>> with step_timer("subagents"):
+        ...     run_subagent_generation()  # doctest: +SKIP
+    """
+    report = get_active_report()
+    if report is None:
+        # No collector installed — yield a throwaway record so callers
+        # can use the same idiom unconditionally.
+        record = StepTiming(name=name, duration_s=0.0)
+        start = time.perf_counter()
+        try:
+            yield record
+        finally:
+            record.duration_s = time.perf_counter() - start
+        return
+
+    record = report.begin_step(name)
+    start = time.perf_counter()
+    try:
+        yield record
+    finally:
+        report.end_step(record, time.perf_counter() - start)

--- a/tests/integration/ai/test_orchestrator_integration.py
+++ b/tests/integration/ai/test_orchestrator_integration.py
@@ -266,3 +266,88 @@ class TestOrchestratorEndToEndWorkflows:
                 prompt="Valid prompt",
                 output_format="invalid",  # type: ignore[arg-type]
             )
+
+
+@pytest.mark.integration
+class TestOrchestratorAsyncWorkflows:
+    """Coverage for the AsyncAnthropic-backed generate_async path."""
+
+    @pytest.mark.asyncio
+    @patch("start_green_stay_green.ai.orchestrator.AsyncAnthropic")
+    async def test_generate_async_returns_generation_result(
+        self,
+        mock_async_anthropic: MagicMock,
+    ) -> None:
+        """End-to-end: generate_async resolves to a populated GenerationResult."""
+        # The orchestrator caches a single AsyncAnthropic per instance,
+        # so the constructor returns a configured async client.
+        mock_client = MagicMock()
+        mock_async_anthropic.return_value = mock_client
+
+        text_block = create_autospec(TextBlock, instance=True)
+        text_block.text = "{}"
+
+        mock_response = MagicMock()
+        mock_response.id = "msg_async_smoke"
+        mock_response.content = [text_block]
+        mock_response.usage.input_tokens = 12
+        mock_response.usage.output_tokens = 7
+        mock_response.model = ModelConfig.SONNET
+
+        # ``messages.create`` on AsyncAnthropic is a coroutine; the
+        # orchestrator awaits it directly.
+        async def _create(**_kwargs: object) -> MagicMock:
+            return mock_response
+
+        mock_client.messages.create.side_effect = _create
+
+        # ``aclose`` is awaited from ``AIOrchestrator.aclose``; provide
+        # an awaitable so the close path runs cleanly.
+        async def _close() -> None:
+            return None
+
+        mock_client.close.side_effect = _close
+
+        orchestrator = AIOrchestrator(api_key="async-smoke", retry_delay=0.01)
+        try:
+            result = await orchestrator.generate_async(
+                prompt="hello", output_format="markdown"
+            )
+        finally:
+            await orchestrator.aclose()
+
+        assert isinstance(result, GenerationResult)
+        assert result.content == "{}"
+        assert result.token_usage.input_tokens == 12
+        assert result.token_usage.output_tokens == 7
+        # The async client is created exactly once (lazy + cached).
+        mock_async_anthropic.assert_called_once_with(api_key="async-smoke")
+
+    @pytest.mark.asyncio
+    @patch("start_green_stay_green.ai.orchestrator.AsyncAnthropic")
+    async def test_aclose_is_idempotent(
+        self,
+        mock_async_anthropic: MagicMock,
+    ) -> None:
+        """``aclose`` may be called repeatedly without raising."""
+        mock_client = MagicMock()
+        mock_async_anthropic.return_value = mock_client
+
+        async def _close() -> None:
+            return None
+
+        mock_client.close.side_effect = _close
+
+        orchestrator = AIOrchestrator(api_key="async-aclose")
+
+        # No async work was done — ``aclose`` is a no-op.
+        await orchestrator.aclose()
+        await orchestrator.aclose()
+        mock_client.close.assert_not_called()
+
+        # Now allocate the client by calling ``_get_async_client`` and
+        # close it twice.
+        orchestrator._get_async_client()
+        await orchestrator.aclose()
+        await orchestrator.aclose()
+        mock_client.close.assert_called_once()

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -40,6 +40,7 @@ def _block_orchestrator_init() -> Generator[None, None, None]:
 
 def _stub_ci_step(
     project_path: Path,
+    _project_name: str,
     _language: str,
     _orchestrator: object,
     _file_writer: object = None,
@@ -48,6 +49,7 @@ def _stub_ci_step(
 
     Args:
         project_path: Target project directory.
+        _project_name: Project name (unused in stub).
         _language: Programming language (unused in stub).
         _orchestrator: Mock orchestrator (unused in stub).
         _file_writer: File writer (unused in stub).

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -60,14 +60,12 @@ def _stub_ci_step(
 
 def _stub_review_step(
     project_path: Path,
-    _orchestrator: object,
     _file_writer: object = None,
 ) -> None:
     """Stub review generation step that writes a minimal code-review workflow.
 
     Args:
         project_path: Target project directory.
-        _orchestrator: Mock orchestrator (unused in stub).
         _file_writer: File writer (unused in stub).
     """
     workflows_dir = project_path / ".github" / "workflows"
@@ -101,7 +99,6 @@ def _stub_architecture_step(
     project_path: Path,
     project_name: str,
     _language: str,
-    _orchestrator: object,
     _file_writer: object = None,
 ) -> None:
     """Stub architecture generation step that writes minimal rule files.
@@ -110,7 +107,6 @@ def _stub_architecture_step(
         project_path: Target project directory.
         project_name: Name of the project.
         _language: Programming language (unused in stub).
-        _orchestrator: Mock orchestrator (unused in stub).
         _file_writer: File writer (unused in stub).
     """
     arch_dir = project_path / "plans" / "architecture"

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -11,6 +11,7 @@ See Issue #196 for details.
 """
 
 from collections.abc import Generator
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -537,3 +538,45 @@ class TestFullIntegrationFlow:
         project_path = output_dir / "test-custom-dir"
         assert project_path.exists()
         assert project_path.is_dir()
+
+    def test_init_writes_timing_json_report(self, tmp_path: Path) -> None:
+        """End-to-end: --timing-json writes a structured JSON report."""
+        output_dir = tmp_path / "out"
+        timing_path = tmp_path / "reports" / "timing.json"
+        runner = CliRunner()
+
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                "timing-smoke",
+                "--language",
+                "python",
+                "--output-dir",
+                str(output_dir),
+                "--timing-json",
+                str(timing_path),
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert timing_path.exists(), "timing JSON report not written"
+
+        report = json.loads(timing_path.read_text(encoding="utf-8"))
+
+        # Top-level keys are present and well-typed.
+        assert isinstance(report["wall_clock_s"], (int, float))
+        assert isinstance(report["api_calls"], int)
+        assert isinstance(report["api_seconds"], (int, float))
+        assert isinstance(report["steps"], list)
+        assert report["tokens"] == {"input": 0, "output": 0, "cache_read": 0}
+
+        # In offline mode no API calls are made; every deterministic
+        # step is recorded with zero attributed API calls.
+        assert report["api_calls"] == 0
+        step_names = {step["name"] for step in report["steps"]}
+        # Sanity: at least the always-on steps must have been timed.
+        for required in ("structure", "ci", "claude_md", "subagents"):
+            assert required in step_names

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -93,7 +93,7 @@ class TestContentTunerInit:
 
     def test_content_tuner_init_with_orchestrator(self) -> None:
         """Test ContentTuner initializes with orchestrator."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         assert tuner.orchestrator is orchestrator
@@ -101,7 +101,7 @@ class TestContentTunerInit:
 
     def test_content_tuner_init_with_dry_run(self) -> None:
         """Test ContentTuner initializes with dry_run mode."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator, dry_run=True)
 
         assert tuner.dry_run
@@ -144,7 +144,7 @@ class TestContentTunerPromptBuilding:
 
     def test_build_tuning_prompt_without_preserve_sections(self) -> None:
         """Test _build_tuning_prompt without preserve sections."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         prompt = tuner._build_tuning_prompt(
@@ -161,7 +161,7 @@ class TestContentTunerPromptBuilding:
 
     def test_build_tuning_prompt_with_preserve_sections(self) -> None:
         """Test _build_tuning_prompt with preserve sections."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         prompt = tuner._build_tuning_prompt(
@@ -175,7 +175,7 @@ class TestContentTunerPromptBuilding:
 
     def test_build_tuning_prompt_includes_requirements(self) -> None:
         """Test _build_tuning_prompt includes all requirements."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         prompt = tuner._build_tuning_prompt(
@@ -196,7 +196,7 @@ class TestContentTunerResponseParsing:
 
     def test_parse_tuning_response_with_changes_section(self) -> None:
         """Test _parse_tuning_response extracts content and changes."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         response = """# Adapted Content
@@ -219,7 +219,7 @@ CHANGES:
 
     def test_parse_tuning_response_with_asterisk_markers(self) -> None:
         """Test _parse_tuning_response handles asterisk markers."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         response = """Content here
@@ -237,7 +237,7 @@ CHANGES:
 
     def test_parse_tuning_response_without_changes_section(self) -> None:
         """Test _parse_tuning_response when no CHANGES section."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         response = "Just content without changes section"
@@ -249,7 +249,7 @@ CHANGES:
 
     def test_parse_tuning_response_with_empty_changes(self) -> None:
         """Test _parse_tuning_response with empty CHANGES section."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         response = """Content
@@ -264,7 +264,7 @@ CHANGES:
 
     def test_parse_tuning_response_strips_whitespace(self) -> None:
         """Test _parse_tuning_response strips surrounding whitespace."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         response = """
@@ -287,7 +287,7 @@ class TestContentTunerTuneAsync:
     @pytest.mark.asyncio
     async def test_tune_with_valid_inputs(self) -> None:
         """Test tune() with valid inputs."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="""# Django Project
 
@@ -320,7 +320,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_calls_orchestrator_generate(self) -> None:
         """Test tune() calls orchestrator.generate with correct args."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Adapted\n\nCHANGES:\n- Change",
             format="markdown",
@@ -345,7 +345,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_with_empty_content_raises_error(self) -> None:
         """Test tune() raises ValueError for empty content."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         with pytest.raises(ValueError, match="Content cannot be empty"):
@@ -358,7 +358,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_with_empty_source_context_raises_error(self) -> None:
         """Test tune() raises ValueError for empty source context."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         with pytest.raises(ValueError, match="Source context cannot be empty"):
@@ -371,7 +371,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_with_empty_target_context_raises_error(self) -> None:
         """Test tune() raises ValueError for empty target context."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator)
 
         with pytest.raises(ValueError, match="Target context cannot be empty"):
@@ -384,7 +384,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_in_dry_run_mode(self) -> None:
         """Test tune() in dry-run mode returns original content."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator, dry_run=True)
 
         result = await tuner.tune(
@@ -405,7 +405,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_with_preserve_sections(self) -> None:
         """Test tune() passes preserve_sections to prompt builder."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Adapted\n\nCHANGES:\n- Modified",
             format="markdown",
@@ -429,7 +429,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_handles_generation_error(self) -> None:
         """Test tune() propagates GenerationError from orchestrator."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.side_effect = GenerationError("API error")
 
         tuner = ContentTuner(orchestrator)
@@ -444,7 +444,7 @@ CHANGES:
     @pytest.mark.asyncio
     async def test_tune_without_preserve_sections_works(self) -> None:
         """Test tune() works without preserve_sections (default None)."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Result\n\nCHANGES:\n- Done",
             format="markdown",
@@ -470,7 +470,7 @@ class TestContentTunerLoggerBehavior:
     @pytest.mark.asyncio
     async def test_tune_logs_dry_run_mode(self, mocker: MockerFixture) -> None:
         """Test logger.info called for dry-run mode."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator, dry_run=True)
 
         mock_logger = mocker.patch("start_green_stay_green.ai.tuner.logger")
@@ -489,7 +489,7 @@ class TestContentTunerLoggerBehavior:
     @pytest.mark.asyncio
     async def test_tune_logs_tuning_start(self, mocker: MockerFixture) -> None:
         """Test logger.info called when tuning starts."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Result\n\nCHANGES:\n- Done",
             format="markdown",
@@ -516,7 +516,7 @@ class TestContentTunerLoggerBehavior:
     @pytest.mark.asyncio
     async def test_tune_logs_exception_on_error(self, mocker: MockerFixture) -> None:
         """Test logger.exception called when tuning fails."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.side_effect = GenerationError("API error")
         tuner = ContentTuner(orchestrator)
 
@@ -536,7 +536,7 @@ class TestContentTunerLoggerBehavior:
         self, mocker: MockerFixture
     ) -> None:
         """Test logger.info called with change count on success."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Result\n\nCHANGES:\n- Change 1\n- Change 2\n- Change 3",
             format="markdown",
@@ -565,7 +565,7 @@ class TestContentTunerLoggerBehavior:
         self, mocker: MockerFixture
     ) -> None:
         """Test logger.debug called for each change."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         orchestrator.generate.return_value = GenerationResult(
             content="Result\n\nCHANGES:\n- First change\n- Second change",
             format="markdown",
@@ -591,7 +591,7 @@ class TestContentTunerLoggerBehavior:
     @pytest.mark.asyncio
     async def test_tune_dry_run_does_not_call_orchestrator(self) -> None:
         """Test dry-run mode skips orchestrator.generate call."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator, dry_run=True)
 
         result = await tuner.tune(
@@ -608,7 +608,7 @@ class TestContentTunerLoggerBehavior:
     @pytest.mark.asyncio
     async def test_tune_dry_run_returns_original_content_exactly(self) -> None:
         """Test dry-run returns exact original content unchanged."""
-        orchestrator = create_autospec(AIOrchestrator)
+        orchestrator = MagicMock(spec=AIOrchestrator)
         tuner = ContentTuner(orchestrator, dry_run=True)
 
         original = "# Title\n\nContent with special chars: !@#$%"

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -336,11 +336,24 @@ CHANGES:
             target_context="Target",
         )
 
+        # ``MagicMock(spec=...)`` (chosen over ``create_autospec`` so
+        # ``asyncio.iscoroutinefunction`` returns False on the sync
+        # ``generate`` method) does not validate call signatures
+        # automatically. Assert the shape explicitly so a future
+        # refactor of ``AIOrchestrator.generate`` that changes its
+        # signature will be caught here.
         orchestrator.generate.assert_called_once()
-        call_args = orchestrator.generate.call_args
-        assert call_args[0][1] == "markdown"  # output_format
-        assert "Source" in call_args[0][0]  # prompt contains source context
-        assert "Target" in call_args[0][0]  # prompt contains target context
+        positional, keyword = orchestrator.generate.call_args
+        assert (
+            len(positional) == 2
+        ), f"expected (prompt, output_format) positionally, got {positional!r}"
+        prompt_arg, format_arg = positional
+        assert isinstance(prompt_arg, str)
+        assert format_arg == "markdown"
+        assert keyword == {}, f"no kwargs expected, got {keyword!r}"
+        # Prompt content sanity: contains both contexts.
+        assert "Source" in prompt_arg
+        assert "Target" in prompt_arg
 
     @pytest.mark.asyncio
     async def test_tune_with_empty_content_raises_error(self) -> None:

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -15,28 +15,29 @@ class TestArchitectureEnforcementGeneratorInit:
     """Test ArchitectureEnforcementGenerator initialization."""
 
     def test_init_with_orchestrator(self) -> None:
-        """Test initialization with AI orchestrator."""
+        """Passing an orchestrator still works but emits a DeprecationWarning."""
         orchestrator = create_autospec(AIOrchestrator)
-        generator = ArchitectureEnforcementGenerator(orchestrator)
+        with pytest.warns(DeprecationWarning, match="'orchestrator' parameter"):
+            generator = ArchitectureEnforcementGenerator(orchestrator)
 
         assert generator.orchestrator is orchestrator
 
+    def test_init_without_orchestrator_is_silent(self) -> None:
+        """The default (no orchestrator) does not emit a warning."""
+        generator = ArchitectureEnforcementGenerator()
+        assert generator.orchestrator is None
+
     def test_init_with_output_dir(self) -> None:
         """Test initialization with custom output directory."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = Path("/custom/plans/architecture")
 
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         assert generator.output_dir == output_dir
 
     def test_init_with_default_output_dir(self) -> None:
         """Test initialization sets default output directory."""
-        orchestrator = create_autospec(AIOrchestrator)
-        generator = ArchitectureEnforcementGenerator(orchestrator)
+        generator = ArchitectureEnforcementGenerator()
 
         assert generator.output_dir == Path("plans/architecture")
 
@@ -49,12 +50,8 @@ class TestArchitectureEnforcementGeneratorGenerate:
         tmp_path: Path,
     ) -> None:
         """Test generating import-linter config for Python."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="python", project_name="test-project")
 
@@ -78,12 +75,8 @@ class TestArchitectureEnforcementGeneratorGenerate:
         tmp_path: Path,
     ) -> None:
         """Test generating dependency-cruiser config for TypeScript."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(
             language="typescript",
@@ -96,8 +89,7 @@ class TestArchitectureEnforcementGeneratorGenerate:
 
     def test_generate_raises_on_unsupported_language(self) -> None:
         """Test generate raises ValueError for unsupported languages."""
-        orchestrator = create_autospec(AIOrchestrator)
-        generator = ArchitectureEnforcementGenerator(orchestrator)
+        generator = ArchitectureEnforcementGenerator()
 
         with pytest.raises(ValueError, match="Unsupported language"):
             generator.generate(language="ruby", project_name="test")
@@ -107,12 +99,8 @@ class TestArchitectureEnforcementGeneratorGenerate:
         tmp_path: Path,
     ) -> None:
         """Test README contains usage instructions."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="python", project_name="test-project")
 
@@ -129,12 +117,8 @@ class TestArchitectureEnforcementGeneratorGenerate:
         tmp_path: Path,
     ) -> None:
         """Test run-check.sh is created with executable permissions."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="python", project_name="test-project")
 
@@ -151,12 +135,8 @@ class TestArchitectureEnforcementGeneratorPython:
         tmp_path: Path,
     ) -> None:
         """Test Python config enforces layer separation."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="python", project_name="myapp")
 
@@ -171,12 +151,8 @@ class TestArchitectureEnforcementGeneratorPython:
         tmp_path: Path,
     ) -> None:
         """Test Python config prevents circular dependencies."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="python", project_name="myapp")
 
@@ -195,12 +171,8 @@ class TestArchitectureEnforcementGeneratorTypeScript:
         tmp_path: Path,
     ) -> None:
         """Test TypeScript config enforces layer separation."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="typescript", project_name="myapp")
 
@@ -215,12 +187,8 @@ class TestArchitectureEnforcementGeneratorTypeScript:
         tmp_path: Path,
     ) -> None:
         """Test TypeScript config prevents circular dependencies."""
-        orchestrator = create_autospec(AIOrchestrator)
         output_dir = tmp_path / "plans" / "architecture"
-        generator = ArchitectureEnforcementGenerator(
-            orchestrator,
-            output_dir=output_dir,
-        )
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
 
         generator.generate(language="typescript", project_name="myapp")
 

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -12,6 +12,7 @@ Comprehensive tests for CI pipeline generation covering:
 from pathlib import Path
 from unittest.mock import Mock
 
+from jinja2 import UndefinedError
 import pytest
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
@@ -1303,4 +1304,80 @@ class TestCIGeneratorTemplatePath:
         )
 
         with pytest.raises(FileNotFoundError, match="reference CI template"):
+            generator.generate_workflow_from_template()
+
+    def test_project_name_substituted_into_template(self, tmp_path: Path) -> None:
+        """A ``<<% project_name %>>`` placeholder renders with the real value."""
+        # Build a synthetic reference template that *does* use the
+        # placeholder. The real reference YAMLs do not yet (intentional —
+        # the API is forward-looking); this fixture proves the wiring
+        # works the moment a maintainer adds it.
+        reference_dir = tmp_path / "ref"
+        reference_dir.mkdir()
+        (reference_dir / "python.yml").write_text(
+            "name: CI for <<% project_name %>>\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  quality:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo <<% project_name %>>\n",
+            encoding="utf-8",
+        )
+
+        generator = CIGenerator(
+            language="python",
+            reference_dir=reference_dir,
+            project_name="my-cool-app",
+        )
+        workflow = generator.generate_workflow()
+
+        assert workflow.is_valid
+        assert "name: CI for my-cool-app" in workflow.content
+        assert "echo my-cool-app" in workflow.content
+        # The placeholder must be fully substituted.
+        assert "<<% project_name %>>" not in workflow.content
+
+    def test_project_name_none_renders_empty_string(self, tmp_path: Path) -> None:
+        """``project_name=None`` coerces to ``""`` rather than the string "None"."""
+        reference_dir = tmp_path / "ref"
+        reference_dir.mkdir()
+        (reference_dir / "python.yml").write_text(
+            "name: CI<<% project_name %>>\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  quality:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n",
+            encoding="utf-8",
+        )
+
+        generator = CIGenerator(
+            language="python",
+            reference_dir=reference_dir,
+        )
+        workflow = generator.generate_workflow_from_template()
+
+        assert workflow.is_valid
+        # ``None`` would have produced "name: CINone" — that's the bug
+        # the StrictUndefined+coercion change fixed.
+        assert "None" not in workflow.content
+        assert "name: CI\n" in workflow.content
+
+    def test_undeclared_placeholder_raises_strict_undefined(
+        self, tmp_path: Path
+    ) -> None:
+        """Adding a new placeholder without wiring it raises at render time."""
+        reference_dir = tmp_path / "ref"
+        reference_dir.mkdir()
+        (reference_dir / "python.yml").write_text(
+            "name: CI <<% missing_var %>>\n"
+            "jobs:\n  quality:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - run: echo hi\n",
+            encoding="utf-8",
+        )
+
+        generator = CIGenerator(language="python", reference_dir=reference_dir)
+        with pytest.raises(UndefinedError):
             generator.generate_workflow_from_template()

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -1240,9 +1240,7 @@ class TestCIGeneratorTemplatePath:
         "language",
         ["python", "typescript", "go", "rust"],
     )
-    def test_generate_from_template_for_supported_language(
-        self, language: str
-    ) -> None:
+    def test_generate_from_template_for_supported_language(self, language: str) -> None:
         """Each canonical language renders without an orchestrator."""
         generator = CIGenerator(language=language)
 

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -9,6 +9,7 @@ Comprehensive tests for CI pipeline generation covering:
 - Static utility methods
 """
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -1230,3 +1231,78 @@ jobs:
             versions = config["supported_versions"]
             assert isinstance(versions, list), f"{lang} versions not a list"
             assert len(versions) > 0, f"{lang} versions is empty"
+
+
+class TestCIGeneratorTemplatePath:
+    """Tests for the deterministic, no-API template path (Phase 1)."""
+
+    @pytest.mark.parametrize(
+        "language",
+        ["python", "typescript", "go", "rust"],
+    )
+    def test_generate_from_template_for_supported_language(
+        self, language: str
+    ) -> None:
+        """Each canonical language renders without an orchestrator."""
+        generator = CIGenerator(language=language)
+
+        workflow = generator.generate_workflow_from_template()
+
+        assert workflow.is_valid
+        assert workflow.language == language
+        assert workflow.content
+        # Reference templates ship a 'quality' job; validation should pass.
+        assert "quality" in workflow.content
+
+    def test_generate_workflow_uses_template_when_no_orchestrator(self) -> None:
+        """Calling generate_workflow() with no orchestrator picks the template path."""
+        generator = CIGenerator(language="python")
+
+        workflow = generator.generate_workflow()
+
+        assert workflow.is_valid
+        # Output should match what generate_workflow_from_template returns.
+        from_template = generator.generate_workflow_from_template()
+        assert workflow.content == from_template.content
+
+    def test_generate_workflow_falls_back_to_ai_when_orchestrator_provided(
+        self,
+    ) -> None:
+        """When an orchestrator is supplied the legacy AI path is taken."""
+        # Build a minimal valid workflow YAML for the AI mock to return.
+        valid_yaml = (
+            "name: Test\n"
+            "on: [push]\n"
+            "jobs:\n"
+            "  quality:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+        )
+        mock_orchestrator = Mock(spec=AIOrchestrator)
+        mock_orchestrator.generate.return_value = GenerationResult(
+            content=valid_yaml,
+            format="yaml",
+            token_usage=TokenUsage(input_tokens=10, output_tokens=20),
+            model=ModelConfig.SONNET,
+            message_id="msg_test",
+        )
+
+        generator = CIGenerator(mock_orchestrator, "python")
+        workflow = generator.generate_workflow()
+
+        assert workflow.is_valid
+        mock_orchestrator.generate.assert_called_once()
+
+    def test_generate_from_template_raises_for_missing_template(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing reference template raises FileNotFoundError."""
+        # Point reference_dir at an empty directory.
+        generator = CIGenerator(
+            language="python",
+            reference_dir=tmp_path,
+        )
+
+        with pytest.raises(FileNotFoundError, match="reference CI template"):
+            generator.generate_workflow_from_template()

--- a/tests/unit/generators/test_claude_md.py
+++ b/tests/unit/generators/test_claude_md.py
@@ -388,3 +388,60 @@ class TestClaudeMdGeneratorIntegration:
         prompt = call_args[0][0]
         assert "awesome-project" in prompt
         assert "rust" in prompt
+
+
+class TestClaudeMdGeneratorBaseline:
+    """Tests for the deterministic, no-API baseline path (Phase 1)."""
+
+    def test_baseline_renders_without_orchestrator(self) -> None:
+        """Baseline path works with no orchestrator at all."""
+        generator = ClaudeMdGenerator()  # No orchestrator.
+
+        result = generator.generate_baseline(
+            {
+                "project_name": "my-cool-app",
+                "language": "python",
+                "scripts": ["check-all.sh", "test.sh"],
+                "skills": ["testing", "security"],
+            }
+        )
+
+        assert result.token_usage_input == 0
+        assert result.token_usage_output == 0
+        # Project name was substituted into the H1.
+        assert "my-cool-app" in result.content
+        # No untouched ``{{PROJECT_NAME}}`` token leaks through for known keys.
+        assert "{{PROJECT_NAME}}" not in result.content
+
+    def test_baseline_used_when_orchestrator_is_none(self) -> None:
+        """generate() with orchestrator=None falls back to baseline."""
+        generator = ClaudeMdGenerator(orchestrator=None)
+
+        result = generator.generate(
+            {
+                "project_name": "fallback-test",
+                "language": "go",
+                "scripts": [],
+                "skills": [],
+            }
+        )
+
+        assert result.token_usage_input == 0
+        assert "fallback-test" in result.content
+
+    def test_baseline_renders_skills_and_scripts(self) -> None:
+        """Baseline substitutes scripts and skills if templates use them."""
+        generator = ClaudeMdGenerator()
+
+        result = generator.generate_baseline(
+            {
+                "project_name": "demo",
+                "language": "python",
+                "scripts": ["foo.sh", "bar.sh"],
+                "skills": ["alpha", "beta"],
+            }
+        )
+
+        # Reference template doesn't currently use {{SCRIPTS}}/{{SKILLS}}
+        # tokens, so we just assert the baseline renders without error.
+        assert "# Claude Code Project Context: demo" in result.content

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -218,7 +218,8 @@ class TestMetricsGeneratorInit:
             project_name="test",
         )
 
-        generator = MetricsGenerator(orchestrator, config)
+        with pytest.warns(DeprecationWarning, match="'orchestrator' parameter"):
+            generator = MetricsGenerator(orchestrator, config)
 
         assert generator.orchestrator is orchestrator
         assert generator.config is config

--- a/tests/unit/generators/test_subagents.py
+++ b/tests/unit/generators/test_subagents.py
@@ -619,12 +619,17 @@ class TestSubagentsParallelism:
 
         results = await generator.generate_all_agents("test-context")
 
-        # Every agent generated, and the maximum concurrent in-flight
-        # was at least 2 (it should be all 8 with the default semaphore).
+        # The latch only releases ``gate`` once ``active_calls`` reaches
+        # ``len(REQUIRED_AGENTS)``, so the gather can only return if every
+        # agent was in-flight at the same instant. Asserting the strict
+        # equality (rather than a weaker ``>= 2`` lower bound) makes the
+        # invariant explicit and would catch a regression where the
+        # semaphore was tightened or the gather was serialized.
         assert set(results) == set(REQUIRED_AGENTS)
-        assert (
-            max_active >= 2
-        ), f"Expected concurrent dispatch but max_active={max_active}"
+        assert max_active == len(REQUIRED_AGENTS), (
+            f"Expected all {len(REQUIRED_AGENTS)} agents in-flight at once, "
+            f"got max_active={max_active}"
+        )
 
     @pytest.mark.asyncio
     async def test_generate_all_agents_respects_semaphore(

--- a/tests/unit/generators/test_subagents.py
+++ b/tests/unit/generators/test_subagents.py
@@ -11,6 +11,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
@@ -563,3 +564,114 @@ async def test_dry_run_mode(
     # Dry run should set tuned=False
     assert not result.tuned
     assert not result.changes
+
+
+class TestSubagentsParallelism:
+    """Verify generate_all_agents fans out concurrently (Phase 2)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_all_agents_runs_in_parallel(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """All eight agent tunings dispatch before any single one returns."""
+        # Populate the reference dir with the eight required agent files.
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        for source_file in REQUIRED_AGENTS.values():
+            (agents_dir / source_file).write_text(SAMPLE_AGENT_CONTENT)
+
+        # Latch that records each call's start order, then waits until
+        # all sibling calls have started before allowing any to return.
+        # If the generator were sequential, only the first call would
+        # ever start.
+        active_calls = 0
+        max_active = 0
+        gate = asyncio.Event()
+
+        async def slow_tune(*_args: object, **_kwargs: object) -> object:
+            nonlocal active_calls, max_active
+            active_calls += 1
+            max_active = max(max_active, active_calls)
+            if active_calls >= len(REQUIRED_AGENTS):
+                gate.set()
+            await gate.wait()
+            active_calls -= 1
+            return mocker.Mock(
+                content="# tuned body",
+                changes=["change"],
+                dry_run=False,
+                token_usage_input=1,
+                token_usage_output=1,
+            )
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+            dry_run=False,
+        )
+        # Replace the tuner's tune with the latch-instrumented stub.
+        generator.tuner = AsyncMock()
+        generator.tuner.tune = slow_tune  # type: ignore[assignment]
+
+        results = await generator.generate_all_agents("test-context")
+
+        # Every agent generated, and the maximum concurrent in-flight
+        # was at least 2 (it should be all 8 with the default semaphore).
+        assert set(results) == set(REQUIRED_AGENTS)
+        assert max_active >= 2, (
+            f"Expected concurrent dispatch but max_active={max_active}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_all_agents_respects_semaphore(
+        self,
+        tmp_path: Path,
+        mocker: MockerFixture,
+    ) -> None:
+        """The semaphore caps the number of in-flight tunings."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        for source_file in REQUIRED_AGENTS.values():
+            (agents_dir / source_file).write_text(SAMPLE_AGENT_CONTENT)
+
+        in_flight = 0
+        peak = 0
+        complete: list[asyncio.Event] = []
+
+        async def staged_tune(*_args: object, **_kwargs: object) -> object:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            ev = asyncio.Event()
+            complete.append(ev)
+            # Release one slot at a time once enough tasks queued up.
+            if len(complete) >= 2:
+                # Signal all stalled siblings to finish in order.
+                for waiter in complete:
+                    waiter.set()
+            await ev.wait()
+            in_flight -= 1
+            return mocker.Mock(
+                content="# t",
+                changes=[],
+                dry_run=False,
+                token_usage_input=1,
+                token_usage_output=1,
+            )
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+            dry_run=False,
+            max_concurrency=2,
+        )
+        generator.tuner = AsyncMock()
+        generator.tuner.tune = staged_tune  # type: ignore[assignment]
+
+        await generator.generate_all_agents("ctx")
+        assert peak <= 2

--- a/tests/unit/generators/test_subagents.py
+++ b/tests/unit/generators/test_subagents.py
@@ -615,16 +615,16 @@ class TestSubagentsParallelism:
         )
         # Replace the tuner's tune with the latch-instrumented stub.
         generator.tuner = AsyncMock()
-        generator.tuner.tune = slow_tune  # type: ignore[assignment]
+        generator.tuner.tune = slow_tune
 
         results = await generator.generate_all_agents("test-context")
 
         # Every agent generated, and the maximum concurrent in-flight
         # was at least 2 (it should be all 8 with the default semaphore).
         assert set(results) == set(REQUIRED_AGENTS)
-        assert max_active >= 2, (
-            f"Expected concurrent dispatch but max_active={max_active}"
-        )
+        assert (
+            max_active >= 2
+        ), f"Expected concurrent dispatch but max_active={max_active}"
 
     @pytest.mark.asyncio
     async def test_generate_all_agents_respects_semaphore(
@@ -671,7 +671,7 @@ class TestSubagentsParallelism:
             max_concurrency=2,
         )
         generator.tuner = AsyncMock()
-        generator.tuner.tune = staged_tune  # type: ignore[assignment]
+        generator.tuner.tune = staged_tune
 
         await generator.generate_all_agents("ctx")
         assert peak <= 2

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -38,6 +38,7 @@ from typer.testing import CliRunner
 
 from start_green_stay_green import cli
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
+from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 
 
 class TestVersionCommand:
@@ -1297,3 +1298,45 @@ class TestGenerateProjectFiles:
         mock_scripts.assert_called()
         mock_precommit.assert_called()
         mock_skills.assert_called()
+
+
+class TestCopyReferenceSubagents:
+    """Cover the no-API copy path's error handling."""
+
+    def test_raises_filenotfounderror_when_reference_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing reference agent file surfaces a FileNotFoundError."""
+        target_dir = tmp_path / "agents"
+
+        # Patch REFERENCE_AGENTS_DIR to an empty directory so every
+        # required source_file is missing.
+        empty_ref_dir = tmp_path / "empty"
+        empty_ref_dir.mkdir()
+
+        with (
+            patch("start_green_stay_green.cli.REFERENCE_AGENTS_DIR", empty_ref_dir),
+            pytest.raises(FileNotFoundError, match="Reference subagent not found"),
+        ):
+            cli._copy_reference_subagents(target_dir)
+
+    def test_writes_utf8_encoded_content(self, tmp_path: Path) -> None:
+        """Copied agents are written with explicit UTF-8 encoding."""
+        # Build a fake reference dir with a single agent file.
+        ref_dir = tmp_path / "ref"
+        ref_dir.mkdir()
+        # Cover every REQUIRED_AGENTS source_file with a UTF-8 sentinel.
+        sentinel = "# Agent: ✓ — non-ASCII\n"
+
+        for src in REQUIRED_AGENTS.values():
+            (ref_dir / src).write_text(sentinel, encoding="utf-8")
+
+        target_dir = tmp_path / "agents"
+        with patch("start_green_stay_green.cli.REFERENCE_AGENTS_DIR", ref_dir):
+            cli._copy_reference_subagents(target_dir)
+
+        # Round-trip through utf-8 decoding.
+        for agent_name in REQUIRED_AGENTS:
+            target = target_dir / f"{agent_name}.md"
+            assert target.exists()
+            assert target.read_text(encoding="utf-8") == sentinel

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -26,6 +26,7 @@ def test_something(mock_path: Mock) -> None:
 ```
 """
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -1360,3 +1361,41 @@ class TestCopyReferenceSubagents:
         assert mock_writer.write_file.call_count == len(REQUIRED_AGENTS)
         for agent_name in REQUIRED_AGENTS:
             assert not (target_dir / f"{agent_name}.md").exists()
+
+
+class TestRunWithOrchestratorClose:
+    """``_run_with_orchestrator_close`` must release the async client.
+
+    The wrapper exists specifically so that a parallel-tuning failure
+    inside ``asyncio.gather`` cannot leak the lazily-created
+    :class:`AsyncAnthropic` connection pool. The two tests below pin
+    that contract: ``aclose`` is called on success, and on failure.
+    """
+
+    def test_aclose_called_on_success(self) -> None:
+        """When the wrapped coroutine returns normally, aclose runs."""
+        orchestrator = MagicMock()
+        orchestrator.aclose = MagicMock(return_value=asyncio.sleep(0))
+
+        async def _ok() -> str:
+            return "done"
+
+        result = asyncio.run(cli._run_with_orchestrator_close(orchestrator, _ok()))
+        assert result == "done"
+        orchestrator.aclose.assert_called_once()
+
+    def test_aclose_called_on_exception(self) -> None:
+        """When the wrapped coroutine raises, aclose still runs."""
+        orchestrator = MagicMock()
+        orchestrator.aclose = MagicMock(return_value=asyncio.sleep(0))
+
+        async def _boom() -> str:
+            msg = "tuning failed"
+            raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="tuning failed"):
+            asyncio.run(cli._run_with_orchestrator_close(orchestrator, _boom()))
+
+        # Even though ``_boom`` raised, the finally block must have
+        # called aclose to release the httpx pool.
+        orchestrator.aclose.assert_called_once()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1107,21 +1107,30 @@ class TestGenerateSteps:
 
         mock_ci_generator_class.assert_called_with(mock_orchestrator, "python")
 
-    def test_generate_ci_step_skips_without_orchestrator(
-        self,
+    @patch("start_green_stay_green.cli.CIGenerator")
+    def test_generate_ci_step_uses_template_without_orchestrator(
+        self, mock_ci_generator_class: Mock
     ) -> None:
-        """Test _generate_ci_step skips without orchestrator."""
+        """_generate_ci_step now runs the template path with no orchestrator."""
+        mock_generator = MagicMock()
+        mock_workflow = MagicMock()
+        mock_workflow.content = "workflow content"
+        mock_generator.generate_workflow.return_value = mock_workflow
+        mock_ci_generator_class.return_value = mock_generator
         mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
             cli._generate_ci_step(mock_path, "python", None)
 
+        mock_ci_generator_class.assert_called_with(None, "python")
+        mock_generator.generate_workflow.assert_called_once()
+
     @patch("start_green_stay_green.cli.GitHubActionsReviewGenerator")
-    def test_generate_review_step_with_orchestrator(
+    def test_generate_review_step_runs_unconditionally(
         self, mock_generator_class: Mock
     ) -> None:
-        """Test _generate_review_step with orchestrator."""
-        mock_orchestrator = MagicMock()
+        """_generate_review_step now always renders the template."""
         mock_generator = MagicMock()
         mock_workflow = MagicMock()
         mock_workflow.content = "workflow content"
@@ -1131,18 +1140,29 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_review_step(mock_path, mock_orchestrator)
+            cli._generate_review_step(mock_path, MagicMock())
 
-        mock_generator_class.assert_called_with(mock_orchestrator)
+        # Generator no longer takes an orchestrator argument.
+        mock_generator_class.assert_called_with()
+        mock_generator.generate.assert_called_once()
 
-    def test_generate_review_step_skips_without_orchestrator(
-        self,
+    @patch("start_green_stay_green.cli.GitHubActionsReviewGenerator")
+    def test_generate_review_step_runs_without_orchestrator(
+        self, mock_generator_class: Mock
     ) -> None:
-        """Test _generate_review_step skips without orchestrator."""
+        """_generate_review_step still runs when no orchestrator is given."""
+        mock_generator = MagicMock()
+        mock_workflow = MagicMock()
+        mock_workflow.content = "workflow content"
+        mock_generator.generate.return_value = mock_workflow
+        mock_generator_class.return_value = mock_generator
         mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
             cli._generate_review_step(mock_path, None)
+
+        mock_generator.generate.assert_called_once()
 
     @patch("start_green_stay_green.cli.ClaudeMdGenerator")
     def test_generate_claude_md_step(self, mock_generator_class: Mock) -> None:
@@ -1168,19 +1188,19 @@ class TestGenerateSteps:
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step(self, mock_generator_class: Mock) -> None:
-        """Test _generate_architecture_step creates generator."""
-        mock_orchestrator = MagicMock()
+        """Test _generate_architecture_step creates generator without orchestrator."""
         mock_generator = MagicMock()
         mock_generator_class.return_value = mock_generator
         mock_path = MagicMock(spec=Path)
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
+            # Pass orchestrator=None — generator should still be invoked.
             cli._generate_architecture_step(
                 mock_path,
                 "my-project",
                 "python",
-                mock_orchestrator,
+                None,
             )
 
         mock_generator.generate.assert_called()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1141,17 +1141,17 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_review_step(mock_path, MagicMock())
+            cli._generate_review_step(mock_path)
 
         # Generator no longer takes an orchestrator argument.
         mock_generator_class.assert_called_with()
         mock_generator.generate.assert_called_once()
 
     @patch("start_green_stay_green.cli.GitHubActionsReviewGenerator")
-    def test_generate_review_step_runs_without_orchestrator(
+    def test_generate_review_step_uses_default_file_writer(
         self, mock_generator_class: Mock
     ) -> None:
-        """_generate_review_step still runs when no orchestrator is given."""
+        """_generate_review_step works with the default ``file_writer=None``."""
         mock_generator = MagicMock()
         mock_workflow = MagicMock()
         mock_workflow.content = "workflow content"
@@ -1161,7 +1161,8 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_review_step(mock_path, None)
+            # No file_writer passed — exercises the ``write_text`` branch.
+            cli._generate_review_step(mock_path)
 
         mock_generator.generate.assert_called_once()
 
@@ -1189,20 +1190,16 @@ class TestGenerateSteps:
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step(self, mock_generator_class: Mock) -> None:
-        """Test _generate_architecture_step creates generator without orchestrator."""
+        """Test _generate_architecture_step creates generator deterministically."""
         mock_generator = MagicMock()
         mock_generator_class.return_value = mock_generator
         mock_path = MagicMock(spec=Path)
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            # Pass orchestrator=None — generator should still be invoked.
-            cli._generate_architecture_step(
-                mock_path,
-                "my-project",
-                "python",
-                None,
-            )
+            # The orchestrator parameter has been removed; this private
+            # helper now takes only the (path, name, language, writer).
+            cli._generate_architecture_step(mock_path, "my-project", "python")
 
         mock_generator.generate.assert_called()
 
@@ -1340,3 +1337,26 @@ class TestCopyReferenceSubagents:
             target = target_dir / f"{agent_name}.md"
             assert target.exists()
             assert target.read_text(encoding="utf-8") == sentinel
+
+    def test_uses_file_writer_when_provided(self, tmp_path: Path) -> None:
+        """The ``file_writer`` branch routes writes through the writer."""
+        ref_dir = tmp_path / "ref"
+        ref_dir.mkdir()
+        sentinel = "# Agent body\n"
+        for src in REQUIRED_AGENTS.values():
+            (ref_dir / src).write_text(sentinel, encoding="utf-8")
+
+        target_dir = tmp_path / "agents"
+        # The FileWriter contract has ``write_file(path, content)``;
+        # use a Mock with that signature so the test asserts the
+        # public boundary, not implementation details.
+        mock_writer = MagicMock()
+
+        with patch("start_green_stay_green.cli.REFERENCE_AGENTS_DIR", ref_dir):
+            cli._copy_reference_subagents(target_dir, file_writer=mock_writer)
+
+        # All eight required agents flowed through the writer; no
+        # files were created via the direct ``write_text`` fallback.
+        assert mock_writer.write_file.call_count == len(REQUIRED_AGENTS)
+        for agent_name in REQUIRED_AGENTS:
+            assert not (target_dir / f"{agent_name}.md").exists()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1216,9 +1216,20 @@ class TestGenerateSteps:
         mock_orchestrator = MagicMock()
         mock_generator = MagicMock()
         mock_generator_class.return_value = mock_generator
-        mock_run_async.return_value = {}
         mock_path = MagicMock(spec=Path)
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        # ``_generate_subagents_step`` now wraps the gather in
+        # ``_run_with_orchestrator_close``, which returns a coroutine.
+        # The mocked ``run_async`` never awaits it, so we must close it
+        # explicitly to avoid the "coroutine was never awaited" warning.
+        def _consume(coro: object) -> dict[str, object]:
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            return {}
+
+        mock_run_async.side_effect = _consume
 
         with patch("start_green_stay_green.cli.console"):
             cli._generate_subagents_step(

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1105,9 +1105,13 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_ci_step(mock_path, "python", mock_orchestrator)
+            cli._generate_ci_step(mock_path, "my-project", "python", mock_orchestrator)
 
-        mock_ci_generator_class.assert_called_with(mock_orchestrator, "python")
+        # ``project_name`` is now threaded through so ``<<% project_name %>>``
+        # placeholders in the reference templates render with the real value.
+        mock_ci_generator_class.assert_called_with(
+            mock_orchestrator, "python", project_name="my-project"
+        )
 
     @patch("start_green_stay_green.cli.CIGenerator")
     def test_generate_ci_step_uses_template_without_orchestrator(
@@ -1123,9 +1127,11 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_ci_step(mock_path, "python", None)
+            cli._generate_ci_step(mock_path, "no-orch-project", "python", None)
 
-        mock_ci_generator_class.assert_called_with(None, "python")
+        mock_ci_generator_class.assert_called_with(
+            None, "python", project_name="no-orch-project"
+        )
         mock_generator.generate_workflow.assert_called_once()
 
     @patch("start_green_stay_green.cli.GitHubActionsReviewGenerator")

--- a/tests/unit/utils/test_timing.py
+++ b/tests/unit/utils/test_timing.py
@@ -1,0 +1,164 @@
+"""Unit tests for ``start_green_stay_green.utils.timing``."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from start_green_stay_green.utils.timing import APICallRecord
+from start_green_stay_green.utils.timing import TimingReport
+from start_green_stay_green.utils.timing import get_active_report
+from start_green_stay_green.utils.timing import set_active_report
+from start_green_stay_green.utils.timing import step_timer
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_report() -> None:
+    """Make sure tests cannot leak the active report into each other."""
+    set_active_report(None)
+    yield
+    set_active_report(None)
+
+
+class TestTimingReport:
+    """Tests for the ``TimingReport`` collector."""
+
+    def test_begin_and_end_step_records_duration(self) -> None:
+        report = TimingReport()
+        record = report.begin_step("structure")
+        report.end_step(record, 0.42)
+
+        assert len(report.steps) == 1
+        assert report.steps[0].name == "structure"
+        assert report.steps[0].duration_s == pytest.approx(0.42)
+
+    def test_record_api_call_attributes_to_active_step(self) -> None:
+        report = TimingReport()
+        record = report.begin_step("subagents")
+        report.record_api_call(
+            APICallRecord(
+                latency_s=1.5,
+                retries=0,
+                input_tokens=100,
+                output_tokens=200,
+            )
+        )
+        report.end_step(record, 1.6)
+
+        assert report.steps[0].api_calls == 1
+        assert report.api_calls[0].input_tokens == 100
+        assert report.api_calls[0].output_tokens == 200
+
+    def test_api_call_outside_step_still_recorded_globally(self) -> None:
+        report = TimingReport()
+        report.record_api_call(APICallRecord(latency_s=0.5))
+
+        assert len(report.api_calls) == 1
+        assert report.steps == []
+
+    def test_aggregate_token_totals(self) -> None:
+        report = TimingReport()
+        report.record_api_call(
+            APICallRecord(
+                latency_s=1.0,
+                input_tokens=100,
+                output_tokens=200,
+                cache_read_tokens=50,
+            )
+        )
+        report.record_api_call(
+            APICallRecord(
+                latency_s=2.0,
+                input_tokens=300,
+                output_tokens=400,
+            )
+        )
+
+        assert report.total_input_tokens == 400
+        assert report.total_output_tokens == 600
+        assert report.total_cache_read_tokens == 50
+        assert report.api_seconds == pytest.approx(3.0)
+
+    def test_to_dict_shape(self) -> None:
+        report = TimingReport()
+        record = report.begin_step("ci")
+        report.record_api_call(
+            APICallRecord(latency_s=0.5, input_tokens=10, output_tokens=20)
+        )
+        report.end_step(record, 0.6)
+
+        payload = report.to_dict()
+
+        assert payload["api_calls"] == 1
+        assert payload["tokens"] == {"input": 10, "output": 20, "cache_read": 0}
+        assert payload["steps"][0]["name"] == "ci"
+        assert payload["steps"][0]["api_calls"] == 1
+
+    def test_write_json_round_trip(self, tmp_path: Path) -> None:
+        report = TimingReport()
+        record = report.begin_step("readme")
+        report.end_step(record, 0.1)
+
+        out = tmp_path / "report.json"
+        report.write_json(out)
+
+        loaded = json.loads(out.read_text())
+        assert loaded["steps"][0]["name"] == "readme"
+
+
+class TestStepTimerContext:
+    """Tests for the ``step_timer`` context manager."""
+
+    def test_step_timer_without_active_report_runs_silently(self) -> None:
+        # No report installed; step_timer must still work.
+        with step_timer("noop") as record:
+            time.sleep(0.001)
+        assert record.duration_s > 0
+        assert get_active_report() is None
+
+    def test_step_timer_with_active_report_records_step(self) -> None:
+        report = TimingReport()
+        set_active_report(report)
+
+        with step_timer("structure"):
+            time.sleep(0.001)
+
+        assert len(report.steps) == 1
+        assert report.steps[0].name == "structure"
+        assert report.steps[0].duration_s > 0
+
+    def test_nested_step_timers_attribute_to_innermost(self) -> None:
+        report = TimingReport()
+        set_active_report(report)
+
+        with step_timer("outer"), step_timer("inner"):
+            report.record_api_call(APICallRecord(latency_s=0.1))
+
+        # Both steps recorded; the API call belongs to ``inner``.
+        names = [s.name for s in report.steps]
+        assert names == ["outer", "inner"]
+        outer = next(s for s in report.steps if s.name == "outer")
+        inner = next(s for s in report.steps if s.name == "inner")
+        assert inner.api_calls == 1
+        assert outer.api_calls == 0
+
+    def test_step_timer_records_duration_on_exception(self) -> None:
+        report = TimingReport()
+        set_active_report(report)
+
+        def _explode() -> None:
+            with step_timer("explodes"):
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _explode()
+
+        assert report.steps[0].name == "explodes"
+        assert report.steps[0].duration_s >= 0

--- a/tests/unit/utils/test_timing.py
+++ b/tests/unit/utils/test_timing.py
@@ -8,15 +8,20 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import Path
-
+from start_green_stay_green.cli import _maybe_collect_timing
 from start_green_stay_green.utils.timing import APICallRecord
 from start_green_stay_green.utils.timing import TimingReport
 from start_green_stay_green.utils.timing import get_active_report
 from start_green_stay_green.utils.timing import set_active_report
 from start_green_stay_green.utils.timing import step_timer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+class _BoomError(RuntimeError):
+    """Sentinel exception used by ``TestMaybeCollectTimingExceptionPath``."""
 
 
 @pytest.fixture(autouse=True)
@@ -165,3 +170,51 @@ class TestStepTimerContext:
 
         assert report.steps[0].name == "explodes"
         assert report.steps[0].duration_s >= 0
+
+
+class TestMaybeCollectTimingExceptionPath:
+    """The `_maybe_collect_timing` cm in cli.py must persist on exception."""
+
+    @staticmethod
+    def _explode_with_step(report_path: Path) -> None:
+        """Helper that records a step then raises, for the persistence test."""
+        with _maybe_collect_timing(report_path):
+            # Record at least one step before the failure so the
+            # written JSON has something to verify.
+            with step_timer("structure"):
+                pass
+            msg = "boom"
+            raise _BoomError(msg)
+
+    @staticmethod
+    def _explode_bare() -> None:
+        """Helper that raises inside a no-op _maybe_collect_timing block."""
+        with _maybe_collect_timing(None):
+            msg = "bare"
+            raise ValueError(msg)
+
+    def test_exception_inside_block_still_writes_report(self, tmp_path: Path) -> None:
+        """If the wrapped block raises, the partial timing report is still written."""
+        report_path = tmp_path / "reports" / "partial.json"
+
+        with pytest.raises(_BoomError, match="boom"):
+            self._explode_with_step(report_path)
+
+        # The finally block must have executed: report exists,
+        # active-report singleton is cleared.
+        assert report_path.exists(), "partial timing report not persisted"
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        assert isinstance(payload["steps"], list)
+        names = [s["name"] for s in payload["steps"]]
+        assert "structure" in names
+        assert get_active_report() is None
+
+    def test_no_path_is_a_no_op(self, tmp_path: Path) -> None:
+        """When timing_json is None the cm leaves no side effects."""
+        # No file is created; no report is installed; the exception
+        # propagates exactly like a plain block.
+        with pytest.raises(ValueError, match="bare"):
+            self._explode_bare()
+
+        assert list(tmp_path.iterdir()) == []
+        assert get_active_report() is None

--- a/tests/unit/utils/test_timing.py
+++ b/tests/unit/utils/test_timing.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 from start_green_stay_green.utils.timing import APICallRecord
@@ -19,7 +20,7 @@ from start_green_stay_green.utils.timing import step_timer
 
 
 @pytest.fixture(autouse=True)
-def _reset_active_report() -> None:
+def _reset_active_report() -> Iterator[None]:
     """Make sure tests cannot leak the active report into each other."""
     set_active_report(None)
     yield
@@ -97,8 +98,10 @@ class TestTimingReport:
 
         assert payload["api_calls"] == 1
         assert payload["tokens"] == {"input": 10, "output": 20, "cache_read": 0}
-        assert payload["steps"][0]["name"] == "ci"
-        assert payload["steps"][0]["api_calls"] == 1
+        steps = payload["steps"]
+        assert isinstance(steps, list)
+        assert steps[0]["name"] == "ci"
+        assert steps[0]["api_calls"] == 1
 
     def test_write_json_round_trip(self, tmp_path: Path) -> None:
         report = TimingReport()


### PR DESCRIPTION
Phase 0 — Telemetry baseline:
* New start_green_stay_green/utils/timing.py with TimingReport collector
  and step_timer context manager.
* AIOrchestrator records per-call latency, retries, and token usage on
  the active report.
* New green init --timing-json PATH flag writes a structured report
  (wall_clock_s, api_calls, api_seconds, per-step durations, tokens).

Phase 1 — De-AI the deterministic generators:
* CIGenerator: orchestrator now optional; new
  generate_workflow_from_template() renders reference/ci/<lang>.yml via
  Jinja2 with custom delimiters so existing GitHub Actions ${{ }}
  expressions pass through unchanged.
* ClaudeMdGenerator: split into generate_baseline() (template-only,
  no API) and the legacy generate() (orchestrator-driven). Orchestrator
  is now optional; generate() falls back to baseline when None.
* ArchitectureEnforcementGenerator, MetricsGenerator: orchestrator
  parameter is now optional and unused (was already dead).
* cli.py: removed all five "⊘ Skipped (no API key)" branches. CI,
  review, CLAUDE.md, architecture, and subagents now produce real
  output even with no orchestrator. New _copy_reference_subagents
  helper backs the no-API subagent path.

Phase 2 — Async orchestrator + parallel subagents:
* AIOrchestrator gains an AsyncAnthropic-backed generate_async()
  method, sharing one long-lived client per orchestrator instance.
* SubagentsGenerator.generate_all_agents now uses asyncio.gather with
  a bounded Semaphore (default 8) for concurrent dispatch instead of
  the serial for-loop.
* ContentTuner offloads sync orchestrator calls to asyncio.to_thread
  so concurrent tunings actually overlap; AsyncMock and autospec mocks
  in tests are dispatched without a thread hop.
* New parallelism tests assert all 8 in-flight before any returns and
  that the semaphore caps in-flight concurrency.

Verified end-to-end with `green init --timing-json`: a no-API project
generates in ~0.07 s with zero "Skipped" messages — every artifact
produced by a deterministic path. 1602 unit + integration tests pass.

Roadmap: plans/2026-05-03-claude-init-optimization-roadmap.md updated
to reflect Phases 0–2 shipped; remaining work is prompt cache /
tool_use parsing (2c), the two-pass split + green enhance (3), prompt
cleanup (4), batch mode (5), and UX/docs (6).

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U