### PR TITLE
feat(cli): Phase 3c — `.enhance-state.json` resume + source-hash skip logic

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -13,11 +13,14 @@ Shipped:
   `0986d89`.
 - Phase 3b (MVP `green enhance [PATH]` command — re-runs Pass 2 against an
   existing project; `--targets`, `--dry-run`, auto-detection of project
-  name + language) — branch `claude/execute-optimization-roadmap-Fhfnu`.
+  name + language) — PR #309 merged onto main as commit `f0793e7`.
+- Phase 3c (`.claude/.enhance-state.json` resume + per-target source-hash
+  skip logic; `--force` bypasses the skip; `green enhance` is now
+  idempotent — re-running on a project with no input changes is a fast
+  no-op) — branch `claude/execute-optimization-roadmap-Fhfnu`.
 
-Remaining: prompt caching + `tool_use` parsing (2c), `.enhance-state.json`
-resume + source-hash skip-logic (3c — splits the rest of Phase 3 from the
-roadmap), prompt cleanup (4), batch mode (5), UX/docs (6).
+Remaining: prompt caching + `tool_use` parsing (2c), prompt cleanup (4),
+batch mode (5), UX/docs (6).
 
 ---
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1945,6 +1945,43 @@ def _require_enhance_orchestrator(
     return orchestrator
 
 
+# Single source of truth for the script list embedded in the
+# CLAUDE.md prompt. Defined ahead of the helpers that read it so
+# the dependency direction is obvious to a reader scanning the file
+# top-to-bottom (Python's late binding makes any order legal, but
+# top-down readability is worth the four lines of motion).
+_CLAUDE_MD_SCRIPTS: tuple[str, ...] = (
+    "check-all.sh",
+    "test.sh",
+    "lint.sh",
+    "format.sh",
+    "security.sh",
+    "mutation.sh",
+)
+
+
+def _read_reference_or_warn(path: Path, label: str) -> str:
+    """Read a reference file or print a dim warning and return ``""``.
+
+    The hash helpers must remain crash-free even on a broken install
+    (missing submodule, moved file, etc.) — see Phase 3c reviewer
+    note. But silent fallback to an empty string would let the empty
+    hash get persisted, after which every subsequent re-tune skips
+    permanently with no user-visible signal. Print a warning so the
+    user can spot the broken install while still preserving the
+    no-crash contract.
+    """
+    if path.is_file():
+        return path.read_text(encoding="utf-8")
+    console.print(
+        f"[yellow]warning:[/yellow] reference file missing — "
+        f"{label}: {path}\n"
+        f"  This will produce an empty-input hash and may suppress "
+        f"future re-tunes. Check your install."
+    )
+    return ""
+
+
 def _hash_claude_md_inputs(project_name: str, language: str) -> str:
     """Hash the inputs that drive a ``CLAUDE.md`` re-tune.
 
@@ -1955,9 +1992,7 @@ def _hash_claude_md_inputs(project_name: str, language: str) -> str:
     """
     project_root = Path(__file__).parent.parent
     reference = project_root / "reference" / "claude" / "CLAUDE.md"
-    template_bytes = (
-        reference.read_text(encoding="utf-8") if reference.is_file() else ""
-    )
+    template_bytes = _read_reference_or_warn(reference, "CLAUDE.md template")
     return hash_inputs(
         [
             "claude-md\x00",
@@ -1988,24 +2023,10 @@ def _hash_subagents_inputs(project_name: str, language: str) -> str:
     # deterministic regardless of dict insertion-order quirks.
     for agent_name, source_file in REQUIRED_AGENTS.items():
         source_path = REFERENCE_AGENTS_DIR / source_file
-        body = source_path.read_text(encoding="utf-8") if source_path.is_file() else ""
+        body = _read_reference_or_warn(source_path, f"subagent '{agent_name}'")
         parts.append(f"agent={agent_name}\x00")
         parts.append(body)
     return hash_inputs(parts)
-
-
-# Single source of truth for the script list embedded in the
-# CLAUDE.md prompt. Kept here (not duplicated in
-# ``_enhance_claude_md``) so the hash stays in sync with the actual
-# input.
-_CLAUDE_MD_SCRIPTS: tuple[str, ...] = (
-    "check-all.sh",
-    "test.sh",
-    "lint.sh",
-    "format.sh",
-    "security.sh",
-    "mutation.sh",
-)
 
 
 def _compute_target_source_hash(
@@ -2177,6 +2198,30 @@ _ENHANCE_DISPATCH: dict[str, tuple[str, str]] = {
         "_enhance_subagents",
     ),
 }
+
+
+def _assert_enhance_dispatch_intact() -> None:
+    """Fail at import time if a dispatch entry references a missing helper.
+
+    The dispatch table looks helpers up by *name* (so test ``patch``
+    decorators can intercept), which trades static-analysis safety
+    for late-binding flexibility. This guard rebuilds the missing
+    safety net at import time so a typo in ``_ENHANCE_DISPATCH`` is
+    caught as soon as the module loads, not at first ``green
+    enhance`` invocation.
+    """
+    missing = [
+        name for _msg, name in _ENHANCE_DISPATCH.values() if name not in globals()
+    ]
+    if missing:
+        msg = (
+            f"_ENHANCE_DISPATCH references undefined helper(s): "
+            f"{', '.join(missing)}"
+        )
+        raise RuntimeError(msg)
+
+
+_assert_enhance_dispatch_intact()
 
 
 def _dispatch_enhance_targets(  # noqa: PLR0913 — orchestration glue

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -6,6 +6,7 @@ Implements the command-line interface using Typer with rich output formatting.
 from __future__ import annotations
 
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
 import json
@@ -638,7 +639,7 @@ def _copy_reference_subagents(
 @contextmanager
 def _maybe_collect_timing(
     timing_json: Path | None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Optionally install a :class:`TimingReport` for the wrapped block.
 
     When ``timing_json`` is ``None`` the manager is a no-op; otherwise a
@@ -1945,11 +1946,7 @@ def _require_enhance_orchestrator(
     return orchestrator
 
 
-# Single source of truth for the script list embedded in the
-# CLAUDE.md prompt. Defined ahead of the helpers that read it so
-# the dependency direction is obvious to a reader scanning the file
-# top-to-bottom (Python's late binding makes any order legal, but
-# top-down readability is worth the four lines of motion).
+# Single source of truth for the script list embedded in the CLAUDE.md prompt.
 _CLAUDE_MD_SCRIPTS: tuple[str, ...] = (
     "check-all.sh",
     "test.sh",
@@ -1998,7 +1995,8 @@ def _hash_claude_md_inputs(project_name: str, language: str) -> str:
             "claude-md\x00",
             f"project_name={project_name}\x00",
             f"language={language}\x00",
-            f"scripts={','.join(sorted(_CLAUDE_MD_SCRIPTS))}\x00",
+            # Declaration order is authoritative — same order the prompt sees.
+            f"scripts={','.join(_CLAUDE_MD_SCRIPTS)}\x00",
             f"skills={','.join(sorted(REQUIRED_SKILLS))}\x00",
             "template:\x00",
             template_bytes,
@@ -2034,13 +2032,13 @@ def _compute_target_source_hash(
     project_name: str,
     language: str,
 ) -> str:
-    """Dispatch to the per-target hash function."""
-    if target == "claude-md":
-        return _hash_claude_md_inputs(project_name, language)
-    if target == "subagents":
-        return _hash_subagents_inputs(project_name, language)
-    msg = f"unknown target: {target}"
-    raise ValueError(msg)
+    """Look the target up in the registry and call its hash helper."""
+    spec = _ENHANCE_DISPATCH.get(target)
+    if spec is None:
+        msg = f"unknown target: {target}"
+        raise ValueError(msg)
+    hash_helper: Callable[[str, str], str] = globals()[spec.hash_helper_name]
+    return hash_helper(project_name, language)
 
 
 def _enhance_claude_md(  # noqa: PLR0913 — Pass 2 helpers mirror init steps
@@ -2179,23 +2177,40 @@ def _resolve_enhance_metadata(
     )
 
 
-# Map from target name → (skip-message, name-of-helper-on-this-module).
-# Storing the helper *name* (rather than the function reference) lets
-# tests patch ``cli._enhance_claude_md`` / ``cli._enhance_subagents``
-# at the module attribute level and have the dispatcher pick up the
-# patched version at call time. Python's late binding via
-# ``globals()[name]`` is the simplest way to achieve that without
-# adding a registry layer.
-_ENHANCE_DISPATCH: dict[str, tuple[str, str]] = {
-    "claude-md": (
-        "[dim]CLAUDE.md unchanged since last successful tune — "
-        "skipping (use --force to re-tune anyway).[/dim]",
-        "_enhance_claude_md",
+@dataclass(frozen=True)
+class _EnhanceTargetSpec:
+    """Per-target wiring for ``green enhance``.
+
+    Single source of truth pairing the skip message, the tune helper,
+    and the source-hash helper for one target. Holding all three in
+    one record means a new target requires exactly one entry in
+    :data:`_ENHANCE_DISPATCH` — there is no separate hash table to
+    forget to update. Helpers are stored by *name* (not function
+    reference) so test ``patch("cli._enhance_…")`` decorations are
+    honoured at call time via ``globals()[name]``.
+    """
+
+    skip_message: str
+    helper_name: str
+    hash_helper_name: str
+
+
+_ENHANCE_DISPATCH: dict[str, _EnhanceTargetSpec] = {
+    "claude-md": _EnhanceTargetSpec(
+        skip_message=(
+            "[dim]CLAUDE.md unchanged since last successful tune — "
+            "skipping (use --force to re-tune anyway).[/dim]"
+        ),
+        helper_name="_enhance_claude_md",
+        hash_helper_name="_hash_claude_md_inputs",
     ),
-    "subagents": (
-        "[dim]Subagents unchanged since last successful tune — "
-        "skipping (use --force to re-tune anyway).[/dim]",
-        "_enhance_subagents",
+    "subagents": _EnhanceTargetSpec(
+        skip_message=(
+            "[dim]Subagents unchanged since last successful tune — "
+            "skipping (use --force to re-tune anyway).[/dim]"
+        ),
+        helper_name="_enhance_subagents",
+        hash_helper_name="_hash_subagents_inputs",
     ),
 }
 
@@ -2203,15 +2218,18 @@ _ENHANCE_DISPATCH: dict[str, tuple[str, str]] = {
 def _assert_enhance_dispatch_intact() -> None:
     """Fail at import time if a dispatch entry references a missing helper.
 
-    The dispatch table looks helpers up by *name* (so test ``patch``
+    The registry looks helpers up by *name* (so test ``patch``
     decorators can intercept), which trades static-analysis safety
     for late-binding flexibility. This guard rebuilds the missing
-    safety net at import time so a typo in ``_ENHANCE_DISPATCH`` is
-    caught as soon as the module loads, not at first ``green
-    enhance`` invocation.
+    safety net at import time so a typo in either ``helper_name`` or
+    ``hash_helper_name`` is caught as soon as the module loads, not
+    at first ``green enhance`` invocation.
     """
-    missing = [
-        name for _msg, name in _ENHANCE_DISPATCH.values() if name not in globals()
+    missing: list[str] = [
+        name
+        for spec in _ENHANCE_DISPATCH.values()
+        for name in (spec.helper_name, spec.hash_helper_name)
+        if name not in globals()
     ]
     if missing:
         msg = (
@@ -2245,15 +2263,15 @@ def _dispatch_enhance_targets(  # noqa: PLR0913 — orchestration glue
     """
     skipped: list[str] = []
     for target in targets:
-        skip_message, helper_name = _ENHANCE_DISPATCH[target]
+        spec = _ENHANCE_DISPATCH[target]
         target_hash = target_hashes[target]
         if not force and state.is_unchanged(target, target_hash):
-            console.print(skip_message)
+            console.print(spec.skip_message)
             skipped.append(target)
             continue
         # Late-bound lookup so test ``patch("cli._enhance_claude_md")``
         # decorations are honoured.
-        helper: Callable[..., None] = globals()[helper_name]
+        helper: Callable[..., None] = globals()[spec.helper_name]
         helper(
             project_path,
             project_name,
@@ -2284,7 +2302,7 @@ def _persist_enhance_state(
     """
     if dry_run:
         return
-    if len(skipped) >= len(selected_targets):
+    if len(skipped) == len(selected_targets):
         return
     save_state(project_path, state)
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -21,9 +21,12 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Coroutine
     from collections.abc import Generator
     from collections.abc import Sequence
+
+    from start_green_stay_green.utils.enhance_state import EnhanceState
 
 from rich.console import Console
 from rich.panel import Panel
@@ -63,6 +66,9 @@ from start_green_stay_green.generators.tests_gen import TestsGenerator
 from start_green_stay_green.utils.async_bridge import run_async
 from start_green_stay_green.utils.credentials import get_api_key_from_keyring
 from start_green_stay_green.utils.credentials import store_api_key_in_keyring
+from start_green_stay_green.utils.enhance_state import hash_inputs
+from start_green_stay_green.utils.enhance_state import load_state
+from start_green_stay_green.utils.enhance_state import save_state
 from start_green_stay_green.utils.file_writer import FileWriter
 from start_green_stay_green.utils.timing import TimingReport
 from start_green_stay_green.utils.timing import set_active_report
@@ -1939,6 +1945,83 @@ def _require_enhance_orchestrator(
     return orchestrator
 
 
+def _hash_claude_md_inputs(project_name: str, language: str) -> str:
+    """Hash the inputs that drive a ``CLAUDE.md`` re-tune.
+
+    Captures everything that would alter the model's output: the
+    reference template content (so updates to the canonical template
+    invalidate stale tunes), plus the project metadata (name +
+    language + the script and skill lists baked into the prompt).
+    """
+    project_root = Path(__file__).parent.parent
+    reference = project_root / "reference" / "claude" / "CLAUDE.md"
+    template_bytes = (
+        reference.read_text(encoding="utf-8") if reference.is_file() else ""
+    )
+    return hash_inputs(
+        [
+            "claude-md\x00",
+            f"project_name={project_name}\x00",
+            f"language={language}\x00",
+            f"scripts={','.join(sorted(_CLAUDE_MD_SCRIPTS))}\x00",
+            f"skills={','.join(sorted(REQUIRED_SKILLS))}\x00",
+            "template:\x00",
+            template_bytes,
+        ]
+    )
+
+
+def _hash_subagents_inputs(project_name: str, language: str) -> str:
+    """Hash the inputs that drive a subagents re-tune.
+
+    Captures the union of every required reference subagent's content
+    (so a maintainer-side update to any one of them invalidates the
+    cached tune) plus the target context (project name + language)
+    which flows verbatim into the prompt.
+    """
+    parts: list[str | bytes] = [
+        "subagents\x00",
+        f"project_name={project_name}\x00",
+        f"language={language}\x00",
+    ]
+    # Walk REQUIRED_AGENTS in declaration order so the hash is
+    # deterministic regardless of dict insertion-order quirks.
+    for agent_name, source_file in REQUIRED_AGENTS.items():
+        source_path = REFERENCE_AGENTS_DIR / source_file
+        body = source_path.read_text(encoding="utf-8") if source_path.is_file() else ""
+        parts.append(f"agent={agent_name}\x00")
+        parts.append(body)
+    return hash_inputs(parts)
+
+
+# Single source of truth for the script list embedded in the
+# CLAUDE.md prompt. Kept here (not duplicated in
+# ``_enhance_claude_md``) so the hash stays in sync with the actual
+# input.
+_CLAUDE_MD_SCRIPTS: tuple[str, ...] = (
+    "check-all.sh",
+    "test.sh",
+    "lint.sh",
+    "format.sh",
+    "security.sh",
+    "mutation.sh",
+)
+
+
+def _compute_target_source_hash(
+    target: str,
+    project_name: str,
+    language: str,
+) -> str:
+    """Dispatch to the per-target hash function."""
+    if target == "claude-md":
+        return _hash_claude_md_inputs(project_name, language)
+    if target == "subagents":
+        return _hash_subagents_inputs(project_name, language)
+    msg = f"unknown target: {target}"
+    raise ValueError(msg)
+
+
 def _enhance_claude_md(  # noqa: PLR0913 — Pass 2 helpers mirror init steps
     project_path: Path,
     project_name: str,
@@ -1961,14 +2044,7 @@ def _enhance_claude_md(  # noqa: PLR0913 — Pass 2 helpers mirror init steps
             {
                 "project_name": project_name,
                 "language": language,
-                "scripts": [
-                    "check-all.sh",
-                    "test.sh",
-                    "lint.sh",
-                    "format.sh",
-                    "security.sh",
-                    "mutation.sh",
-                ],
+                "scripts": list(_CLAUDE_MD_SCRIPTS),
                 "skills": REQUIRED_SKILLS.copy(),
             }
         )
@@ -2080,6 +2156,144 @@ def _resolve_enhance_metadata(
         _resolve_enhance_name(project_path, project_name),
         _resolve_enhance_language(project_path, language),
     )
+
+
+# Map from target name → (skip-message, name-of-helper-on-this-module).
+# Storing the helper *name* (rather than the function reference) lets
+# tests patch ``cli._enhance_claude_md`` / ``cli._enhance_subagents``
+# at the module attribute level and have the dispatcher pick up the
+# patched version at call time. Python's late binding via
+# ``globals()[name]`` is the simplest way to achieve that without
+# adding a registry layer.
+_ENHANCE_DISPATCH: dict[str, tuple[str, str]] = {
+    "claude-md": (
+        "[dim]CLAUDE.md unchanged since last successful tune — "
+        "skipping (use --force to re-tune anyway).[/dim]",
+        "_enhance_claude_md",
+    ),
+    "subagents": (
+        "[dim]Subagents unchanged since last successful tune — "
+        "skipping (use --force to re-tune anyway).[/dim]",
+        "_enhance_subagents",
+    ),
+}
+
+
+def _dispatch_enhance_targets(  # noqa: PLR0913 — orchestration glue
+    targets: tuple[str, ...],
+    *,
+    project_path: Path,
+    project_name: str,
+    language: str,
+    orchestrator: AIOrchestrator,
+    state: EnhanceState,
+    target_hashes: dict[str, str],
+    dry_run: bool,
+    force: bool,
+    file_writer: FileWriter | None,
+) -> list[str]:
+    """Drive Pass 2 across each selected target with the skip/force logic.
+
+    Returns the list of target names that were skipped because the
+    source hash matched a stored completion. The caller uses that to
+    decide whether the state file is worth re-writing.
+    """
+    skipped: list[str] = []
+    for target in targets:
+        skip_message, helper_name = _ENHANCE_DISPATCH[target]
+        target_hash = target_hashes[target]
+        if not force and state.is_unchanged(target, target_hash):
+            console.print(skip_message)
+            skipped.append(target)
+            continue
+        # Late-bound lookup so test ``patch("cli._enhance_claude_md")``
+        # decorations are honoured.
+        helper: Callable[..., None] = globals()[helper_name]
+        helper(
+            project_path,
+            project_name,
+            language,
+            orchestrator,
+            dry_run=dry_run,
+            file_writer=file_writer,
+        )
+        if not dry_run:
+            state.mark_completed(target, target_hash, orchestrator.model)
+    return skipped
+
+
+def _persist_enhance_state(
+    project_path: Path,
+    state: EnhanceState,
+    *,
+    skipped: list[str],
+    selected_targets: tuple[str, ...],
+    dry_run: bool,
+) -> None:
+    """Save the state file unless this run wrote nothing.
+
+    A "nothing happened" run is either a ``--dry-run`` (we ran the
+    API calls but skipped the writes) or a run where every selected
+    target was skipped because its source hash matched. In both
+    cases the prior state on disk is still authoritative.
+    """
+    if dry_run:
+        return
+    if len(skipped) >= len(selected_targets):
+        return
+    save_state(project_path, state)
+
+
+def _print_enhance_summary(*, project_name: str, dry_run: bool) -> None:
+    """Print the closing one-liner for an ``enhance`` invocation."""
+    if dry_run:
+        console.print("\n[green]✓[/green] Dry run complete — no files written.")
+    else:
+        console.print(f"\n[green]✓[/green] Enhancement complete: {project_name}")
+
+
+def _run_enhance_pipeline(  # noqa: PLR0913 — orchestration glue
+    *,
+    project_path: Path,
+    project_name: str,
+    language: str,
+    selected_targets: tuple[str, ...],
+    orchestrator: AIOrchestrator,
+    file_writer: FileWriter | None,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    """Execute the full Pass 2 pipeline + persist state on success."""
+    console.print(
+        f"[dim]Enhancing project: {project_name} ({language})"
+        f"  →  targets: {', '.join(selected_targets)}"
+        f"{'  [DRY RUN]' if dry_run else ''}[/dim]"
+    )
+    state = load_state(project_path)
+    target_hashes = {
+        target: _compute_target_source_hash(target, project_name, language)
+        for target in selected_targets
+    }
+    skipped = _dispatch_enhance_targets(
+        selected_targets,
+        project_path=project_path,
+        project_name=project_name,
+        language=language,
+        orchestrator=orchestrator,
+        state=state,
+        target_hashes=target_hashes,
+        dry_run=dry_run,
+        force=force,
+        file_writer=file_writer,
+    )
+    _persist_enhance_state(
+        project_path,
+        state,
+        skipped=skipped,
+        selected_targets=selected_targets,
+        dry_run=dry_run,
+    )
+    _print_enhance_summary(project_name=project_name, dry_run=dry_run)
 
 
 def _validate_enhance_path(project_path: Path) -> None:
@@ -2252,7 +2466,6 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
 
     selected_targets = _resolve_enhance_targets(targets)
     orchestrator = _require_enhance_orchestrator(api_key, no_interactive=no_interactive)
-
     file_writer = FileWriter(
         project_root=project_path,
         force=force,
@@ -2260,35 +2473,16 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         console=console,
     )
 
-    console.print(
-        f"[dim]Enhancing project: {resolved_name} ({resolved_language})"
-        f"  →  targets: {', '.join(selected_targets)}"
-        f"{'  [DRY RUN]' if dry_run else ''}[/dim]"
+    _run_enhance_pipeline(
+        project_path=project_path,
+        project_name=resolved_name,
+        language=resolved_language,
+        selected_targets=selected_targets,
+        orchestrator=orchestrator,
+        file_writer=file_writer,
+        dry_run=dry_run,
+        force=force,
     )
-
-    if "claude-md" in selected_targets:
-        _enhance_claude_md(
-            project_path,
-            resolved_name,
-            resolved_language,
-            orchestrator,
-            dry_run=dry_run,
-            file_writer=file_writer,
-        )
-    if "subagents" in selected_targets:
-        _enhance_subagents(
-            project_path,
-            resolved_name,
-            resolved_language,
-            orchestrator,
-            dry_run=dry_run,
-            file_writer=file_writer,
-        )
-
-    if dry_run:
-        console.print("\n[green]✓[/green] Dry run complete — no files written.")
-    else:
-        console.print(f"\n[green]✓[/green] Enhancement complete: {resolved_name}")
 
 
 def cli_main() -> None:

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -1,0 +1,271 @@
+"""State tracking for the ``green enhance`` resume / skip-unchanged path.
+
+Phase 3c of the optimization roadmap: persists per-target source
+hashes after a successful tune so a follow-up ``green enhance`` on a
+project whose inputs have not changed becomes a fast no-op. Eliminates
+the cost of re-tuning artifacts that would land identical content.
+
+The state lives at ``<project>/.claude/.enhance-state.json``. The
+schema is intentionally minimal — every field is necessary for either
+skip-decision making or for diagnosing why a stored hash mismatched.
+
+Schema (JSON):
+
+    {
+      "version": 1,
+      "last_run": "2026-05-06T07:00:00+00:00",
+      "completed": {
+        "claude-md": {
+          "hash": "sha256:abc…",
+          "model": "claude-sonnet-…",
+          "timestamp": "2026-05-06T07:00:00+00:00"
+        },
+        "subagents": { ... }
+      }
+    }
+
+Forward-compat: callers must tolerate unknown ``completed`` keys (a
+future Phase 4 might add ``skills``) and unknown top-level keys.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import UTC
+from datetime import datetime
+import hashlib
+import json
+from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+# Stored on every state file. Bump only when an existing reader would
+# misinterpret the new schema; additive fields are not breaking.
+STATE_FILE_VERSION = 1
+
+# Path within a green-init project where the state file lives. Keeping
+# it under ``.claude/`` matches the existing convention for tool
+# scratch state and keeps a future ``.gitignore`` rule narrow.
+STATE_FILE_RELATIVE = ".claude/.enhance-state.json"
+
+
+@dataclass(frozen=True)
+class TargetCompletion:
+    """Completion record for a single ``green enhance`` target.
+
+    Attributes:
+        hash: Hex-encoded ``sha256:`` of the source inputs that drove
+            the tune (reference template content + project metadata).
+            A subsequent ``enhance`` run hashes the same inputs and
+            compares — equal hash → skip, different → re-tune.
+        model: Identifier of the Claude model that produced the
+            tune. Stored for diagnostics; not used in skip decisions.
+        timestamp: ISO-8601 UTC timestamp of when this target was
+            last successfully tuned.
+    """
+
+    hash: str
+    model: str
+    timestamp: str
+
+
+@dataclass
+class EnhanceState:
+    """Persistent state for ``green enhance``.
+
+    Attributes:
+        version: Schema version. Always equal to
+            :data:`STATE_FILE_VERSION` on round-trip.
+        last_run: ISO-8601 UTC timestamp of the most recent
+            ``enhance`` invocation that wrote this file.
+        completed: Map from target name (e.g. ``"claude-md"``,
+            ``"subagents"``) to its :class:`TargetCompletion` record.
+    """
+
+    version: int = STATE_FILE_VERSION
+    last_run: str = ""
+    completed: dict[str, TargetCompletion] = field(default_factory=dict)
+
+    def is_unchanged(self, target: str, current_hash: str) -> bool:
+        """Return ``True`` if ``target`` was last tuned at ``current_hash``.
+
+        A missing target (never tuned) returns ``False`` — the caller
+        should run the tune.
+
+        Args:
+            target: Target name (matches the keys of
+                ``completed``).
+            current_hash: Hash of the inputs that *would* drive a
+                fresh tune, for comparison against the stored hash.
+
+        Returns:
+            ``True`` only if a stored completion exists *and* its
+            hash equals ``current_hash``.
+        """
+        record = self.completed.get(target)
+        return record is not None and record.hash == current_hash
+
+    def mark_completed(self, target: str, source_hash: str, model: str) -> None:
+        """Record a successful tune of ``target``.
+
+        Args:
+            target: Target name.
+            source_hash: Hash of the inputs that produced this run's
+                output (what we'll compare against next time).
+            model: Model identifier (e.g. ``ModelConfig.SONNET``).
+        """
+        timestamp = datetime.now(UTC).isoformat()
+        self.completed[target] = TargetCompletion(
+            hash=source_hash,
+            model=model,
+            timestamp=timestamp,
+        )
+        self.last_run = timestamp
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly mapping."""
+        return {
+            "version": self.version,
+            "last_run": self.last_run,
+            "completed": {
+                target: {
+                    "hash": rec.hash,
+                    "model": rec.model,
+                    "timestamp": rec.timestamp,
+                }
+                for target, rec in self.completed.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> EnhanceState:
+        """Build a state instance from a previously-serialised mapping.
+
+        Tolerant of unknown ``completed`` keys (forward-compat with
+        future targets) and missing optional keys; skips records that
+        are malformed rather than aborting the whole load — a stale
+        record is no worse than a missing one (worst case the caller
+        re-tunes the target).
+        """
+        return cls(
+            version=int(
+                payload.get("version", STATE_FILE_VERSION) or STATE_FILE_VERSION
+            ),
+            last_run=str(payload.get("last_run", "") or ""),
+            completed=_parse_completed_records(payload.get("completed")),
+        )
+
+
+def _valid_hash(raw: object) -> str | None:
+    """Return ``raw`` if it is a non-empty string, else ``None``."""
+    if isinstance(raw, str) and raw:
+        return raw
+    return None
+
+
+def _parse_record(raw: object) -> TargetCompletion | None:
+    """Validate and build a single ``TargetCompletion`` from a stored payload.
+
+    Returns ``None`` for malformed input so the caller can drop the
+    record instead of aborting the whole load.
+    """
+    if not isinstance(raw, dict):
+        return None
+    hash_value = _valid_hash(raw.get("hash"))
+    if hash_value is None:
+        return None
+    return TargetCompletion(
+        hash=hash_value,
+        model=str(raw.get("model", "") or ""),
+        timestamp=str(raw.get("timestamp", "") or ""),
+    )
+
+
+def _parse_completed_records(raw: object) -> dict[str, TargetCompletion]:
+    """Parse the ``completed`` map, dropping any malformed entries."""
+    if not isinstance(raw, dict):
+        return {}
+    completed: dict[str, TargetCompletion] = {}
+    for name, payload in raw.items():
+        record = _parse_record(payload)
+        if record is not None:
+            completed[str(name)] = record
+    return completed
+
+
+def state_path_for(project_path: Path) -> Path:
+    """Return the canonical state-file path for a project."""
+    return project_path / STATE_FILE_RELATIVE
+
+
+def load_state(project_path: Path) -> EnhanceState:
+    """Read the project's ``.enhance-state.json``, or return an empty state.
+
+    A missing file, an unreadable file, or a JSON-shaped file that
+    happens to be malformed all degrade to "empty state" rather than
+    aborting the run. The worst-case outcome is a redundant re-tune,
+    which is exactly the pre-Phase-3c behaviour and therefore safe.
+
+    Args:
+        project_path: Project root.
+
+    Returns:
+        Either the parsed state or a default-constructed empty one.
+    """
+    path = state_path_for(project_path)
+    if not path.is_file():
+        return EnhanceState()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return EnhanceState()
+    if not isinstance(payload, dict):
+        return EnhanceState()
+    return EnhanceState.from_dict(payload)
+
+
+def save_state(project_path: Path, state: EnhanceState) -> None:
+    """Persist ``state`` to ``<project>/.claude/.enhance-state.json``.
+
+    Creates the parent directory if absent. Writes UTF-8 with
+    ``sort_keys=True`` so the file diffs cleanly across runs (useful
+    if a user commits the state file even though we recommend
+    ignoring it).
+
+    Args:
+        project_path: Project root.
+        state: The state to write.
+    """
+    path = state_path_for(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(state.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def hash_inputs(parts: Iterable[bytes | str]) -> str:
+    """Hash a sequence of inputs into a stable ``sha256:<hex>`` string.
+
+    Each part is encoded to UTF-8 (if a ``str``) and fed in order
+    into a single SHA-256 digest. Order matters — callers must pass
+    the parts in a deterministic order so re-runs with identical
+    inputs produce the same hash.
+
+    Args:
+        parts: Iterable of bytes or str chunks.
+
+    Returns:
+        The lowercase hex digest prefixed with ``"sha256:"``.
+    """
+    digest = hashlib.sha256()
+    for part in parts:
+        if isinstance(part, str):
+            digest.update(part.encode("utf-8"))
+        else:
+            digest.update(part)
+    return f"sha256:{digest.hexdigest()}"

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -44,6 +44,21 @@ from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 from start_green_stay_green.utils.enhance_state import load_state
 
 
+def _make_orch_mock(mock_init: Mock) -> MagicMock:
+    """Build an ``AIOrchestrator`` mock with ``.model`` populated.
+
+    ``MagicMock(spec=AIOrchestrator)`` does not auto-populate the
+    instance attributes set in ``__init__``, so the Phase 3c
+    ``state.mark_completed(..., orchestrator.model)`` path fails
+    without a value here. Wires the mock onto ``mock_init`` and
+    returns it for callers that need to set further attributes.
+    """
+    orch = MagicMock(spec=AIOrchestrator)
+    orch.model = "claude-sonnet-4-5"
+    mock_init.return_value = orch
+    return orch
+
+
 class TestVersionCommand:
     """Test version-related functionality."""
 
@@ -1825,14 +1840,7 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """No ``--targets`` flag → both helpers are invoked."""
-        # ``model`` is an instance attribute set in
-        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
-        # not auto-populate instance attrs, so wire it explicitly for
-        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
-        # path.
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path, name="full", language="python")
 
         runner = CliRunner()
@@ -1856,14 +1864,7 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``--targets claude-md`` runs only that target."""
-        # ``model`` is an instance attribute set in
-        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
-        # not auto-populate instance attrs, so wire it explicitly for
-        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
-        # path.
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path, name="claude-only", language="python")
 
         runner = CliRunner()
@@ -1893,14 +1894,7 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``--dry-run`` flows through to every target helper."""
-        # ``model`` is an instance attribute set in
-        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
-        # not auto-populate instance attrs, so wire it explicitly for
-        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
-        # path.
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path, name="preview", language="python")
 
         runner = CliRunner()
@@ -1926,14 +1920,7 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``-n`` and ``-l`` win over auto-detection from the project."""
-        # ``model`` is an instance attribute set in
-        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
-        # not auto-populate instance attrs, so wire it explicitly for
-        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
-        # path.
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         # Make the project look like Python + name="auto-name", but
         # override both at the CLI.
         project = self._make_project(tmp_path, name="auto-name", language="python")
@@ -1967,14 +1954,7 @@ class TestEnhanceCommand:
         self, mock_init: Mock, tmp_path: Path
     ) -> None:
         """``-l cobol`` is rejected before any API call."""
-        # ``model`` is an instance attribute set in
-        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
-        # not auto-populate instance attrs, so wire it explicitly for
-        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
-        # path.
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path, name="bad-lang", language="python")
 
         runner = CliRunner()
@@ -2021,9 +2001,7 @@ class TestEnhanceSkipUnchanged:
         tmp_path: Path,
     ) -> None:
         """First enhance run writes ``.claude/.enhance-state.json`` for both targets."""
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
 
         runner = CliRunner()
@@ -2048,9 +2026,7 @@ class TestEnhanceSkipUnchanged:
         tmp_path: Path,
     ) -> None:
         """Second enhance with no input change skips both target helpers."""
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
 
         runner = CliRunner()
@@ -2083,9 +2059,7 @@ class TestEnhanceSkipUnchanged:
         tmp_path: Path,
     ) -> None:
         """``--force`` re-tunes even when the source hash matches."""
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
 
         runner = CliRunner()
@@ -2136,9 +2110,7 @@ class TestEnhanceSkipUnchanged:
         tmp_path: Path,
     ) -> None:
         """Project name change → CLAUDE.md hash differs → re-tune fires."""
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
 
         runner = CliRunner()
@@ -2173,9 +2145,7 @@ class TestEnhanceSkipUnchanged:
         tmp_path: Path,
     ) -> None:
         """``--dry-run`` runs the helpers but doesn't claim a tune happened."""
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
 
         runner = CliRunner()
@@ -2207,9 +2177,7 @@ class TestEnhanceSkipUnchanged:
         ``last_run`` timestamp or otherwise rewrite the file even
         though no tune actually happened.
         """
-        orch = MagicMock(spec=AIOrchestrator)
-        orch.model = "claude-sonnet-4-5"
-        mock_init.return_value = orch
+        _make_orch_mock(mock_init)
         project = self._make_project(tmp_path)
         runner = CliRunner()
 
@@ -2225,6 +2193,81 @@ class TestEnhanceSkipUnchanged:
         )
         assert result.exit_code == 0
         assert state_file.read_bytes() == seeded_bytes
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_force_dry_run_combo_does_not_persist_state(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """``--force --dry-run`` invokes helpers but leaves state on disk untouched.
+
+        Both flags are independently respected: ``--force`` bypasses
+        the skip so the helpers run; ``--dry-run`` short-circuits
+        ``_persist_enhance_state`` so no write happens.
+        """
+        _make_orch_mock(mock_init)
+        project = self._make_project(tmp_path)
+        runner = CliRunner()
+
+        runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+        state_file = project / ".claude" / ".enhance-state.json"
+        seeded_bytes = state_file.read_bytes()
+        mock_claude.reset_mock()
+        mock_subagents.reset_mock()
+
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--force",
+                "--dry-run",
+                "--no-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+        # ``--force`` ran the helpers…
+        assert mock_claude.call_count == 1
+        assert mock_subagents.call_count == 1
+        # …but ``--dry-run`` left the state file byte-identical.
+        assert state_file.read_bytes() == seeded_bytes
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_persist_skipped_when_every_target_is_skipped(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """A run where every target is skipped never calls ``save_state``.
+
+        Pairs with ``test_unchanged_target_is_skipped`` but asserts
+        the implementation detail directly: no spurious ``last_run``
+        bumps from no-op invocations.
+        """
+        _make_orch_mock(mock_init)
+        project = self._make_project(tmp_path)
+        runner = CliRunner()
+
+        # Seed state (real ``save_state``).
+        runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+
+        # Second run — every target skipped. Patch ``save_state`` only
+        # for this invocation so the seed actually persisted.
+        with patch("start_green_stay_green.cli.save_state") as mock_save:
+            result = runner.invoke(
+                cli.app, ["enhance", str(project), "--no-interactive"]
+            )
+        assert result.exit_code == 0
+        mock_save.assert_not_called()
 
 
 class TestEnhanceSourceHashes:
@@ -2307,19 +2350,28 @@ class TestReferenceFileWarning:
 class TestEnhanceDispatchAssertion:
     """The import-time guard that catches typos in ``_ENHANCE_DISPATCH``."""
 
-    def test_assert_passes_for_current_table(self) -> None:
-        """Sanity: every helper name in the live dispatch resolves."""
-        # Should be a no-op (raises only on broken install).
-        cli._assert_enhance_dispatch_intact()
-
     def test_assert_raises_when_helper_is_undefined(self) -> None:
         """A typo'd helper name in the table is caught at import time."""
+        bogus = cli._EnhanceTargetSpec(
+            skip_message="[dim]nope[/dim]",
+            helper_name="_does_not_exist",
+            hash_helper_name="_hash_claude_md_inputs",
+        )
         with (
-            patch.dict(
-                cli._ENHANCE_DISPATCH,
-                {"bogus": ("[dim]nope[/dim]", "_does_not_exist")},
-                clear=False,
-            ),
+            patch.dict(cli._ENHANCE_DISPATCH, {"bogus": bogus}, clear=False),
+            pytest.raises(RuntimeError, match="undefined helper"),
+        ):
+            cli._assert_enhance_dispatch_intact()
+
+    def test_assert_raises_when_hash_helper_is_undefined(self) -> None:
+        """The guard also catches typos in ``hash_helper_name``."""
+        bogus = cli._EnhanceTargetSpec(
+            skip_message="[dim]nope[/dim]",
+            helper_name="_enhance_claude_md",
+            hash_helper_name="_does_not_exist",
+        )
+        with (
+            patch.dict(cli._ENHANCE_DISPATCH, {"bogus": bogus}, clear=False),
             pytest.raises(RuntimeError, match="undefined helper"),
         ):
             cli._assert_enhance_dispatch_intact()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -2094,7 +2094,14 @@ class TestEnhanceSkipUnchanged:
         mock_claude.reset_mock()
         mock_subagents.reset_mock()
 
-        # --force → skip is bypassed.
+        # Capture the seeded state's last_run timestamp so we can
+        # verify the force run actually rewrites the record (not just
+        # re-invokes the helpers).
+        seeded_state = load_state(project)
+        seeded_last_run = seeded_state.last_run
+        seeded_claude_ts = seeded_state.completed["claude-md"].timestamp
+
+        # --force → skip is bypassed AND state is updated.
         result = runner.invoke(
             cli.app,
             ["enhance", str(project), "--no-interactive", "--force"],
@@ -2102,6 +2109,21 @@ class TestEnhanceSkipUnchanged:
         assert result.exit_code == 0
         assert mock_claude.call_count == 1
         assert mock_subagents.call_count == 1
+
+        # The PR description's claim ("forced re-tunes produce an
+        # idempotent state file") only holds if mark_completed runs
+        # on the force path. Verify by reading the state file after
+        # the force run and asserting both records are present and
+        # carry refreshed timestamps.
+        post_force = load_state(project)
+        assert "claude-md" in post_force.completed
+        assert "subagents" in post_force.completed
+        assert post_force.completed["claude-md"].model == "claude-sonnet-4-5"
+        assert post_force.completed["subagents"].model == "claude-sonnet-4-5"
+        # Timestamps moved forward — rules out the silent "we ran
+        # the helpers but forgot to mark_completed" regression.
+        assert post_force.last_run >= seeded_last_run
+        assert post_force.completed["claude-md"].timestamp >= seeded_claude_ts
 
     @patch("start_green_stay_green.cli._enhance_subagents")
     @patch("start_green_stay_green.cli._enhance_claude_md")
@@ -2169,6 +2191,41 @@ class TestEnhanceSkipUnchanged:
         state_file = project / ".claude" / ".enhance-state.json"
         assert not state_file.exists(), state_file.read_text(encoding="utf-8")
 
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_dry_run_after_seeded_state_leaves_file_untouched(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """A dry run after a real run preserves the existing state file.
+
+        Catches a regression where dry-run logic might bump the
+        ``last_run`` timestamp or otherwise rewrite the file even
+        though no tune actually happened.
+        """
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+        runner = CliRunner()
+
+        # Seed real state.
+        runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+        state_file = project / ".claude" / ".enhance-state.json"
+        seeded_bytes = state_file.read_bytes()
+
+        # Dry run after seeded state — file must be byte-identical.
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--dry-run", "--no-interactive"],
+        )
+        assert result.exit_code == 0
+        assert state_file.read_bytes() == seeded_bytes
+
 
 class TestEnhanceSourceHashes:
     """Hash determinism + sensitivity for the per-target hash helpers."""
@@ -2208,3 +2265,61 @@ class TestEnhanceSourceHashes:
         a = cli._compute_target_source_hash("claude-md", "alpha", "python")
         b = cli._compute_target_source_hash("subagents", "alpha", "python")
         assert a != b
+
+
+class TestReferenceFileWarning:
+    """``_read_reference_or_warn`` returns "" + prints when file missing."""
+
+    def test_missing_file_prints_warning_and_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Broken-install case: missing ref → warning + empty string.
+
+        Regression test for the silent-empty-hash issue: if a
+        reference file vanishes (moved submodule, partial install)
+        the helper must surface that to the user instead of silently
+        baking the empty hash into the state file and permanently
+        suppressing future re-tunes.
+        """
+        missing = tmp_path / "nope.md"
+        with patch("start_green_stay_green.cli.console") as mock_console:
+            result = cli._read_reference_or_warn(missing, "test label")
+
+        assert result == ""
+        mock_console.print.assert_called_once()
+        # The warning names the file label so a user can tell which
+        # of the several refs is broken.
+        printed = mock_console.print.call_args[0][0]
+        assert "test label" in printed
+        assert "missing" in printed.lower()
+
+    def test_present_file_returns_contents_silently(self, tmp_path: Path) -> None:
+        """The happy path stays silent — no warning when the file exists."""
+        path = tmp_path / "ref.md"
+        path.write_text("hello\n", encoding="utf-8")
+        with patch("start_green_stay_green.cli.console") as mock_console:
+            result = cli._read_reference_or_warn(path, "test label")
+
+        assert result == "hello\n"
+        mock_console.print.assert_not_called()
+
+
+class TestEnhanceDispatchAssertion:
+    """The import-time guard that catches typos in ``_ENHANCE_DISPATCH``."""
+
+    def test_assert_passes_for_current_table(self) -> None:
+        """Sanity: every helper name in the live dispatch resolves."""
+        # Should be a no-op (raises only on broken install).
+        cli._assert_enhance_dispatch_intact()
+
+    def test_assert_raises_when_helper_is_undefined(self) -> None:
+        """A typo'd helper name in the table is caught at import time."""
+        with (
+            patch.dict(
+                cli._ENHANCE_DISPATCH,
+                {"bogus": ("[dim]nope[/dim]", "_does_not_exist")},
+                clear=False,
+            ),
+            pytest.raises(RuntimeError, match="undefined helper"),
+        ):
+            cli._assert_enhance_dispatch_intact()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -41,6 +41,7 @@ from start_green_stay_green import cli
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
+from start_green_stay_green.utils.enhance_state import load_state
 
 
 class TestVersionCommand:
@@ -1824,7 +1825,14 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """No ``--targets`` flag → both helpers are invoked."""
-        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # ``model`` is an instance attribute set in
+        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
+        # not auto-populate instance attrs, so wire it explicitly for
+        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
+        # path.
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
         project = self._make_project(tmp_path, name="full", language="python")
 
         runner = CliRunner()
@@ -1848,7 +1856,14 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``--targets claude-md`` runs only that target."""
-        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # ``model`` is an instance attribute set in
+        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
+        # not auto-populate instance attrs, so wire it explicitly for
+        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
+        # path.
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
         project = self._make_project(tmp_path, name="claude-only", language="python")
 
         runner = CliRunner()
@@ -1878,7 +1893,14 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``--dry-run`` flows through to every target helper."""
-        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # ``model`` is an instance attribute set in
+        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
+        # not auto-populate instance attrs, so wire it explicitly for
+        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
+        # path.
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
         project = self._make_project(tmp_path, name="preview", language="python")
 
         runner = CliRunner()
@@ -1904,7 +1926,14 @@ class TestEnhanceCommand:
         tmp_path: Path,
     ) -> None:
         """``-n`` and ``-l`` win over auto-detection from the project."""
-        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # ``model`` is an instance attribute set in
+        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
+        # not auto-populate instance attrs, so wire it explicitly for
+        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
+        # path.
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
         # Make the project look like Python + name="auto-name", but
         # override both at the CLI.
         project = self._make_project(tmp_path, name="auto-name", language="python")
@@ -1938,7 +1967,14 @@ class TestEnhanceCommand:
         self, mock_init: Mock, tmp_path: Path
     ) -> None:
         """``-l cobol`` is rejected before any API call."""
-        mock_init.return_value = MagicMock(spec=AIOrchestrator)
+        # ``model`` is an instance attribute set in
+        # ``AIOrchestrator.__init__`` — ``MagicMock(spec=...)`` does
+        # not auto-populate instance attrs, so wire it explicitly for
+        # Phase 3c's ``state.mark_completed(..., orchestrator.model)``
+        # path.
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
         project = self._make_project(tmp_path, name="bad-lang", language="python")
 
         runner = CliRunner()
@@ -1954,3 +1990,221 @@ class TestEnhanceCommand:
         )
         assert result.exit_code == 1
         assert "Unsupported language" in self._flat(result.stdout)
+
+
+class TestEnhanceSkipUnchanged:
+    """Phase 3c — ``green enhance`` skips targets whose source hash matches state."""
+
+    @staticmethod
+    def _make_project(tmp_path: Path) -> Path:
+        project = tmp_path / "phase-3c-project"
+        project.mkdir()
+        (project / "CLAUDE.md").write_text(
+            "# Claude Code Project Context: phase-3c-project\n", encoding="utf-8"
+        )
+        (project / "pyproject.toml").write_text("[project]\nname='x'\n")
+        (project / ".claude" / "agents").mkdir(parents=True)
+        return project
+
+    @staticmethod
+    def _flat(text: str) -> str:
+        return " ".join(text.split())
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_state_file_written_after_first_enhance(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """First enhance run writes ``.claude/.enhance-state.json`` for both targets."""
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+
+        assert result.exit_code == 0, result.stdout
+
+        state = load_state(project)
+        assert "claude-md" in state.completed
+        assert "subagents" in state.completed
+        # Model name is recorded for diagnostics.
+        assert state.completed["claude-md"].model == "claude-sonnet-4-5"
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_unchanged_target_is_skipped(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Second enhance with no input change skips both target helpers."""
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+
+        runner = CliRunner()
+        # First run — both targets execute, state is written.
+        first = runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+        assert first.exit_code == 0
+        assert mock_claude.call_count == 1
+        assert mock_subagents.call_count == 1
+
+        # Second run — no source changed → both helpers skipped.
+        mock_claude.reset_mock()
+        mock_subagents.reset_mock()
+        second = runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+
+        assert second.exit_code == 0, second.stdout
+        mock_claude.assert_not_called()
+        mock_subagents.assert_not_called()
+        flat = self._flat(second.stdout)
+        assert "CLAUDE.md unchanged" in flat
+        assert "Subagents unchanged" in flat
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_force_overrides_skip(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """``--force`` re-tunes even when the source hash matches."""
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+
+        runner = CliRunner()
+        # Seed state with a successful first run.
+        runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+        mock_claude.reset_mock()
+        mock_subagents.reset_mock()
+
+        # --force → skip is bypassed.
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--no-interactive", "--force"],
+        )
+        assert result.exit_code == 0
+        assert mock_claude.call_count == 1
+        assert mock_subagents.call_count == 1
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_changed_overrides_skip(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,
+        mock_subagents: Mock,
+        tmp_path: Path,
+    ) -> None:
+        """Project name change → CLAUDE.md hash differs → re-tune fires."""
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+
+        runner = CliRunner()
+        # Seed state with the auto-detected project name.
+        runner.invoke(cli.app, ["enhance", str(project), "--no-interactive"])
+        mock_claude.reset_mock()
+        mock_subagents.reset_mock()
+
+        # Override the project name → both target hashes change.
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--project-name",
+                "renamed-project",
+                "--no-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_claude.call_count == 1
+        assert mock_subagents.call_count == 1
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_dry_run_does_not_persist_state(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """``--dry-run`` runs the helpers but doesn't claim a tune happened."""
+        orch = MagicMock(spec=AIOrchestrator)
+        orch.model = "claude-sonnet-4-5"
+        mock_init.return_value = orch
+        project = self._make_project(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--dry-run", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0
+        # The state file must not exist after a dry run; otherwise the
+        # next real run would skip these targets thinking they're up
+        # to date when no actual write happened.
+        state_file = project / ".claude" / ".enhance-state.json"
+        assert not state_file.exists(), state_file.read_text(encoding="utf-8")
+
+
+class TestEnhanceSourceHashes:
+    """Hash determinism + sensitivity for the per-target hash helpers."""
+
+    def test_claude_md_hash_changes_with_project_name(self) -> None:
+        a = cli._compute_target_source_hash("claude-md", "alpha", "python")
+        b = cli._compute_target_source_hash("claude-md", "beta", "python")
+        assert a != b
+
+    def test_claude_md_hash_changes_with_language(self) -> None:
+        a = cli._compute_target_source_hash("claude-md", "alpha", "python")
+        b = cli._compute_target_source_hash("claude-md", "alpha", "go")
+        assert a != b
+
+    def test_claude_md_hash_is_deterministic(self) -> None:
+        a = cli._compute_target_source_hash("claude-md", "alpha", "python")
+        b = cli._compute_target_source_hash("claude-md", "alpha", "python")
+        assert a == b
+        assert a.startswith("sha256:")
+
+    def test_subagents_hash_changes_with_project_name(self) -> None:
+        a = cli._compute_target_source_hash("subagents", "alpha", "python")
+        b = cli._compute_target_source_hash("subagents", "beta", "python")
+        assert a != b
+
+    def test_subagents_hash_is_deterministic(self) -> None:
+        a = cli._compute_target_source_hash("subagents", "alpha", "python")
+        b = cli._compute_target_source_hash("subagents", "alpha", "python")
+        assert a == b
+
+    def test_unknown_target_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown target"):
+            cli._compute_target_source_hash("bogus", "alpha", "python")
+
+    def test_target_namespace_separation(self) -> None:
+        """Two targets with same metadata must hash differently — no collisions."""
+        a = cli._compute_target_source_hash("claude-md", "alpha", "python")
+        b = cli._compute_target_source_hash("subagents", "alpha", "python")
+        assert a != b

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -1,0 +1,206 @@
+"""Unit tests for ``start_green_stay_green.utils.enhance_state``."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from start_green_stay_green.utils.enhance_state import EnhanceState
+from start_green_stay_green.utils.enhance_state import STATE_FILE_VERSION
+from start_green_stay_green.utils.enhance_state import TargetCompletion
+from start_green_stay_green.utils.enhance_state import hash_inputs
+from start_green_stay_green.utils.enhance_state import load_state
+from start_green_stay_green.utils.enhance_state import save_state
+from start_green_stay_green.utils.enhance_state import state_path_for
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestHashInputs:
+    """Hashing must be deterministic and order-sensitive."""
+
+    def test_same_inputs_same_hash(self) -> None:
+        """Identical input sequences produce identical hashes."""
+        a = hash_inputs(["foo", "bar"])
+        b = hash_inputs(["foo", "bar"])
+        assert a == b
+
+    def test_order_matters(self) -> None:
+        """Different orderings of the same inputs must produce different hashes."""
+        a = hash_inputs(["foo", "bar"])
+        b = hash_inputs(["bar", "foo"])
+        assert a != b
+
+    def test_str_and_bytes_are_equivalent_when_utf8(self) -> None:
+        """``str`` and its UTF-8 bytes hash the same — encoding is well-defined."""
+        text_hash = hash_inputs(["hello"])
+        bytes_hash = hash_inputs([b"hello"])
+        assert text_hash == bytes_hash
+
+    def test_returns_sha256_prefix(self) -> None:
+        """The returned digest is prefixed with ``sha256:`` for readability."""
+        h = hash_inputs(["x"])
+        assert h.startswith("sha256:")
+        # 64 hex chars after prefix.
+        assert len(h) == len("sha256:") + 64
+
+    def test_empty_inputs_still_hashes(self) -> None:
+        """Empty iterable returns the digest of the empty string."""
+        h = hash_inputs([])
+        # The SHA-256 of empty input — locked in so a regression that
+        # accidentally seeds the digest is loud.
+        assert h == (
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+
+
+class TestEnhanceState:
+    """``EnhanceState`` round-trip + skip-decision logic."""
+
+    def test_default_state_is_empty(self) -> None:
+        """A default-constructed state has version + empty completed map."""
+        state = EnhanceState()
+        assert state.version == STATE_FILE_VERSION
+        assert state.last_run == ""
+        assert state.completed == {}
+
+    def test_is_unchanged_returns_false_for_unknown_target(self) -> None:
+        """A target that has never been tuned can never be "unchanged"."""
+        state = EnhanceState()
+        assert not state.is_unchanged("claude-md", "sha256:anything")
+
+    def test_is_unchanged_matches_stored_hash(self) -> None:
+        """Same hash → unchanged; different hash → changed."""
+        state = EnhanceState()
+        state.mark_completed("claude-md", "sha256:abc", "claude-sonnet")
+        assert state.is_unchanged("claude-md", "sha256:abc")
+        assert not state.is_unchanged("claude-md", "sha256:def")
+
+    def test_mark_completed_sets_timestamp_and_last_run(self) -> None:
+        """Recording a completion updates both the per-target and global timestamps."""
+        state = EnhanceState()
+        state.mark_completed("claude-md", "sha256:abc", "claude-sonnet")
+
+        record = state.completed["claude-md"]
+        assert record.hash == "sha256:abc"
+        assert record.model == "claude-sonnet"
+        assert record.timestamp  # any ISO-8601 string
+        assert state.last_run == record.timestamp
+
+    def test_round_trip(self) -> None:
+        """``to_dict`` + ``from_dict`` reproduces the original state."""
+        original = EnhanceState()
+        original.mark_completed("claude-md", "sha256:abc", "claude-sonnet")
+        original.mark_completed("subagents", "sha256:def", "claude-opus")
+
+        round_tripped = EnhanceState.from_dict(original.to_dict())
+
+        assert round_tripped.version == original.version
+        assert round_tripped.last_run == original.last_run
+        assert round_tripped.completed == original.completed
+
+    def test_from_dict_tolerates_unknown_targets(self) -> None:
+        """A future target appearing in stored state is loaded, not rejected."""
+        loaded = EnhanceState.from_dict(
+            {
+                "version": 1,
+                "last_run": "2026-05-06T07:00:00+00:00",
+                "completed": {
+                    "future-target": {
+                        "hash": "sha256:abc",
+                        "model": "claude-x",
+                        "timestamp": "2026-05-06T07:00:00+00:00",
+                    },
+                },
+            }
+        )
+        assert "future-target" in loaded.completed
+
+    def test_from_dict_drops_malformed_records(self) -> None:
+        """A record without a ``hash`` is silently dropped (not raised)."""
+        loaded = EnhanceState.from_dict(
+            {
+                "completed": {
+                    "good": {"hash": "sha256:abc", "model": "x", "timestamp": "y"},
+                    "no-hash": {"model": "x"},
+                    "non-dict": "garbage",
+                },
+            }
+        )
+        assert set(loaded.completed) == {"good"}
+
+    def test_from_dict_handles_missing_completed(self) -> None:
+        """``completed`` absent from payload → empty dict, no crash."""
+        loaded = EnhanceState.from_dict({"version": 1})
+        assert loaded.completed == {}
+
+
+class TestStateRoundTripOnDisk:
+    """End-to-end ``save_state`` → ``load_state`` cycle."""
+
+    def test_save_then_load_round_trip(self, tmp_path: Path) -> None:
+        original = EnhanceState()
+        original.mark_completed("claude-md", "sha256:abc", "claude-sonnet")
+
+        save_state(tmp_path, original)
+        loaded = load_state(tmp_path)
+
+        assert loaded.completed["claude-md"].hash == "sha256:abc"
+
+    def test_load_state_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        """No state file → empty state (so first runs aren't flagged as changes)."""
+        loaded = load_state(tmp_path)
+        assert loaded.completed == {}
+
+    def test_load_state_returns_empty_on_invalid_json(self, tmp_path: Path) -> None:
+        """Garbage in the state file degrades to empty state, not a crash."""
+        path = state_path_for(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not valid json {", encoding="utf-8")
+
+        loaded = load_state(tmp_path)
+        assert loaded.completed == {}
+
+    def test_load_state_returns_empty_when_payload_is_not_dict(
+        self, tmp_path: Path
+    ) -> None:
+        """A JSON list at the top level → empty state, not a TypeError."""
+        path = state_path_for(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+
+        loaded = load_state(tmp_path)
+        assert loaded.completed == {}
+
+    def test_save_state_creates_parent_directory(self, tmp_path: Path) -> None:
+        """``.claude/`` is created on first save (no init step required)."""
+        state = EnhanceState()
+        state.mark_completed("claude-md", "sha256:abc", "claude-sonnet")
+
+        save_state(tmp_path, state)
+
+        assert state_path_for(tmp_path).is_file()
+        assert (tmp_path / ".claude").is_dir()
+
+    def test_save_state_writes_utf8_with_sorted_keys(self, tmp_path: Path) -> None:
+        """The on-disk file is UTF-8 with sorted keys (clean diffs across runs)."""
+        state = EnhanceState()
+        state.mark_completed("subagents", "sha256:b", "claude-x")
+        state.mark_completed("claude-md", "sha256:a", "claude-y")
+
+        save_state(tmp_path, state)
+        raw = state_path_for(tmp_path).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        # ``sort_keys=True`` ensures completed keys are alphabetical.
+        completed_keys = list(payload["completed"].keys())
+        assert completed_keys == sorted(completed_keys)
+
+
+def test_target_completion_is_immutable() -> None:
+    """``TargetCompletion`` is a frozen dataclass — locks the contract."""
+    rec = TargetCompletion(hash="sha256:abc", model="x", timestamp="y")
+    with pytest.raises(AttributeError):
+        rec.hash = "sha256:def"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Phase 3c completes Phase 3 of the optimization roadmap. PR #309
shipped the MVP `green enhance` command (re-runs Pass 2 on an
existing project). This PR makes it **idempotent**: re-running
`green enhance` on a project whose inputs haven't changed becomes
a fast no-op instead of paying for redundant API calls. The
source-hash machinery also gives us a precise "what changed"
signal for future Phase 4/5 work.

## What landed

### New module — `start_green_stay_green/utils/enhance_state.py`

- `EnhanceState` dataclass with `version`, `last_run`, and a
  `completed` map of target → `TargetCompletion(hash, model,
  timestamp)`.
- `load_state` / `save_state` round-trip via UTF-8 JSON at
  `<project>/.claude/.enhance-state.json`. Missing / unreadable /
  malformed JSON degrades to "empty state" rather than crashing —
  worst case the caller re-tunes (the pre-3c behaviour). Sorted
  keys on save for clean diffs.
- `hash_inputs(parts)` — small `sha256:<hex>` helper, order-
  sensitive so callers can compose deterministic input streams.
- Forward-compat: unknown `completed` keys + unknown top-level
  keys tolerated; malformed records silently dropped.

### CLI integration

- `green enhance` now loads state, computes per-target source
  hashes, and short-circuits any target whose hash matches the
  stored value.
- `--force` bypasses the skip while still updating state on
  success — forced re-tunes produce an idempotent state file.
- `--dry-run` runs the API calls but does **not** persist state
  (we don't want to claim a tune happened when nothing was
  written).
- Skip message names the target and the `--force` override flag.
- When every target was skipped the state file is left untouched
  (no spurious `last_run` bumps from no-op invocations).

### Hash composition

- **`claude-md`** source hash = reference template content +
  `project_name` + language + script list + skill list. Updates
  to the canonical template invalidate stale tunes automatically.
- **`subagents`** source hash = every required reference
  subagent's body (in declaration order) + `project_name` +
  language. A maintainer-side update to any one agent invalidates
  the cached tune for the whole set.

### Architecture / complexity

Every function stays at cyclomatic grade A via extracted helpers:

- `_dispatch_enhance_targets` (table-driven loop)
- per-target `_hash_*` functions + `_compute_target_source_hash`
- `_persist_enhance_state`
- `_print_enhance_summary`
- `_run_enhance_pipeline`
- `_parse_record` + `_parse_completed_records` + `_valid_hash` in
  `enhance_state.py`

The dispatch table stores helper *names* (not function refs), so
`unittest.mock.patch("cli._enhance_claude_md")` is honoured at
call time — late binding via `globals()[name]` rather than baking
module references at import time.

## Tests (32 new)

- **`tests/unit/utils/test_enhance_state.py`** (20 tests):
  - `TestHashInputs` — determinism, order sensitivity, str/bytes
    equivalence, sha256 prefix, empty input lock-in.
  - `TestEnhanceState` — default empty state, `is_unchanged` for
    known/unknown targets, `mark_completed` timestamp wiring,
    round-trip, forward-compat with unknown targets, malformed
    record rejection, missing `completed` handling.
  - `TestStateRoundTripOnDisk` — save/load round-trip, missing
    file → empty, invalid JSON → empty, non-dict payload → empty,
    parent-directory creation, sorted keys on disk.
  - `TargetCompletion` immutability assertion.

- **`tests/unit/test_cli_mocked.py`** (12 new):
  - `TestEnhanceSkipUnchanged` (5) — first-run state writing,
    second-run skip, `--force` overrides, source-change overrides
    (project name change → hash differs), dry-run does **not**
    persist state.
  - `TestEnhanceSourceHashes` (7) — per-target determinism,
    sensitivity to project_name and language changes, namespace
    separation across targets, unknown target raises.

Existing Phase 3b tests updated to set `orch.model = "..."` on
their `MagicMock(spec=AIOrchestrator)` since the new state path
reads that attribute (instance attrs aren't auto-populated by
`spec=`).

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck,
  security, complexity — every function grade A).
- 1684 unit + integration tests pass (32 new for Phase 3c).

## Test plan

- [ ] CI green on this PR.
- [ ] Smoke: run `green enhance` twice with the same source state;
      second run skips both targets and prints "unchanged" hints.
- [ ] Smoke: run `green enhance --force` after a clean run;
      bypasses skip, re-tunes both, updates state.
- [ ] Smoke: run `green enhance --dry-run`; runs API calls but
      leaves `.claude/.enhance-state.json` absent (or unchanged).
- [ ] Smoke: change `--project-name` on second run; hash differs
      so re-tune fires.

## Roadmap status

- ✅ Phase 0 (telemetry) — PR #305 (commit `acf4572`).
- ✅ Phase 1 (de-AI generators) — PR #305 (commit `acf4572`).
- ✅ Phase 2 (subagent parallelism) — PR #305 (commit `acf4572`).
- ✅ Phase 3a (two-pass split foundation: flags + rename) —
  PR #308 (commit `0986d89`).
- ✅ Phase 3b (`green enhance` MVP) — PR #309 (commit `f0793e7`).
- ⏳ **Phase 3c (this PR)** — `.enhance-state.json` resume +
  source-hash skip logic. Phase 3 complete after this lands.
- 🔜 Phase 2c (prompt caching + tool_use), 4 (prompt cleanup),
  5 (batch mode), 6 (UX/docs).

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_