### PR TITLE
feat(init): Phase 3a — two-pass split foundation, --offline / --no-enhance flags

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -3,10 +3,18 @@
 **Created**: 2026-05-03
 **Owner**: Performance / AI Orchestration
 **Branch**: `claude/optimize-green-init-performance-Lsf7Y`
-**Status**: In progress — Phases 0, 1, and 2 (subagent parallelism) shipped on
-`claude/execute-optimization-roadmap-Fhfnu`. Remaining work: prompt caching
-+ tool_use parsing (Phase 2c), the two-pass split + `green enhance`
-(Phase 3), prompt cleanup (Phase 4), batch mode (Phase 5), UX/docs (Phase 6).
+**Status**: In progress.
+
+Shipped:
+- Phases 0 (telemetry), 1 (de-AI generators), 2 (subagent parallelism) — PR #305
+  merged onto main as commit `acf4572`.
+- Phase 3a (two-pass split foundation: `--offline` / `--no-enhance` flags +
+  `_generate_pass2_polish` rename) — branch
+  `claude/execute-optimization-roadmap-Fhfnu`, commit `1abea59`.
+
+Remaining: prompt caching + `tool_use` parsing (2c), `green enhance` command
++ `.enhance-state.json` resume (3b), prompt cleanup (4), batch mode (5),
+UX/docs (6).
 
 ---
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1180,14 +1180,28 @@ def _generate_metrics_dashboard_step(
         )
 
 
