### PR TITLE
feat(cli): Phase 3b — `green enhance` command (re-run Pass 2 on existing project)

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -9,12 +9,15 @@ Shipped:
 - Phases 0 (telemetry), 1 (de-AI generators), 2 (subagent parallelism) — PR #305
   merged onto main as commit `acf4572`.
 - Phase 3a (two-pass split foundation: `--offline` / `--no-enhance` flags +
-  `_generate_pass2_polish` rename) — branch
-  `claude/execute-optimization-roadmap-Fhfnu`, commit `1abea59`.
+  `_generate_pass2_polish` rename) — PR #308 merged onto main as commit
+  `0986d89`.
+- Phase 3b (MVP `green enhance [PATH]` command — re-runs Pass 2 against an
+  existing project; `--targets`, `--dry-run`, auto-detection of project
+  name + language) — branch `claude/execute-optimization-roadmap-Fhfnu`.
 
-Remaining: prompt caching + `tool_use` parsing (2c), `green enhance` command
-+ `.enhance-state.json` resume (3b), prompt cleanup (4), batch mode (5),
-UX/docs (6).
+Remaining: prompt caching + `tool_use` parsing (2c), `.enhance-state.json`
+resume + source-hash skip-logic (3c — splits the rest of Phase 3 from the
+roadmap), prompt cleanup (4), batch mode (5), UX/docs (6).
 
 ---
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1785,6 +1785,512 @@ def init(  # noqa: PLR0913
         )
 
 