-def _generate_with_orchestrator(
+def _generate_pass2_polish(
     project_path: Path,
     project_name: str,
     language: str,
     orchestrator: AIOrchestrator | None,
     file_writer: FileWriter | None = None,
 ) -> None:
-    """Generate AI-powered artifacts (CI, CLAUDE.md, etc.) with progress indicators."""
+    """Run Pass 2 of the optimization roadmap's two-pass init model.
+
+    Generates the artifacts whose output is *enhanced* by an
+    :class:`AIOrchestrator` when one is available. After Phase 1 every
+    one of these has a deterministic baseline path too, so the function
+    runs unconditionally; the orchestrator is what flips each step
+    between "render template" and "AI-tune the template". When
+    ``orchestrator`` is ``None`` (``--offline`` / ``--no-enhance`` /
+    no API key), every step still runs and produces a complete project
+    via the deterministic path.
+
+    The roadmap (plans/2026-05-03-claude-init-optimization-roadmap.md)
+    calls this Pass 2 to distinguish it from Pass 1's per-language
+    scaffold steps.
+    """
     _generate_ci_step(project_path, project_name, language, orchestrator, file_writer)
     _generate_review_step(project_path, file_writer)
     _generate_claude_md_step(
@@ -1249,9 +1263,10 @@ def _generate_project_files(
         _generate_readme_step(project_path, project_name, primary_language, file_writer)
         _generate_skills_step(project_path, file_writer)
 
-        # AI-powered features use primary language
+        # Pass 2 of the two-pass init model: AI-tunable artifacts.
+        # Uses the primary language for cross-language projects.
         try:
-            _generate_with_orchestrator(
+            _generate_pass2_polish(
                 project_path,
                 project_name,
                 primary_language,
@@ -1454,6 +1469,100 @@ def _validate_conflict_flags(
         raise typer.Exit(code=1)
 
 
+def _resolve_pass2_orchestrator(
+    *,
+    api_key: str | None,
+    offline: bool,
+    no_enhance: bool,
+    no_interactive: bool,
+) -> AIOrchestrator | None:
+    """Decide whether Pass 2 should run, and return the orchestrator if so.
+
+    Encapsulates the three flags that interact to control Pass 2 of the
+    two-pass init model so the ``init`` command stays at complexity
+    grade A. The branches are deliberately mutually-exclusive (the
+    validator guarantees this) so each one returns directly:
+
+    * ``--offline`` → never resolve a key, never instantiate an
+      orchestrator. Returns ``None`` and prints a dim status line so
+      the user sees that Pass 1 alone is running.
+    * ``--no-enhance`` → resolve the key (so it lands in the keyring
+      / env / etc. for a future ``green enhance``) and then discard
+      the orchestrator so Pass 2 is skipped this run.
+    * Otherwise → resolve the key normally; if no key is available
+      print the legacy "AI features disabled" instructions.
+    """
+    if offline:
+        console.print(
+            "[dim]Running in offline mode — Pass 1 only (no API calls).[/dim]"
+        )
+        return None
+
+    orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
+
+    if no_enhance:
+        if orchestrator is not None:
+            console.print(
+                "[dim]--no-enhance: skipping Pass 2; run `green enhance` "
+                "later to add AI polish.[/dim]"
+            )
+        return None
+
+    if orchestrator is None:
+        console.print("\n[yellow]![/yellow] AI features disabled")
+        console.print("  - Skills: Using reference templates (no customization)")
+        console.print("  - CI/Subagents/CLAUDE.md: Using default templates")
+        console.print("\n  To enable AI features:")
+        console.print("    1. Get API key: https://console.anthropic.com/")
+        console.print("    2. Run: sgsg init --api-key YOUR_KEY")
+        console.print("    3. Or: Set ANTHROPIC_API_KEY environment variable\n")
+    return orchestrator
+
+
+def _validate_pass2_flags(
+    *,
+    offline: bool,
+    no_enhance: bool,
+    api_key: str | None,
+) -> None:
+    """Validate the Pass 2 flag combinations introduced for the two-pass init.
+
+    The flags interact in three ways the user might trip on:
+
+    * ``--offline`` and ``--no-enhance`` are redundant when used together
+      (both skip Pass 2). It is an error to combine them — the user
+      almost certainly meant one or the other.
+    * ``--offline`` with ``--api-key`` is contradictory (the user is
+      both supplying a key and asking to never use it). Treated as an
+      error to surface the mistake loudly.
+    * ``--no-enhance`` with ``--api-key`` is fine — the key gets
+      cached / kept available for a future ``green enhance`` (Phase 3b),
+      it just is not used during this init.
+
+    Args:
+        offline: Whether ``--offline`` was passed.
+        no_enhance: Whether ``--no-enhance`` was passed.
+        api_key: Whether ``--api-key`` was passed (any non-empty value).
+
+    Raises:
+        typer.Exit: If a contradictory combination is detected.
+    """
+    if offline and no_enhance:
+        console.print(
+            "[red]Error:[/red] --offline and --no-enhance are redundant; "
+            "pass only one.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    if offline and api_key:
+        console.print(
+            "[red]Error:[/red] --offline and --api-key are contradictory; "
+            "drop --offline or omit --api-key.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+
+
 @app.command()
 def init(  # noqa: PLR0913
     project_name: Annotated[
@@ -1524,6 +1633,30 @@ def init(  # noqa: PLR0913
             hide_input=True,
         ),
     ] = None,
+    offline: Annotated[
+        bool,
+        typer.Option(
+            "--offline",
+            help=(
+                "Run only Pass 1 of the two-pass init: produce a complete "
+                "project from deterministic templates. No API key is read, "
+                "no network is used, no AI tuning is attempted. Equivalent "
+                "to ``--no-enhance`` plus suppressing every API-key prompt."
+            ),
+        ),
+    ] = False,
+    no_enhance: Annotated[
+        bool,
+        typer.Option(
+            "--no-enhance",
+            help=(
+                "Skip Pass 2 of the two-pass init (the AI-tuned polish over "
+                "CLAUDE.md and subagents). Unlike ``--offline`` the API key "
+                "resolution still runs, so a follow-up ``green enhance`` "
+                "call (Phase 3b) can pick up where this one left off."
+            ),
+        ),
+    ] = False,
     enable_live_dashboard: Annotated[
         bool,
         typer.Option(
@@ -1560,6 +1693,10 @@ def init(  # noqa: PLR0913
         interactive: Prompt per-file for conflict resolution.
         no_interactive: Non-interactive mode.
         api_key: Optional Claude API key for AI features.
+        offline: Skip API-key resolution and Pass 2 entirely; produces
+            a complete project from deterministic templates only.
+        no_enhance: Skip Pass 2 (AI tuning) but still resolve the API
+            key for a future ``green enhance`` invocation.
         enable_live_dashboard: Generate live metrics dashboard with workflow.
         timing_json: Optional path to write a timing/telemetry JSON report.
         config: Configuration file path.
@@ -1568,6 +1705,7 @@ def init(  # noqa: PLR0913
         typer.Exit: If validation fails or generation errors occur.
     """
     _validate_conflict_flags(force, interactive)
+    _validate_pass2_flags(offline=offline, no_enhance=no_enhance, api_key=api_key)
 
     # Load configuration
     config_data = _load_config_data(config)
@@ -1601,17 +1739,12 @@ def init(  # noqa: PLR0913
         )
         return
 
-    # Initialize optional AI orchestrator (after dry-run check)
-    orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
-
-    if orchestrator is None:
-        console.print("\n[yellow]![/yellow] AI features disabled")
-        console.print("  - Skills: Using reference templates (no customization)")
-        console.print("  - CI/Subagents/CLAUDE.md: Using default templates")
-        console.print("\n  To enable AI features:")
-        console.print("    1. Get API key: https://console.anthropic.com/")
-        console.print("    2. Run: sgsg init --api-key YOUR_KEY")
-        console.print("    3. Or: Set ANTHROPIC_API_KEY environment variable\n")
+    orchestrator = _resolve_pass2_orchestrator(
+        api_key=api_key,
+        offline=offline,
+        no_enhance=no_enhance,
+        no_interactive=no_interactive,
+    )
 
     # Create project directory
     project_path.mkdir(parents=True, exist_ok=True)

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1501,10 +1501,20 @@ def _resolve_pass2_orchestrator(
     orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
 
     if no_enhance:
+        # Always print *something* so the user knows --no-enhance had an
+        # effect, regardless of whether a key was resolved. The two
+        # paths differ in what the user can do next: with a key cached,
+        # ``green enhance`` will pick it up; without, they need to set
+        # ANTHROPIC_API_KEY first.
         if orchestrator is not None:
             console.print(
                 "[dim]--no-enhance: skipping Pass 2; run `green enhance` "
                 "later to add AI polish.[/dim]"
+            )
+        else:
+            console.print(
+                "[dim]--no-enhance: no API key found; Pass 2 skipped. "
+                "Set ANTHROPIC_API_KEY before running `green enhance`.[/dim]"
             )
         return None
 
@@ -1540,9 +1550,11 @@ def _validate_pass2_flags(
       it just is not used during this init.
 
     Args:
-        offline: Whether ``--offline`` was passed.
-        no_enhance: Whether ``--no-enhance`` was passed.
-        api_key: Whether ``--api-key`` was passed (any non-empty value).
+        offline: ``True`` if ``--offline`` was passed.
+        no_enhance: ``True`` if ``--no-enhance`` was passed.
+        api_key: The string value passed to ``--api-key``, or ``None``
+            if the flag was omitted. Truthiness is what matters here:
+            an empty string is treated the same as ``None``.
 
     Raises:
         typer.Exit: If a contradictory combination is detected.

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -38,6 +38,7 @@ import typer
 from typer.testing import CliRunner
 
 from start_green_stay_green import cli
+from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 
@@ -1250,7 +1251,7 @@ class TestGenerateSteps:
 class TestGenerateProjectFiles:
     """Test project file generation."""
 
-    @patch("start_green_stay_green.cli._generate_with_orchestrator")
+    @patch("start_green_stay_green.cli._generate_pass2_polish")
     @patch("start_green_stay_green.cli._generate_scripts_step")
     @patch("start_green_stay_green.cli._generate_precommit_step")
     @patch("start_green_stay_green.cli._generate_skills_step")
@@ -1259,7 +1260,7 @@ class TestGenerateProjectFiles:
         mock_skills: Mock,
         mock_precommit: Mock,
         mock_scripts: Mock,
-        mock_generate_orch: Mock,
+        mock_pass2: Mock,
     ) -> None:
         """Test _generate_project_files generates all steps."""
         mock_orchestrator = MagicMock()
@@ -1278,7 +1279,7 @@ class TestGenerateProjectFiles:
         mock_scripts.assert_called()
         mock_precommit.assert_called()
         mock_skills.assert_called()
-        mock_generate_orch.assert_called()
+        mock_pass2.assert_called()
 
     @patch("start_green_stay_green.cli._generate_scripts_step")
     @patch("start_green_stay_green.cli._generate_precommit_step")
@@ -1405,3 +1406,127 @@ class TestRunWithOrchestratorClose:
         # Even though ``_boom`` raised, the finally block must have
         # called aclose to release the httpx pool.
         orchestrator.aclose.assert_called_once()
+
+
+class TestValidatePass2Flags:
+    """Tests for the ``--offline`` / ``--no-enhance`` / ``--api-key`` validator."""
+
+    def test_offline_alone_is_valid(self) -> None:
+        """``--offline`` without conflicting flags passes validation."""
+        cli._validate_pass2_flags(offline=True, no_enhance=False, api_key=None)
+
+    def test_no_enhance_alone_is_valid(self) -> None:
+        """``--no-enhance`` without conflicting flags passes validation."""
+        cli._validate_pass2_flags(offline=False, no_enhance=True, api_key=None)
+
+    def test_no_enhance_with_api_key_is_valid(self) -> None:
+        """``--no-enhance`` plus ``--api-key`` is the documented happy path.
+
+        The user has a key (cached for a future ``green enhance``) but
+        does not want Pass 2 to run on this init.
+        """
+        cli._validate_pass2_flags(offline=False, no_enhance=True, api_key="sk-real-key")
+
+    def test_offline_and_no_enhance_together_rejected(self) -> None:
+        """Combining ``--offline`` and ``--no-enhance`` is redundant — error out."""
+        with patch("start_green_stay_green.cli.console") as mock_console:
+            with pytest.raises(typer.Exit) as exc:
+                cli._validate_pass2_flags(offline=True, no_enhance=True, api_key=None)
+            assert exc.value.exit_code == 1
+            mock_console.print.assert_called_once()
+            msg = mock_console.print.call_args[0][0]
+            assert "redundant" in msg
+
+    def test_offline_with_api_key_rejected(self) -> None:
+        """``--offline`` with ``--api-key`` is contradictory — error out."""
+        with patch("start_green_stay_green.cli.console") as mock_console:
+            with pytest.raises(typer.Exit) as exc:
+                cli._validate_pass2_flags(
+                    offline=True, no_enhance=False, api_key="sk-real-key"
+                )
+            assert exc.value.exit_code == 1
+            mock_console.print.assert_called_once()
+            msg = mock_console.print.call_args[0][0]
+            assert "contradictory" in msg
+
+
+class TestOfflineAndNoEnhanceFlags:
+    """End-to-end behaviour of the two new init flags."""
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_offline_skips_orchestrator_initialization(
+        self, mock_init_orch: Mock, tmp_path: Path
+    ) -> None:
+        """``--offline`` short-circuits before ``_initialize_orchestrator``."""
+        runner = CliRunner()
+        runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "offline-smoke",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--offline",
+                "--no-interactive",
+            ],
+        )
+
+        # The point of --offline: the API-key resolution helper is
+        # never called, so a missing keyring or no env var cannot cause
+        # surprise prompts or warnings.
+        mock_init_orch.assert_not_called()
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_no_enhance_resolves_key_but_drops_orchestrator(
+        self, mock_init_orch: Mock, tmp_path: Path
+    ) -> None:
+        """``--no-enhance`` calls ``_initialize_orchestrator`` and discards it."""
+        # Stand up a fake orchestrator so the helper "succeeds".
+        mock_init_orch.return_value = MagicMock(spec=AIOrchestrator)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "no-enhance-smoke",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--no-enhance",
+                "--no-interactive",
+            ],
+        )
+
+        # Key was resolved (Pass 2 is skipped, but the key is "kept"
+        # for a future ``green enhance``).
+        assert result.exit_code == 0
+        mock_init_orch.assert_called_once()
+        # The on-screen hint about ``green enhance`` should fire.
+        assert "green enhance" in result.stdout
+
+    def test_offline_and_no_enhance_together_exits(self, tmp_path: Path) -> None:
+        """Validator surfaces conflict with exit code 1."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "conflict",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--offline",
+                "--no-enhance",
+                "--no-interactive",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "redundant" in result.stdout

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1608,3 +1608,35 @@ class TestOfflineAndNoEnhanceFlags:
         )
         assert result.exit_code == 1
         assert "redundant" in result.stdout
+
+    def test_offline_with_api_key_together_exits(self, tmp_path: Path) -> None:
+        """Validator surfaces ``--offline --api-key`` conflict at the CLI layer.
+
+        The validator unit test (``TestValidatePass2Flags
+        .test_offline_with_api_key_rejected``) covers the validator
+        in isolation, but typer's option-parsing layer is its own
+        moving part. The symmetric ``--offline --no-enhance`` test
+        above exercises the same path end-to-end; this test is the
+        missing counterpart that locks the ``--offline --api-key``
+        wiring all the way from CLI argv to the validator's exit-1
+        path.
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "conflict",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--offline",
+                "--api-key",
+                "sk-test-key",
+                "--no-interactive",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "contradictory" in result.stdout

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1459,7 +1459,7 @@ class TestOfflineAndNoEnhanceFlags:
     ) -> None:
         """``--offline`` short-circuits before ``_initialize_orchestrator``."""
         runner = CliRunner()
-        runner.invoke(
+        result = runner.invoke(
             cli.app,
             [
                 "init",
@@ -1473,6 +1473,12 @@ class TestOfflineAndNoEnhanceFlags:
                 "--no-interactive",
             ],
         )
+
+        # ``runner.invoke`` swallows exceptions by default, so a broken
+        # ``--offline`` path could still leave ``mock_init_orch.assert_
+        # not_called()`` passing. Anchor the test on a successful exit
+        # first so a regression that crashes mid-init fails loudly.
+        assert result.exit_code == 0, result.stdout
 
         # The point of --offline: the API-key resolution helper is
         # never called, so a missing keyring or no env var cannot cause
@@ -1509,6 +1515,78 @@ class TestOfflineAndNoEnhanceFlags:
         mock_init_orch.assert_called_once()
         # The on-screen hint about ``green enhance`` should fire.
         assert "green enhance" in result.stdout
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_no_enhance_with_no_api_key_prints_actionable_hint(
+        self, mock_init_orch: Mock, tmp_path: Path
+    ) -> None:
+        """``--no-enhance`` without an API key still tells the user what happened.
+
+        Regression test for the silent-feedback bug: without this
+        branch the user sees neither the legacy "AI features disabled"
+        block (suppressed by ``--no-enhance``) nor the
+        "run ``green enhance`` later" hint, leaving them with no idea
+        what their flag did.
+        """
+        mock_init_orch.return_value = None  # Simulate no key found.
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "no-enhance-no-key",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--no-enhance",
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_init_orch.assert_called_once()
+        # Specifically the "no API key found" branch — separate string
+        # from the key-found branch so a future refactor that collapses
+        # them is loud.
+        assert "no API key found" in result.stdout
+        # And the actionable next-step pointer.
+        assert "ANTHROPIC_API_KEY" in result.stdout
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_no_enhance_with_explicit_api_key_is_documented_happy_path(
+        self, mock_init_orch: Mock, tmp_path: Path
+    ) -> None:
+        """``--no-enhance --api-key X`` is the documented "tune later" combo."""
+        mock_init_orch.return_value = MagicMock(spec=AIOrchestrator)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "no-enhance-with-key",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--no-enhance",
+                "--api-key",
+                "sk-test-key",
+                "--no-interactive",
+            ],
+        )
+
+        # Validator accepts the combo (no exit 1) and the helper is
+        # called with the explicit key.
+        assert result.exit_code == 0
+        mock_init_orch.assert_called_once()
+        # The key-found branch ran (not the no-key branch).
+        assert "run `green enhance`" in result.stdout
+        assert "no API key found" not in result.stdout
 
     def test_offline_and_no_enhance_together_exits(self, tmp_path: Path) -> None:
         """Validator surfaces conflict with exit code 1."""

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -26,7 +26,7 @@ from start_green_stay_green.cli import _scripts_dir_has_other_language
 from start_green_stay_green.utils.file_writer import FileWriter
 
 _STEP_NAMES = [
-    "_generate_with_orchestrator",
+    "_generate_pass2_polish",
     "_generate_skills_step",
     "_generate_precommit_step",
     "_generate_scripts_step",
@@ -135,7 +135,7 @@ class TestMultiLanguageGeneration:
             # Shared steps called once (not per-language)
             _get_mock("_generate_readme_step").assert_called_once()
             _get_mock("_generate_skills_step").assert_called_once()
-            _get_mock("_generate_with_orchestrator").assert_called_once()
+            _get_mock("_generate_pass2_polish").assert_called_once()
 
     def test_single_language_backward_compatible(self) -> None:
         """Test single language works identically to before."""


### PR DESCRIPTION
## Summary

This PR is the first slice of **Phase 3 of the optimization roadmap**
(`plans/2026-05-03-claude-init-optimization-roadmap.md`). It lays the
foundation for the two-pass init model by exposing the implicit
behaviour Phase 1 unlocked as explicit user-facing flags. The big
architectural pieces — the `green enhance` command and the
`.claude/.enhance-state.json` resume file — are deferred to Phase 3b.

## What changed

### Renames (no behaviour change)

- `_generate_with_orchestrator` → `_generate_pass2_polish`. The
  helper has not actually required an orchestrator since Phase 1;
  every step inside it has a deterministic path now. The new name
  matches the roadmap's vocabulary and addresses the seventh-pass
  PR #305 reviewer's flagged misnomer.

### New CLI flags on `green init`

- **`--offline`**: skips API-key resolution entirely (no keyring
  lookup, no env-var read, no prompts) and forces `orchestrator=None`
  so only Pass 1 runs. Equivalent in output to the existing no-key
  behaviour, but explicit and key-discovery-free.
- **`--no-enhance`**: resolves the API key normally (so it lands in
  the keyring / cache for a future `green enhance` call once 3b
  ships) but discards the orchestrator before Pass 2 runs. Use case:
  "set up the project deterministically now, tune later".

### Flag validation

`_validate_pass2_flags` rejects:

- `--offline + --no-enhance` — redundant
- `--offline + --api-key` — contradictory (key supplied + told to
  never use it)

`--no-enhance + --api-key` is the documented happy path.

### Internal refactor

- `_resolve_pass2_orchestrator` encapsulates the three-flag
  interaction so `init()` stays at cyclomatic complexity grade A
  (the new flags would have pushed it to B otherwise).

## Tests

Eight new tests in `tests/unit/test_cli_mocked.py`:

- `TestValidatePass2Flags` — five cases covering each flag alone, the
  legitimate `--no-enhance --api-key` combination, and the two
  rejected conflicts.
- `TestOfflineAndNoEnhanceFlags` — three end-to-end CLI tests:
  `--offline` short-circuits `_initialize_orchestrator` entirely;
  `--no-enhance` calls it then drops the result and prints the
  "run `green enhance` later" hint; `--offline --no-enhance` exits
  non-zero with the redundant-flags message.

Existing tests updated for the rename in `test_multi_language.py` and
the `TestGenerateProjectFiles` mock patch in `test_cli_mocked.py`.

## Verification

- All five CI gate scripts ✓ locally (lint, format, typecheck,
  security, complexity).
- 1626 unit + integration tests pass.
- Smoke-tested end-to-end: `green init --offline --no-interactive`
  produces a complete project with zero API calls and prints the
  offline-mode status line.

## Test plan

- [ ] CI green on this PR.
- [ ] Smoke: `green init --offline -n smoke -l python` produces a
      complete project with no `Skipped` messages and no
      `_initialize_orchestrator` call.
- [ ] Smoke: `green init --no-enhance -n smoke -l python` resolves
      the key, skips Pass 2, and prints "run `green enhance` later".
- [ ] `--offline --no-enhance` together exits 1 with the redundant
      message; `--offline --api-key foo` exits 1 with the
      contradictory message.

## Roadmap status

- ✅ Phase 0 (telemetry) — shipped in PR #305.
- ✅ Phase 1 (de-AI generators) — shipped in PR #305.
- ✅ Phase 2 (subagent parallelism) — shipped in PR #305.
- ⏳ **Phase 3a (this PR)** — two-pass split foundation +
  `--offline` / `--no-enhance` flags.
- 🔜 Phase 3b — `green enhance [PATH]` command and
  `.claude/.enhance-state.json` resume.
- 🔜 Phase 2c, 4, 5, 6 — see roadmap.

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_