+_LANGUAGE_PROBES: tuple[tuple[str, str], ...] = (
+    # (filename relative to project root, language). The first match wins.
+    ("pyproject.toml", "python"),
+    ("requirements.txt", "python"),
+    ("package.json", "typescript"),
+    ("go.mod", "go"),
+    ("Cargo.toml", "rust"),
+    ("pom.xml", "java"),
+    ("build.gradle", "java"),
+    ("Gemfile", "ruby"),
+    ("composer.json", "php"),
+    ("Package.swift", "swift"),
+)
+
+# Pattern for the H1 line in a generated CLAUDE.md file.
+# ``# Claude Code Project Context: <project-name>``
+_CLAUDE_MD_TITLE = re.compile(
+    r"^#\s+Claude Code Project Context:\s+(?P<name>.+?)\s*$",
+    re.MULTILINE,
+)
+
+# Targets the ``green enhance`` command knows how to re-tune. Order
+# matches the on-disk layout users expect to see touched.
+_ENHANCE_TARGETS: tuple[str, ...] = ("claude-md", "subagents")
+
+
+def _detect_project_name(project_path: Path) -> str | None:
+    """Return the project name parsed out of an existing CLAUDE.md.
+
+    The init-generated CLAUDE.md baseline starts with
+    ``# Claude Code Project Context: <name>``. Reading the first line
+    matching that pattern is more reliable than guessing from the
+    directory name (the user may have renamed the directory) or from
+    ``pyproject.toml`` (project may be multi-language).
+
+    Returns ``None`` if CLAUDE.md is missing or doesn't have the
+    expected H1 — in which case the caller must require ``-n``.
+    """
+    claude_md = project_path / "CLAUDE.md"
+    if not claude_md.is_file():
+        return None
+    try:
+        content = claude_md.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _CLAUDE_MD_TITLE.search(content)
+    if match is None:
+        return None
+    return match.group("name").strip() or None
+
+
+def _detect_project_language(project_path: Path) -> str | None:
+    """Return the project's primary language by file probing.
+
+    The probes are ordered: the first hit wins. For multi-language
+    projects this returns whatever shows up first in the canonical
+    list; users can override with ``-l`` if the auto-detected one
+    isn't the one they want re-tuned.
+
+    Returns ``None`` if no probe matched, in which case the caller
+    must require ``-l``.
+    """
+    for filename, language in _LANGUAGE_PROBES:
+        if (project_path / filename).is_file():
+            return language
+    return None
+
+
+def _validate_enhance_target(value: str) -> str:
+    """Normalize and validate one ``--targets`` value.
+
+    Args:
+        value: A single target name from the CLI.
+
+    Returns:
+        The lower-cased target name if it is recognised.
+
+    Raises:
+        typer.BadParameter: If the target is not in
+            :data:`_ENHANCE_TARGETS`.
+    """
+    normalized = value.strip().lower()
+    if normalized not in _ENHANCE_TARGETS:
+        valid = ", ".join(_ENHANCE_TARGETS)
+        msg = f"unknown target {value!r}; choose from: {valid}"
+        raise typer.BadParameter(msg)
+    return normalized
+
+
+def _split_target_pieces(targets: list[str]) -> list[str]:
+    """Flatten ``--targets`` values into individual pieces, dropping empties."""
+    return [
+        piece.strip() for raw in targets for piece in raw.split(",") if piece.strip()
+    ]
+
+
+def _resolve_enhance_targets(targets: list[str] | None) -> tuple[str, ...]:
+    """Resolve the ``--targets`` argument list (possibly comma-separated).
+
+    Accepts both ``--targets claude-md --targets subagents`` and
+    ``--targets claude-md,subagents``. ``None`` (no flag passed) means
+    "tune every target".
+
+    Args:
+        targets: Raw values from the typer option.
+
+    Returns:
+        A tuple of resolved target names in the canonical order
+        defined by :data:`_ENHANCE_TARGETS`.
+
+    Raises:
+        typer.BadParameter: If any target is unknown.
+    """
+    if not targets:
+        return _ENHANCE_TARGETS
+    requested = {_validate_enhance_target(p) for p in _split_target_pieces(targets)}
+    # Preserve canonical order, deduplicating.
+    return tuple(t for t in _ENHANCE_TARGETS if t in requested)
+
+
+def _require_enhance_orchestrator(
+    api_key: str | None,
+    *,
+    no_interactive: bool,
+) -> AIOrchestrator:
+    """Resolve an :class:`AIOrchestrator` for the ``enhance`` command.
+
+    Unlike ``init``, ``enhance`` cannot fall back to a deterministic
+    path — re-tuning is the entire point. If no API key is available,
+    fail fast with an actionable message instead of writing an empty
+    "tuning" that silently no-ops.
+
+    Args:
+        api_key: Optional CLI-supplied key.
+        no_interactive: Skip any keyring prompts.
+
+    Returns:
+        A real ``AIOrchestrator`` ready to dispatch.
+
+    Raises:
+        typer.Exit: With code 1 if no key could be resolved.
+    """
+    orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
+    if orchestrator is None:
+        console.print(
+            "[red]Error:[/red] `green enhance` requires an Anthropic API "
+            "key — there is no deterministic fallback for AI-tuned "
+            "artifacts.\n  Set ANTHROPIC_API_KEY or pass --api-key.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    return orchestrator
+
+
+def _enhance_claude_md(  # noqa: PLR0913 — Pass 2 helpers mirror init steps
+    project_path: Path,
+    project_name: str,
+    language: str,
+    orchestrator: AIOrchestrator,
+    *,
+    dry_run: bool,
+    file_writer: FileWriter | None,
+) -> None:
+    """Re-tune ``CLAUDE.md`` against the existing project.
+
+    Mirrors :func:`_generate_claude_md_step`'s tuning path but writes
+    to the existing project rather than a fresh scaffold. ``dry_run``
+    skips the write but still runs the API call so the user sees the
+    full token-usage telemetry (and any errors) they'd see for real.
+    """
+    with step_timer("enhance_claude_md"), console.status("Re-tuning CLAUDE.md..."):
+        claude_md_generator = ClaudeMdGenerator(orchestrator)
+        result = claude_md_generator.generate(
+            {
+                "project_name": project_name,
+                "language": language,
+                "scripts": [
+                    "check-all.sh",
+                    "test.sh",
+                    "lint.sh",
+                    "format.sh",
+                    "security.sh",
+                    "mutation.sh",
+                ],
+                "skills": REQUIRED_SKILLS.copy(),
+            }
+        )
+        target = project_path / "CLAUDE.md"
+        if dry_run:
+            console.print(
+                f"[dim]--dry-run: would rewrite {target} "
+                f"({len(result.content):,} chars).[/dim]"
+            )
+            return
+        if file_writer is not None:
+            file_writer.write_file(target, result.content)
+        else:
+            target.write_text(result.content, encoding="utf-8")
+    console.print("[green]✓[/green] Re-tuned CLAUDE.md")
+
+
+def _enhance_subagents(  # noqa: PLR0913 — Pass 2 helpers mirror init steps
+    project_path: Path,
+    project_name: str,
+    language: str,
+    orchestrator: AIOrchestrator,
+    *,
+    dry_run: bool,
+    file_writer: FileWriter | None,
+) -> None:
+    """Re-tune every subagent against the existing project.
+
+    Same parallel-fan-out path as Pass 2 of init, but writes back to
+    ``<project>/.claude/agents`` instead of generating it fresh.
+    """
+    target_dir = project_path / ".claude" / "agents"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    with step_timer("enhance_subagents"), console.status("Re-tuning subagents..."):
+        subagents_generator = SubagentsGenerator(orchestrator)
+        target_context = (
+            f"Project: {project_name}, "
+            f"Language: {language}, "
+            f"Type: existing project being re-tuned via `green enhance`"
+        )
+        results = run_async(
+            _run_with_orchestrator_close(
+                orchestrator,
+                subagents_generator.generate_all_agents(target_context),
+            )
+        )
+        if dry_run:
+            console.print(
+                f"[dim]--dry-run: would rewrite {len(results)} agent "
+                f"file(s) in {target_dir}.[/dim]"
+            )
+            return
+        for agent_name, result in results.items():
+            agent_file = target_dir / f"{agent_name}.md"
+            if file_writer is not None:
+                file_writer.write_file(agent_file, result.content)
+            else:
+                agent_file.write_text(result.content, encoding="utf-8")
+    console.print(f"[green]✓[/green] Re-tuned {len(results)} subagents")
+
+
+def _resolve_enhance_name(project_path: Path, override: str | None) -> str:
+    """Resolve the project name for ``enhance``; exit if neither path works."""
+    resolved = override or _detect_project_name(project_path)
+    if resolved is None:
+        console.print(
+            "[red]Error:[/red] could not determine the project name "
+            "from CLAUDE.md. Pass --project-name explicitly.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    return resolved
+
+
+def _resolve_enhance_language(project_path: Path, override: str | None) -> str:
+    """Resolve the language for ``enhance``; exit if absent or unsupported."""
+    resolved = override or _detect_project_language(project_path)
+    if resolved is None:
+        console.print(
+            "[red]Error:[/red] could not detect the project language. "
+            "Pass --language explicitly.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    try:
+        validate_language(resolved)
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] {e}", style="bold")
+        raise typer.Exit(code=1) from e
+    return resolved
+
+
+def _resolve_enhance_metadata(
+    project_path: Path,
+    *,
+    project_name: str | None,
+    language: str | None,
+) -> tuple[str, str]:
+    """Resolve project name + language for ``enhance``, exiting on failure.
+
+    Auto-detection from the project layout is the default path; the
+    explicit ``--project-name`` and ``--language`` flags win where
+    supplied. Either piece missing (no override + no detected value)
+    is a fatal error so the caller cannot accidentally tune the wrong
+    project metadata into a fresh CLAUDE.md.
+    """
+    return (
+        _resolve_enhance_name(project_path, project_name),
+        _resolve_enhance_language(project_path, language),
+    )
+
+
+def _validate_enhance_path(project_path: Path) -> None:
+    """Confirm ``project_path`` looks like a generated green-init project.
+
+    The cheapest reliable signature is the presence of ``CLAUDE.md`` —
+    every init flow writes one (Phase 1 added the deterministic
+    baseline so even ``--offline`` projects have it). Without that
+    file, ``enhance`` has no project to re-tune; fail fast with a
+    pointer to ``green init``.
+
+    Args:
+        project_path: Directory the user passed as the enhance target.
+
+    Raises:
+        typer.Exit: With code 1 if the path is not an enhanceable
+            project.
+    """
+    if not project_path.exists():
+        console.print(
+            f"[red]Error:[/red] {project_path} does not exist.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    if not project_path.is_dir():
+        console.print(
+            f"[red]Error:[/red] {project_path} is not a directory.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+    if not (project_path / "CLAUDE.md").is_file():
+        console.print(
+            f"[red]Error:[/red] {project_path} does not look like a "
+            "green-init project (no CLAUDE.md found).\n  Run "
+            "`green init` first or pass a different path.",
+            style="bold",
+        )
+        raise typer.Exit(code=1)
+
+
+@app.command()
+def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
+    project_path: Annotated[
+        Path,
+        typer.Argument(
+            help=(
+                "Path to an existing green-init project. Defaults to the "
+                "current directory. The directory must contain a "
+                "``CLAUDE.md`` produced by `green init`."
+            ),
+            exists=False,
+        ),
+    ] = Path(),
+    project_name: Annotated[
+        str | None,
+        typer.Option(
+            "--project-name",
+            "-n",
+            help=(
+                "Override the auto-detected project name. By default the "
+                "name is parsed out of the existing ``CLAUDE.md``'s H1 "
+                "title."
+            ),
+        ),
+    ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option(
+            "--language",
+            "-l",
+            help=(
+                "Override the auto-detected primary language. By default "
+                "the language is probed from canonical project files "
+                "(pyproject.toml, package.json, go.mod, Cargo.toml, ...)."
+            ),
+        ),
+    ] = None,
+    targets: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--targets",
+            "-t",
+            help=(
+                "Subset of artifacts to re-tune. Repeat the flag or "
+                f"comma-separate. Choices: {', '.join(_ENHANCE_TARGETS)}. "
+                "Default: re-tune everything."
+            ),
+        ),
+    ] = None,
+    *,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help=(
+                "Make the API calls but do not write any files. Useful "
+                "for previewing token cost / changes before committing "
+                "to a re-tune."
+            ),
+        ),
+    ] = False,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            help=(
+                "[DEPRECATED] API key is visible in process list. "
+                "Use ANTHROPIC_API_KEY env var or keyring instead."
+            ),
+            hide_input=True,
+        ),
+    ] = None,
+    no_interactive: Annotated[
+        bool,
+        typer.Option(
+            "--no-interactive",
+            help="Run in non-interactive mode (skip keyring prompts).",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Overwrite files without prompting. Off by default.",
+        ),
+    ] = False,
+) -> None:
+    r"""Re-run Pass 2 (AI tuning) on an existing green-init project.
+
+    Phase 3b of the optimization roadmap: gives users who ran
+    ``green init --offline`` (or who have updated their reference
+    skills/subagents) a way to add or refresh the AI-tuned artifacts
+    without re-scaffolding the whole project.
+
+    Examples:
+        \b
+        # Re-tune everything in the current directory:
+        green enhance
+    \b
+        # Re-tune only CLAUDE.md in a specific project:
+        green enhance ./my-app --targets claude-md
+    \b
+        # Preview the token cost without writing anything:
+        green enhance --dry-run
+
+    Args:
+        project_path: Directory of the existing project.
+        project_name: Optional override for auto-detection.
+        language: Optional override for auto-detection.
+        targets: Subset of artifacts to re-tune.
+        dry_run: Run the API calls but skip the writes.
+        api_key: Optional Claude API key.
+        no_interactive: Disable interactive prompts.
+        force: Overwrite files without prompting.
+
+    Raises:
+        typer.Exit: If the path is invalid, project metadata cannot
+            be inferred, an unknown ``--targets`` value is supplied,
+            or no API key is available.
+    """
+    project_path = project_path.resolve()
+    _validate_enhance_path(project_path)
+
+    resolved_name, resolved_language = _resolve_enhance_metadata(
+        project_path,
+        project_name=project_name,
+        language=language,
+    )
+
+    selected_targets = _resolve_enhance_targets(targets)
+    orchestrator = _require_enhance_orchestrator(api_key, no_interactive=no_interactive)
+
+    file_writer = FileWriter(
+        project_root=project_path,
+        force=force,
+        interactive=False,
+        console=console,
+    )
+
+    console.print(
+        f"[dim]Enhancing project: {resolved_name} ({resolved_language})"
+        f"  →  targets: {', '.join(selected_targets)}"
+        f"{'  [DRY RUN]' if dry_run else ''}[/dim]"
+    )
+
+    if "claude-md" in selected_targets:
+        _enhance_claude_md(
+            project_path,
+            resolved_name,
+            resolved_language,
+            orchestrator,
+            dry_run=dry_run,
+            file_writer=file_writer,
+        )
+    if "subagents" in selected_targets:
+        _enhance_subagents(
+            project_path,
+            resolved_name,
+            resolved_language,
+            orchestrator,
+            dry_run=dry_run,
+            file_writer=file_writer,
+        )
+
+    if dry_run:
+        console.print("\n[green]✓[/green] Dry run complete — no files written.")
+    else:
+        console.print(f"\n[green]✓[/green] Enhancement complete: {resolved_name}")
+
+
 def cli_main() -> None:
     """Entry point for the CLI when installed as a package."""
     app()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1640,3 +1640,317 @@ class TestOfflineAndNoEnhanceFlags:
         )
         assert result.exit_code == 1
         assert "contradictory" in result.stdout
+
+
+class TestEnhanceDetectionHelpers:
+    """Cover the auto-detection helpers used by ``green enhance``."""
+
+    def test_detect_project_name_reads_h1(self, tmp_path: Path) -> None:
+        """``_detect_project_name`` parses the ``Claude Code Project Context`` H1."""
+        (tmp_path / "CLAUDE.md").write_text(
+            "# Claude Code Project Context: my-cool-app\n\nrest of file...\n",
+            encoding="utf-8",
+        )
+        assert cli._detect_project_name(tmp_path) == "my-cool-app"
+
+    def test_detect_project_name_returns_none_without_claude_md(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing CLAUDE.md returns ``None`` (caller falls back to --project-name)."""
+        assert cli._detect_project_name(tmp_path) is None
+
+    def test_detect_project_name_returns_none_for_unmatched_h1(
+        self, tmp_path: Path
+    ) -> None:
+        """Different H1 → ``None`` so we don't grab the wrong string."""
+        (tmp_path / "CLAUDE.md").write_text(
+            "# Some Other Title\n\n",
+            encoding="utf-8",
+        )
+        assert cli._detect_project_name(tmp_path) is None
+
+    def test_detect_project_language_python(self, tmp_path: Path) -> None:
+        """``pyproject.toml`` → python."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        assert cli._detect_project_language(tmp_path) == "python"
+
+    def test_detect_project_language_typescript(self, tmp_path: Path) -> None:
+        """``package.json`` → typescript."""
+        (tmp_path / "package.json").write_text("{}")
+        assert cli._detect_project_language(tmp_path) == "typescript"
+
+    def test_detect_project_language_returns_none_for_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """No probe matches → ``None``."""
+        assert cli._detect_project_language(tmp_path) is None
+
+
+class TestEnhanceTargetResolution:
+    """Cover ``_resolve_enhance_targets`` and ``_validate_enhance_target``."""
+
+    def test_no_targets_means_all(self) -> None:
+        """``None`` (no flag) selects every canonical target."""
+        assert cli._resolve_enhance_targets(None) == cli._ENHANCE_TARGETS
+
+    def test_empty_list_means_all(self) -> None:
+        """An empty list also means "all" — shouldn't deselect everything."""
+        assert cli._resolve_enhance_targets([]) == cli._ENHANCE_TARGETS
+
+    def test_repeated_flag(self) -> None:
+        """``--targets claude-md --targets subagents`` → both, in canonical order."""
+        assert cli._resolve_enhance_targets(["claude-md", "subagents"]) == (
+            "claude-md",
+            "subagents",
+        )
+
+    def test_comma_separated(self) -> None:
+        """``--targets claude-md,subagents`` → both, in canonical order."""
+        assert cli._resolve_enhance_targets(["claude-md,subagents"]) == (
+            "claude-md",
+            "subagents",
+        )
+
+    def test_canonical_ordering(self) -> None:
+        """Order in input is irrelevant; canonical order wins."""
+        assert cli._resolve_enhance_targets(["subagents", "claude-md"]) == (
+            "claude-md",
+            "subagents",
+        )
+
+    def test_deduplicates(self) -> None:
+        """Duplicate targets are squashed."""
+        assert cli._resolve_enhance_targets(["claude-md", "claude-md,claude-md"]) == (
+            "claude-md",
+        )
+
+    def test_unknown_target_raises(self) -> None:
+        """An unknown target surfaces a typer.BadParameter."""
+        with pytest.raises(typer.BadParameter, match="unknown target"):
+            cli._resolve_enhance_targets(["bogus"])
+
+
+class TestEnhanceCommand:
+    """End-to-end CLI tests for the new ``enhance`` command."""
+
+    @staticmethod
+    def _flat(text: str) -> str:
+        """Collapse whitespace so substring checks survive Rich line-wrapping."""
+        return " ".join(text.split())
+
+    @staticmethod
+    def _make_project(tmp_path: Path, *, name: str, language: str) -> Path:
+        """Build a minimal green-init-shaped directory layout."""
+        project = tmp_path / name
+        project.mkdir()
+        (project / "CLAUDE.md").write_text(
+            f"# Claude Code Project Context: {name}\n\nbaseline content.\n",
+            encoding="utf-8",
+        )
+        # Drop a marker file so language detection works without flags.
+        if language == "python":
+            (project / "pyproject.toml").write_text("[project]\nname='x'\n")
+        elif language == "typescript":
+            (project / "package.json").write_text("{}")
+        # Pre-create the subagents dir so the writer doesn't have to
+        # mkdir during the test (mirrors real init output).
+        (project / ".claude" / "agents").mkdir(parents=True)
+        return project
+
+    def test_missing_path_exits(self, tmp_path: Path) -> None:
+        """Non-existent path exits 1 with an actionable message."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(tmp_path / "does-not-exist")],
+        )
+        assert result.exit_code == 1
+        assert "does not exist" in self._flat(result.stdout)
+
+    def test_path_is_a_file_exits(self, tmp_path: Path) -> None:
+        """Pointing at a file (not directory) exits 1."""
+        a_file = tmp_path / "looks-like-a-project"
+        a_file.write_text("not a directory")
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["enhance", str(a_file)])
+        assert result.exit_code == 1
+        assert "is not a directory" in self._flat(result.stdout)
+
+    def test_directory_without_claude_md_exits(self, tmp_path: Path) -> None:
+        """Empty directory without CLAUDE.md exits 1 with the actionable hint."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["enhance", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "does not look like a green-init project" in self._flat(result.stdout)
+
+    def test_unknown_target_exits(self, tmp_path: Path) -> None:
+        """``--targets bogus`` exits non-zero before any API call."""
+        project = self._make_project(tmp_path, name="proj", language="python")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--targets", "bogus"],
+        )
+        assert result.exit_code != 0
+        # ``typer.BadParameter`` writes to stderr; CliRunner.output
+        # mixes both streams while .stdout omits stderr.
+        assert "unknown target" in self._flat(result.output)
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_no_api_key_exits_with_actionable_message(
+        self, mock_init: Mock, tmp_path: Path
+    ) -> None:
+        """``enhance`` cannot run without a key — fail loudly, don't no-op."""
+        mock_init.return_value = None  # No key available.
+        project = self._make_project(tmp_path, name="needs-key", language="python")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--no-interactive"],
+        )
+        assert result.exit_code == 1
+        flat = self._flat(result.stdout)
+        assert "requires an Anthropic API key" in flat
+        assert "ANTHROPIC_API_KEY" in flat
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_default_runs_every_target(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """No ``--targets`` flag → both helpers are invoked."""
+        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        project = self._make_project(tmp_path, name="full", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--no-interactive"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        mock_claude.assert_called_once()
+        mock_subagents.assert_called_once()
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_targets_claude_md_skips_subagents(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """``--targets claude-md`` runs only that target."""
+        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        project = self._make_project(tmp_path, name="claude-only", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--targets",
+                "claude-md",
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        mock_claude.assert_called_once()
+        mock_subagents.assert_not_called()
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_dry_run_propagates_to_helpers(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """``--dry-run`` flows through to every target helper."""
+        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        project = self._make_project(tmp_path, name="preview", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--dry-run", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        # Both helpers receive ``dry_run=True``.
+        assert mock_claude.call_args.kwargs["dry_run"] is True
+        assert mock_subagents.call_args.kwargs["dry_run"] is True
+        assert "Dry run complete" in result.stdout
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_explicit_overrides_skip_detection(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """``-n`` and ``-l`` win over auto-detection from the project."""
+        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # Make the project look like Python + name="auto-name", but
+        # override both at the CLI.
+        project = self._make_project(tmp_path, name="auto-name", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--project-name",
+                "explicit-name",
+                "--language",
+                "typescript",
+                "--targets",
+                "claude-md",
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        # The helper was called with the *explicit* values, not the
+        # auto-detected ones.
+        call = mock_claude.call_args
+        # positional args: (project_path, project_name, language, orchestrator)
+        assert call.args[1] == "explicit-name"
+        assert call.args[2] == "typescript"
+
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_unknown_language_in_override_exits(
+        self, mock_init: Mock, tmp_path: Path
+    ) -> None:
+        """``-l cobol`` is rejected before any API call."""
+        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        project = self._make_project(tmp_path, name="bad-lang", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--language",
+                "cobol",
+                "--no-interactive",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Unsupported language" in self._flat(result.stdout)


### PR DESCRIPTION
## Summary

This is the second slice of **Phase 3 of the optimization roadmap**.
Phase 3a (PR #308) added `--offline` / `--no-enhance` flags to
`green init` and renamed the AI-tunable step group to
`_generate_pass2_polish`. Phase 3b ships the standalone `green
enhance` command that re-runs that Pass 2 against an existing
project — typically one initialised with `--offline` or
`--no-enhance`.

The `.claude/.enhance-state.json` resume file with source-hash
skip-logic is split into a separate slice, **Phase 3c**, since it
is independently valuable (idempotent re-tunes) and would double
the diff here.

## What landed

### New CLI command

```
green enhance [PATH] [--targets …] [--dry-run] [-n NAME] [-l LANG]
              [--api-key KEY] [--no-interactive] [--force]
```

- **Validation** — `_validate_enhance_path` requires the target to
  be a directory containing a `CLAUDE.md` (every green-init flow
  writes one since Phase 1). Failure exits 1 with an actionable
  "run `green init` first" message.
- **Auto-detection** — `_detect_project_name` parses the
  `# Claude Code Project Context: <name>` H1; `_detect_project_language`
  probes for canonical marker files (`pyproject.toml`,
  `package.json`, `go.mod`, `Cargo.toml`, `pom.xml`, `build.gradle`,
  `Gemfile`, `composer.json`, `Package.swift`). `-n` and `-l` are
  explicit overrides.
- **Targets** — `--targets` is repeatable AND comma-separable.
  Default is "every target" (`claude-md` + `subagents`). Unknown
  targets exit non-zero before any API call.
- **API key required** — unlike `init`, `enhance` has no
  deterministic fallback. Exits 1 with "set ANTHROPIC_API_KEY" if
  no key resolves.
- **--dry-run** runs the API calls and prints the byte counts /
  agent counts that would be written, but skips the writes. Useful
  for previewing token cost.

### Internal reuse

`_enhance_claude_md` and `_enhance_subagents` mirror the Pass 2
init steps but write back to the existing project rather than a
fresh scaffold. Subagents are still tuned in parallel via
`asyncio.gather` + `Semaphore` (Phase 2), wrapped in
`_run_with_orchestrator_close` so the `AsyncAnthropic` pool is
released even if a tuning raises mid-flight.

Cyclomatic complexity stays grade A across the new code via:

- `_resolve_enhance_targets` + `_split_target_pieces`
- `_resolve_enhance_metadata` decomposed into
  `_resolve_enhance_name` + `_resolve_enhance_language`
- `_require_enhance_orchestrator`

## Tests

23 new tests across three classes in `tests/unit/test_cli_mocked.py`:

- `TestEnhanceDetectionHelpers` (6) — H1 parsing happy + miss cases;
  language probe for python / typescript / unknown.
- `TestEnhanceTargetResolution` (7) — default-all, comma-separated,
  repeated flag, canonical ordering, deduplication, unknown-target
  rejection.
- `TestEnhanceCommand` (10) — missing path, path-is-file, no
  CLAUDE.md, unknown target, no API key (actionable message),
  default runs every target, `--targets claude-md` filter,
  `--dry-run` propagation, explicit `-n` / `-l` overrides skip
  detection, unsupported language override rejected.

A `_flat` helper collapses whitespace in CLI output so Rich's
terminal-width line-wrap doesn't flake substring assertions.

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck,
  security, complexity).
- 1652 unit + integration tests pass (23 new for `enhance`).
- Smoke-tested end to end:
  - `green init --offline -n smoke -l python --output-dir /tmp/x` →
    produces a complete project.
  - `green enhance /tmp/x/smoke --no-interactive` → exits 1 with
    the "set ANTHROPIC_API_KEY" message.
  - `green enhance --help` → renders the full command surface.

## Test plan

- [ ] CI green on this PR.
- [ ] Smoke: `green enhance` (no path) on a CWD with CLAUDE.md and
      a real API key tunes both targets and reports byte counts.
- [ ] `green enhance --dry-run` runs the API calls and prints byte
      counts but writes no files.
- [ ] `green enhance --targets claude-md` skips subagents.
- [ ] `green enhance ./empty-dir` exits 1 with "does not look like
      a green-init project".
- [ ] `green enhance ./project --language cobol` exits 1 with
      "Unsupported language".

## Roadmap status

- ✅ Phase 0 (telemetry) — PR #305 (commit `acf4572`).
- ✅ Phase 1 (de-AI generators) — PR #305 (commit `acf4572`).
- ✅ Phase 2 (subagent parallelism) — PR #305 (commit `acf4572`).
- ✅ Phase 3a (two-pass split foundation: flags + rename) — PR #308
  (commit `0986d89`).
- ⏳ **Phase 3b (this PR)** — `green enhance` MVP.
- 🔜 Phase 3c — `.claude/.enhance-state.json` resume +
  source-hash skip-logic. Independently valuable.
- 🔜 Phase 2c, 4, 5, 6 — see roadmap doc.

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_