### PR TITLE
feat(prompts): Phase 4 — hoist generator prompts into 6-component templates

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -21,10 +21,16 @@ Shipped:
 - Phase 2c (prompt caching via cache-controlled system blocks +
   `tool_use` structured output replacing the regex `CHANGES:` parser;
   `cache_read_input_tokens` / `cache_creation_input_tokens` plumbed
-  through to the timing report) — branch
-  `claude/phase-2c-cache-and-tool-use`.
+  through to the timing report) — PR #311 merged onto main as commit
+  `8c32724`.
+- Phase 4 (prompt-engineering cleanup: `ClaudeMdGenerator`,
+  `CIGenerator`, and `ContentTuner` inline f-string prompts hoisted
+  into `ai/prompts/templates/{claude_md_tune,ci_enhance,content_tune}.jinja2`,
+  each conforming to the 6-component framework; routed through a
+  lazy `get_default_manager()` singleton) — branch
+  `claude/phase-4-prompt-cleanup`.
 
-Remaining: prompt cleanup (4), batch mode (5), UX/docs (6).
+Remaining: batch mode (5), UX/docs (6).
 
 ---
 

--- a/start_green_stay_green/ai/prompts/manager.py
+++ b/start_green_stay_green/ai/prompts/manager.py
@@ -4,6 +4,7 @@ This module provides utilities for managing Jinja2-based prompt templates
 including caching, validation, and language-specific rendering.
 """
 
+import functools
 import logging
 from pathlib import Path
 from typing import Any
@@ -178,9 +179,7 @@ class PromptManager:
         self._template_cache.clear()
 
 
-_default_manager: PromptManager | None = None
-
-
+@functools.cache
 def get_default_manager() -> PromptManager:
     """Return the process-wide default :class:`PromptManager`, creating it lazily.
 
@@ -189,9 +188,7 @@ def get_default_manager() -> PromptManager:
     manager can keep building their own with a custom
     ``template_dir``; this singleton is for the production path
     where every generator wants the same ``ai/prompts/templates``
-    directory.
+    directory. Tests that need to force a rebuild call
+    ``get_default_manager.cache_clear()``.
     """
-    global _default_manager  # noqa: PLW0603 — module-level singleton by design
-    if _default_manager is None:
-        _default_manager = PromptManager()
-    return _default_manager
+    return PromptManager()

--- a/start_green_stay_green/ai/prompts/manager.py
+++ b/start_green_stay_green/ai/prompts/manager.py
@@ -44,7 +44,6 @@ class PromptManager:
         "quality_scripts",
         "claude_md",
         "project_scaffolding",
-        # Phase 4 — generator-side prompts migrated out of inline f-strings.
         "claude_md_tune",
         "ci_enhance",
         "content_tune",

--- a/start_green_stay_green/ai/prompts/manager.py
+++ b/start_green_stay_green/ai/prompts/manager.py
@@ -44,6 +44,10 @@ class PromptManager:
         "quality_scripts",
         "claude_md",
         "project_scaffolding",
+        # Phase 4 — generator-side prompts migrated out of inline f-strings.
+        "claude_md_tune",
+        "ci_enhance",
+        "content_tune",
     }
 
     def __init__(self, template_dir: Path | None = None) -> None:
@@ -173,3 +177,22 @@ class PromptManager:
         Useful for testing or when templates have been modified.
         """
         self._template_cache.clear()
+
+
+_default_manager: PromptManager | None = None
+
+
+def get_default_manager() -> PromptManager:
+    """Return the process-wide default :class:`PromptManager`, creating it lazily.
+
+    Constructed once on first call so generators never re-parse
+    template files between calls. Tests that need an isolated
+    manager can keep building their own with a custom
+    ``template_dir``; this singleton is for the production path
+    where every generator wants the same ``ai/prompts/templates``
+    directory.
+    """
+    global _default_manager  # noqa: PLW0603 — module-level singleton by design
+    if _default_manager is None:
+        _default_manager = PromptManager()
+    return _default_manager

--- a/start_green_stay_green/ai/prompts/templates/ci_enhance.jinja2
+++ b/start_green_stay_green/ai/prompts/templates/ci_enhance.jinja2
@@ -1,0 +1,55 @@
+## Role
+
+You are a senior CI/CD engineer specialising in GitHub Actions workflows.
+You write production-grade pipelines that enforce maximum-quality standards
+without flaky steps or unnecessary jobs.
+
+## Goal
+
+Generate a single ``.github/workflows/ci.yml`` workflow file for the project
+below. The workflow must define a required ``quality`` job (lint + security
++ tests + coverage) and may add optional jobs for matrix testing, mutation,
+complexity, or build, where appropriate for {{ language }}.
+
+## Context
+
+PROJECT METADATA:
+- Primary language: {{ language }}
+
+ADDITIONAL CONTEXT (from the caller; may include language version, package
+manager, or test framework hints):
+{{ context }}
+
+## Output Format
+
+Pure YAML, ready to write straight to ``.github/workflows/ci.yml``. No
+Markdown code fences. No prose explanation before or after. Begin with
+``name:`` and end with the final workflow line.
+
+## Examples
+
+Job structure looks like this (illustrative — adapt to {{ language }} idioms,
+do not echo verbatim):
+
+```
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: # language-specific lint + test + security
+```
+
+## Requirements
+
+1. The ``quality`` job is required and **must** include test execution and
+   coverage measurement.
+2. Use language-appropriate tooling — pin major versions of any actions
+   referenced (e.g. ``actions/checkout@v4``).
+3. Add matrix testing across at least two language versions where the
+   ecosystem supports it.
+4. Cache dependencies (``actions/setup-*`` cache hooks or
+   ``actions/cache``) so re-runs are fast.
+5. Upload coverage reports and any other artefacts a reviewer would
+   reasonably want.
+6. Output is **only** YAML — no Markdown, no code fences, no commentary.

--- a/start_green_stay_green/ai/prompts/templates/claude_md_tune.jinja2
+++ b/start_green_stay_green/ai/prompts/templates/claude_md_tune.jinja2
@@ -1,0 +1,68 @@
+## Role
+
+You are a senior technical-documentation engineer adapting a reference
+``CLAUDE.md`` (the AI-collaboration context file) from a generic green-init
+template to a specific target project. You preserve structure, principles,
+and quality standards while replacing generic examples with target-language
+idioms.
+
+## Goal
+
+Produce a complete, valid ``CLAUDE.md`` for the project below by adapting
+the reference template against the target project metadata. The output must
+be drop-in usable: a Claude Code session opening this file should immediately
+understand the project's quality bar, scripts, and skills.
+
+## Context
+
+PROJECT METADATA:
+- Name: {{ project_name }}
+- Primary language: {{ language }}
+{%- if scripts %}
+- Generated quality scripts:
+{%- for script in scripts %}
+  - {{ script }}
+{%- endfor %}
+{%- else %}
+- Generated quality scripts: (none)
+{%- endif %}
+{%- if skills %}
+- Generated skills:
+{%- for skill in skills %}
+  - {{ skill }}
+{%- endfor %}
+{%- else %}
+- Generated skills: (none)
+{%- endif %}
+
+REFERENCE CLAUDE.md TEMPLATE (adapt this — do not echo verbatim):
+{{ claude_md_reference }}
+
+MAXIMUM QUALITY ENGINEERING STANDARDS (preserve these as authoritative):
+{{ quality_reference }}
+
+## Output Format
+
+Valid GitHub-flavoured Markdown, beginning with an H1 title and following
+the reference template's section structure. No code fences around the whole
+document. Section ordering matches the reference.
+
+## Examples
+
+Adaptation moves like this — do **not** echo this example into the output,
+treat it as a pattern reference only:
+
+- Reference template line: ``## Tool Invocation Patterns: ./scripts/check-all.sh``
+- Adapted (target uses pixi): ``## Tool Invocation Patterns: pixi run check-all``
+
+## Requirements
+
+1. Begin with a single H1 title that names the project.
+2. Replace generic examples with {{ language }}-specific idioms.
+3. Document every script in ``scripts`` under a Tool Invocation Patterns
+   section; keep the names verbatim.
+4. Document every skill listed in ``skills``.
+5. Preserve the reference template's section structure and ordering.
+6. Preserve every quality threshold and critical principle from the
+   MAXIMUM QUALITY ENGINEERING STANDARDS — do not soften.
+7. Output must be valid Markdown end-to-end. No prose outside the document.

--- a/start_green_stay_green/ai/prompts/templates/content_tune.jinja2
+++ b/start_green_stay_green/ai/prompts/templates/content_tune.jinja2
@@ -1,0 +1,67 @@
+## Role
+
+You are a senior agent designer adapting reusable subagent / skill profiles
+from a generic green-init reference repository to a specific target
+software project. You preserve YAML frontmatter, role identity, and section
+structure verbatim — you only update examples, terminology, and references.
+
+## Goal
+
+When the user supplies a piece of source content, invoke the
+``report_tuning`` tool with the adapted content and a list of every
+change you made. The adaptation must keep the source's intent intact while
+making it sound native to the target project's domain.
+
+## Context
+
+SOURCE CONTEXT:
+{{ source_context }}
+
+TARGET CONTEXT:
+{{ target_context }}
+{%- if preserve_sections %}
+
+PRESERVE THESE SECTIONS UNCHANGED (verbatim — do not edit headings or body):
+{%- for section in preserve_sections %}
+- "{{ section }}"
+{%- endfor %}
+{%- endif %}
+
+## Output Format
+
+You must respond by invoking the ``report_tuning`` tool with this JSON shape:
+
+```
+{
+  "tuned_content": "<the full adapted content as a string>",
+  "changes": ["<short bullet describing each change>", ...]
+}
+```
+
+Both fields are required. If no changes were necessary, ``changes`` is an
+empty array.
+
+## Examples
+
+Typical adaptations look like this (illustrative — do not echo into the
+output):
+
+- Replaced "Mojo ML research" with the target's domain language.
+- Updated example file paths from ``ml-odyssey/`` to the target's layout.
+- Adjusted tooling references (e.g. ``pixi`` → ``uv``) where the target
+  diverges.
+
+## Requirements
+
+1. Preserve the structure and format of the original content.
+2. Adapt terminology, examples, and references to match the target
+   context — but **only** where they would otherwise mislead a reader of
+   the target project.
+3. Maintain all section headings and organisation.
+4. Keep the same level of detail and completeness as the source.
+5. List every meaningful change as a short bullet in ``changes``; return
+   an empty array when no changes were necessary.
+{%- if preserve_sections %}
+6. The PRESERVE sections above must remain byte-identical in
+   ``tuned_content``.
+{%- endif %}

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -183,12 +183,11 @@ class ContentTuner:
     ) -> list[dict[str, object]]:
         """Render the cache-controlled system block for a tune call.
 
-        Phase 4: full prompt body is rendered from
-        ``ai/prompts/templates/content_tune.jinja2`` (6-component
-        framework). The single block carries
-        ``cache_control: {"type": "ephemeral"}`` so Anthropic caches
-        the entire prefix for ~5 minutes — back-to-back per-agent
-        tunes within one ``green init`` hit the cache.
+        The full prompt body is rendered from
+        ``ai/prompts/templates/content_tune.jinja2``. The single block
+        carries ``cache_control: {"type": "ephemeral"}`` so Anthropic
+        caches the entire prefix for ~5 minutes — back-to-back
+        per-agent tunes within one ``green init`` hit the cache.
 
         Why a single block (rather than splitting instructions and
         context across two)? The Anthropic prompt cache keys on the

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -20,6 +20,7 @@ from typing import cast
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError
+from start_green_stay_green.ai.prompts.manager import get_default_manager
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -180,20 +181,20 @@ class ContentTuner:
         target_context: str,
         preserve_sections: Sequence[str] | None,
     ) -> list[dict[str, object]]:
-        """Assemble the cache-controlled system blocks for a tune call.
+        """Render the cache-controlled system block for a tune call.
 
-        Why split this off into system blocks (rather than inline into
-        the user message)? The Anthropic prompt cache keys on the
-        leading prefix of every request. Per-call deltas
-        (``source_content``) live in the user message; everything
-        stable across the 8 subagent tunes in one ``green init``
-        (instructions + source/target context + preserve list) lives
-        here so the second-and-later tunes in a session can hit the
-        cache.
+        Phase 4: full prompt body is rendered from
+        ``ai/prompts/templates/content_tune.jinja2`` (6-component
+        framework). The single block carries
+        ``cache_control: {"type": "ephemeral"}`` so Anthropic caches
+        the entire prefix for ~5 minutes — back-to-back per-agent
+        tunes within one ``green init`` hit the cache.
 
-        The final block carries
-        ``cache_control: {"type": "ephemeral"}`` — Anthropic caches
-        the prefix up through that block for ~5 minutes.
+        Why a single block (rather than splitting instructions and
+        context across two)? The Anthropic prompt cache keys on the
+        leading prefix; one cached block is the cleanest contract.
+        Per-call deltas (``source_content``) live in the user
+        message, not here.
 
         Args:
             source_context: Description of the source repository.
@@ -202,42 +203,23 @@ class ContentTuner:
                 model must leave verbatim.
 
         Returns:
-            List of system blocks, ready to pass straight to
-            :meth:`AIOrchestrator.generate_tool_use_async`.
+            One-element list of system blocks, ready to pass straight
+            to :meth:`AIOrchestrator.generate_tool_use_async`.
         """
-        instructions = (
-            "You are a content tuner adapting source repository "
-            "content to a target repository context. "
-            "Always invoke the report_tuning tool with the adapted "
-            "content and a list of the changes you made.\n\n"
-            "REQUIREMENTS:\n"
-            "- Preserve the structure and format of the original content.\n"
-            "- Adapt terminology, examples, and references to match the "
-            "target context.\n"
-            "- Maintain all section headings and organisation.\n"
-            "- Keep the same level of detail and completeness.\n"
-            "- List every meaningful change in the changes array; "
-            "return an empty array when no changes were necessary."
+        prompt = get_default_manager().render(
+            "content_tune",
+            {
+                "source_context": source_context,
+                "target_context": target_context,
+                "preserve_sections": list(preserve_sections or []),
+            },
         )
-        if preserve_sections:
-            sections = ", ".join(f'"{s}"' for s in preserve_sections)
-            instructions += f"\n- Leave the following sections unchanged: {sections}."
-
-        context_block = (
-            f"SOURCE CONTEXT:\n{source_context}\n\n"
-            f"TARGET CONTEXT:\n{target_context}"
-        )
-
-        # Mark only the *last* block as cached. Anthropic caches every
-        # block up to and including the marked one, so a single marker
-        # at the tail caches the full stable prefix.
         return [
-            {"type": "text", "text": instructions},
             {
                 "type": "text",
-                "text": context_block,
+                "text": prompt,
                 "cache_control": {"type": "ephemeral"},
-            },
+            }
         ]
 
     @staticmethod

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -22,6 +22,7 @@ from jinja2 import Environment
 from jinja2 import StrictUndefined
 import yaml
 
+from start_green_stay_green.ai.prompts.manager import get_default_manager
 from start_green_stay_green.generators.base import BaseGenerator
 from start_green_stay_green.utils.yaml_utils import strip_markdown_fences
 
@@ -332,6 +333,11 @@ The CI workflow MUST:
     def _generate_with_ai(self, context: str) -> GenerationResult:
         """Generate workflow using AI orchestrator.
 
+        Phase 4: prompt body lives in the
+        ``ai/prompts/templates/ci_enhance.jinja2`` template; this
+        method is a thin wrapper that supplies the context dict and
+        forwards to ``orchestrator.generate``.
+
         Args:
             context: Context information for generation.
 
@@ -346,27 +352,10 @@ The CI workflow MUST:
             msg = "AI orchestrator required for generate_with_ai()"
             raise ValueError(msg)
 
-        prompt = f"""You are a GitHub Actions CI/CD expert. Generate a production-grade
-GitHub Actions workflow file for a {self.language.upper()} project.
-
-Context:
-{context}
-
-Generate a complete, valid GitHub Actions workflow in YAML format that:
-1. MUST define a 'quality' job with linting, security checks, tests, coverage
-2. Can optionally include additional jobs (complexity, build, mutation, etc.)
-3. Uses appropriate language-specific tools and commands
-4. Includes matrix testing for multiple versions
-5. Has proper caching for dependencies
-6. Uploads artifacts and coverage reports
-7. Enforces all quality standards mentioned above
-8. Is ready to be saved as .github/workflows/ci.yml
-
-IMPORTANT: The 'quality' job is REQUIRED and must include test execution.
-Additional jobs like 'test', 'mutation', 'complexity', 'build' are OPTIONAL.
-
-Output ONLY valid YAML - no markdown, no explanations, no code fences.
-Start with 'name:' and end with the last workflow configuration line."""
+        prompt = get_default_manager().render(
+            "ci_enhance",
+            {"language": self.language, "context": context},
+        )
 
         return self.orchestrator.generate(
             prompt=prompt,

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -333,10 +333,10 @@ The CI workflow MUST:
     def _generate_with_ai(self, context: str) -> GenerationResult:
         """Generate workflow using AI orchestrator.
 
-        Phase 4: prompt body lives in the
-        ``ai/prompts/templates/ci_enhance.jinja2`` template; this
-        method is a thin wrapper that supplies the context dict and
-        forwards to ``orchestrator.generate``.
+        The prompt body lives in
+        ``ai/prompts/templates/ci_enhance.jinja2``; this method
+        supplies the context dict and forwards to
+        ``orchestrator.generate``.
 
         Args:
             context: Context information for generation.

--- a/start_green_stay_green/generators/claude_md.py
+++ b/start_green_stay_green/generators/claude_md.py
@@ -127,11 +127,9 @@ class ClaudeMdGenerator:
     ) -> str:
         """Render the ``claude_md_tune`` prompt template.
 
-        Phase 4: this is now a thin wrapper around
-        :func:`PromptManager.render`. The 6-component prompt body
-        lives in
+        The 6-component prompt body lives in
         ``start_green_stay_green/ai/prompts/templates/claude_md_tune.jinja2``;
-        this method just supplies the context dict.
+        this method supplies the context dict.
 
         Args:
             claude_md_reference: Reference CLAUDE.md template.

--- a/start_green_stay_green/generators/claude_md.py
+++ b/start_green_stay_green/generators/claude_md.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 from typing import TYPE_CHECKING
 
+from start_green_stay_green.ai.prompts.manager import get_default_manager
+
 if TYPE_CHECKING:
     from start_green_stay_green.ai.orchestrator import AIOrchestrator
 
@@ -117,65 +119,40 @@ class ClaudeMdGenerator:
         """
         return self.quality_ref_path.read_text(encoding="utf-8")
 
+    @staticmethod
     def _build_generation_prompt(
-        self,
         claude_md_reference: str,
         quality_reference: str,
         project_config: dict[str, Any],
     ) -> str:
-        """Build prompt for CLAUDE.md generation.
+        """Render the ``claude_md_tune`` prompt template.
+
+        Phase 4: this is now a thin wrapper around
+        :func:`PromptManager.render`. The 6-component prompt body
+        lives in
+        ``start_green_stay_green/ai/prompts/templates/claude_md_tune.jinja2``;
+        this method just supplies the context dict.
 
         Args:
             claude_md_reference: Reference CLAUDE.md template.
-            quality_reference: MAXIMUM_QUALITY_ENGINEERING.md content.
-            project_config: Project configuration with name, language, scripts, skills.
+            quality_reference: ``MAXIMUM_QUALITY_ENGINEERING.md`` content.
+            project_config: Project configuration with ``project_name``,
+                ``language``, ``scripts``, ``skills``.
 
         Returns:
-            Formatted prompt for AI generation.
+            Fully rendered prompt ready for ``orchestrator.generate``.
         """
-        project_name = project_config.get("project_name", "unknown")
-        language = project_config.get("language", "unknown")
-        scripts = project_config.get("scripts", [])
-        skills = project_config.get("skills", [])
-
-        scripts_text = "\n".join(f"- {script}" for script in scripts)
-        skills_text = "\n".join(f"- {skill}" for skill in skills)
-
-        prompt_intro = (
-            "Generate a customized CLAUDE.md file for a new project based on "
-            "the reference CLAUDE.md template and MAXIMUM QUALITY ENGINEERING "
-            "standards."
+        return get_default_manager().render(
+            "claude_md_tune",
+            {
+                "project_name": project_config.get("project_name", "unknown"),
+                "language": project_config.get("language", "unknown"),
+                "scripts": list(project_config.get("scripts") or []),
+                "skills": list(project_config.get("skills") or []),
+                "claude_md_reference": claude_md_reference,
+                "quality_reference": quality_reference,
+            },
         )
-        return f"""{prompt_intro}
-
-PROJECT CONFIGURATION:
-- Project Name: {project_name}
-- Language: {language}
-- Generated Scripts:
-{scripts_text if scripts else "  (none)"}
-- Generated Skills:
-{skills_text if skills else "  (none)"}
-
-REFERENCE CLAUDE.md TEMPLATE:
-{claude_md_reference}
-
-MAXIMUM QUALITY ENGINEERING STANDARDS (for context):
-{quality_reference}
-
-REQUIREMENTS:
-1. Adapt the reference CLAUDE.md to the target project
-2. Replace generic examples with {language}-specific examples
-3. Document all generated scripts in the Tool Invocation Patterns section
-4. Document all generated skills
-5. Maintain the same structure and organization as the reference
-6. Preserve all critical principles and quality standards
-7. Include project-specific commands for {language}
-8. Ensure the output is valid markdown with proper H1 title
-
-OUTPUT FORMAT:
-Generate the complete customized CLAUDE.md content as valid markdown.
-Start with the H1 title and include all sections from the reference template.
-"""
 
     @staticmethod
     def _has_h1_title(content: str) -> bool:

--- a/tests/unit/ai/test_prompt_manager.py
+++ b/tests/unit/ai/test_prompt_manager.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from jinja2 import TemplateNotFound
 import pytest
 
-import start_green_stay_green.ai.prompts.manager as manager_module
 from start_green_stay_green.ai.prompts.manager import PromptManager
 from start_green_stay_green.ai.prompts.manager import PromptTemplateError
 from start_green_stay_green.ai.prompts.manager import get_default_manager
@@ -1283,12 +1282,12 @@ class TestGetDefaultManager:
     """Lock in the lazy-singleton contract for ``get_default_manager``."""
 
     def setup_method(self) -> None:
-        """Reset the module-level cache so tests do not interfere."""
-        manager_module._default_manager = None
+        """Drop the cache so each test starts with no constructed manager."""
+        get_default_manager.cache_clear()
 
     def teardown_method(self) -> None:
-        """Reset again so production callers in later tests get a fresh manager."""
-        manager_module._default_manager = None
+        """Drop the cache so production callers in later tests rebuild fresh."""
+        get_default_manager.cache_clear()
 
     def test_returns_prompt_manager_instance(self) -> None:
         """First call constructs and returns a real ``PromptManager``."""
@@ -1299,10 +1298,10 @@ class TestGetDefaultManager:
         """The singleton guarantee — both calls hand back the *same* object.
 
         Identity check (``is``), not equality. ``PromptManager`` does
-        not override ``__eq__``, so an accidental drop of either the
-        ``global`` declaration or the ``None`` guard would silently
-        return distinct objects that compare equal by reference but
-        consume separate Jinja2 environments.
+        not override ``__eq__``, so an accidental drop of the
+        ``@functools.lru_cache`` decorator would silently return
+        distinct objects that compare equal by reference but consume
+        separate Jinja2 environments.
         """
         first = get_default_manager()
         second = get_default_manager()
@@ -1313,9 +1312,10 @@ class TestGetDefaultManager:
 
         Important so tests that use a custom ``template_dir`` can
         construct their own ``PromptManager`` without paying for the
-        default one. Setup hook above guarantees the cache starts
-        ``None``; verify nothing along the import path repopulated it.
+        default one. ``cache_info().currsize`` is the public hook
+        ``functools.lru_cache`` exposes for inspecting cache state;
+        zero before the first call, one after.
         """
-        assert manager_module._default_manager is None
+        assert get_default_manager.cache_info().currsize == 0
         get_default_manager()
-        assert manager_module._default_manager is not None
+        assert get_default_manager.cache_info().currsize == 1

--- a/tests/unit/ai/test_prompt_manager.py
+++ b/tests/unit/ai/test_prompt_manager.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from jinja2 import TemplateNotFound
 import pytest
 
+import start_green_stay_green.ai.prompts.manager as manager_module
 from start_green_stay_green.ai.prompts.manager import PromptManager
 from start_green_stay_green.ai.prompts.manager import PromptTemplateError
+from start_green_stay_green.ai.prompts.manager import get_default_manager
 
 
 class TestPromptManagerInitialization:
@@ -66,13 +68,11 @@ class TestPromptManagerInitialization:
     def test_init_supported_template_types_constant(self) -> None:
         """Test SUPPORTED_TEMPLATE_TYPES constant is properly defined."""
         assert {
-            # Pre-Phase-4 stubs.
             "ci_cd",
             "precommit",
             "quality_scripts",
             "claude_md",
             "project_scaffolding",
-            # Phase 4 — generator-side prompts hoisted from inline f-strings.
             "claude_md_tune",
             "ci_enhance",
             "content_tune",
@@ -796,13 +796,11 @@ class TestMutationKillers:
     def test_supported_template_types_exact_set(self) -> None:
         """Test SUPPORTED_TEMPLATE_TYPES contains exact set."""
         expected = {
-            # Pre-Phase-4 stubs.
             "ci_cd",
             "precommit",
             "quality_scripts",
             "claude_md",
             "project_scaffolding",
-            # Phase 4 additions.
             "claude_md_tune",
             "ci_enhance",
             "content_tune",
@@ -1187,10 +1185,10 @@ class TestPromptManagerExceptionChaining:
 
 
 class TestPhase4TemplatesSixComponent:
-    """Phase 4: every generator-side prompt template carries the
-    6-component framework (Role / Goal / Context / Output Format /
-    Examples / Requirements). These tests pin that structure so a
-    reviewer cannot accidentally drop a section while iterating.
+    """Each generator-side prompt template carries the 6-component
+    framework (Role / Goal / Context / Output Format / Examples /
+    Requirements). These tests pin that structure so a reviewer
+    cannot accidentally drop a section while iterating.
     """
 
     SIX_COMPONENT_HEADINGS = (
@@ -1279,3 +1277,45 @@ class TestPhase4TemplatesSixComponent:
         manager = PromptManager()
         for name in ("claude_md_tune", "ci_enhance", "content_tune"):
             assert manager.validate_template(name), f"{name} failed validation"
+
+
+class TestGetDefaultManager:
+    """Lock in the lazy-singleton contract for ``get_default_manager``."""
+
+    def setup_method(self) -> None:
+        """Reset the module-level cache so tests do not interfere."""
+        manager_module._default_manager = None
+
+    def teardown_method(self) -> None:
+        """Reset again so production callers in later tests get a fresh manager."""
+        manager_module._default_manager = None
+
+    def test_returns_prompt_manager_instance(self) -> None:
+        """First call constructs and returns a real ``PromptManager``."""
+        result = get_default_manager()
+        assert isinstance(result, PromptManager)
+
+    def test_returns_same_instance_on_repeated_calls(self) -> None:
+        """The singleton guarantee — both calls hand back the *same* object.
+
+        Identity check (``is``), not equality. ``PromptManager`` does
+        not override ``__eq__``, so an accidental drop of either the
+        ``global`` declaration or the ``None`` guard would silently
+        return distinct objects that compare equal by reference but
+        consume separate Jinja2 environments.
+        """
+        first = get_default_manager()
+        second = get_default_manager()
+        assert first is second
+
+    def test_lazy_construction_defers_until_first_call(self) -> None:
+        """Importing the module does not eagerly build a manager.
+
+        Important so tests that use a custom ``template_dir`` can
+        construct their own ``PromptManager`` without paying for the
+        default one. Setup hook above guarantees the cache starts
+        ``None``; verify nothing along the import path repopulated it.
+        """
+        assert manager_module._default_manager is None
+        get_default_manager()
+        assert manager_module._default_manager is not None

--- a/tests/unit/ai/test_prompt_manager.py
+++ b/tests/unit/ai/test_prompt_manager.py
@@ -66,11 +66,16 @@ class TestPromptManagerInitialization:
     def test_init_supported_template_types_constant(self) -> None:
         """Test SUPPORTED_TEMPLATE_TYPES constant is properly defined."""
         assert {
+            # Pre-Phase-4 stubs.
             "ci_cd",
             "precommit",
             "quality_scripts",
             "claude_md",
             "project_scaffolding",
+            # Phase 4 — generator-side prompts hoisted from inline f-strings.
+            "claude_md_tune",
+            "ci_enhance",
+            "content_tune",
         } == PromptManager.SUPPORTED_TEMPLATE_TYPES
 
 
@@ -791,14 +796,19 @@ class TestMutationKillers:
     def test_supported_template_types_exact_set(self) -> None:
         """Test SUPPORTED_TEMPLATE_TYPES contains exact set."""
         expected = {
+            # Pre-Phase-4 stubs.
             "ci_cd",
             "precommit",
             "quality_scripts",
             "claude_md",
             "project_scaffolding",
+            # Phase 4 additions.
+            "claude_md_tune",
+            "ci_enhance",
+            "content_tune",
         }
         assert expected == PromptManager.SUPPORTED_TEMPLATE_TYPES
-        assert len(PromptManager.SUPPORTED_TEMPLATE_TYPES) == 5
+        assert len(PromptManager.SUPPORTED_TEMPLATE_TYPES) == 8
 
     def test_supported_template_types_contains_ci_cd(self) -> None:
         """Test SUPPORTED_TEMPLATE_TYPES contains ci_cd."""
@@ -1174,3 +1184,98 @@ class TestPromptManagerExceptionChaining:
         # Nonexistent should raise
         with pytest.raises(PromptTemplateError):
             PromptManager(template_dir=nonexistent_dir)
+
+
+class TestPhase4TemplatesSixComponent:
+    """Phase 4: every generator-side prompt template carries the
+    6-component framework (Role / Goal / Context / Output Format /
+    Examples / Requirements). These tests pin that structure so a
+    reviewer cannot accidentally drop a section while iterating.
+    """
+
+    SIX_COMPONENT_HEADINGS = (
+        "## Role",
+        "## Goal",
+        "## Context",
+        "## Output Format",
+        "## Examples",
+        "## Requirements",
+    )
+
+    def test_claude_md_tune_renders_with_all_six_components(self) -> None:
+        """`claude_md_tune` carries all six headings in the rendered prompt."""
+        manager = PromptManager()
+        rendered = manager.render(
+            "claude_md_tune",
+            {
+                "project_name": "alpha",
+                "language": "python",
+                "scripts": ["check-all.sh"],
+                "skills": ["stay-green"],
+                "claude_md_reference": "# Reference\n\nbody",
+                "quality_reference": "thresholds...",
+            },
+        )
+        for heading in self.SIX_COMPONENT_HEADINGS:
+            assert heading in rendered, f"missing {heading} from claude_md_tune"
+
+    def test_ci_enhance_renders_with_all_six_components(self) -> None:
+        """`ci_enhance` carries all six headings in the rendered prompt."""
+        manager = PromptManager()
+        rendered = manager.render(
+            "ci_enhance",
+            {"language": "python", "context": "Python 3.12, pip"},
+        )
+        for heading in self.SIX_COMPONENT_HEADINGS:
+            assert heading in rendered, f"missing {heading} from ci_enhance"
+
+    def test_content_tune_renders_with_all_six_components(self) -> None:
+        """`content_tune` carries all six headings in the rendered prompt."""
+        manager = PromptManager()
+        rendered = manager.render(
+            "content_tune",
+            {
+                "source_context": "Source",
+                "target_context": "Target",
+                "preserve_sections": [],
+            },
+        )
+        for heading in self.SIX_COMPONENT_HEADINGS:
+            assert heading in rendered, f"missing {heading} from content_tune"
+
+    def test_content_tune_renders_preserve_sections_when_supplied(self) -> None:
+        """Optional preserve list flows into the rendered prompt verbatim."""
+        manager = PromptManager()
+        rendered = manager.render(
+            "content_tune",
+            {
+                "source_context": "Source",
+                "target_context": "Target",
+                "preserve_sections": ["Identity", "Workflow"],
+            },
+        )
+        assert "PRESERVE THESE SECTIONS UNCHANGED" in rendered
+        assert "Identity" in rendered
+        assert "Workflow" in rendered
+
+    def test_claude_md_tune_handles_empty_scripts_and_skills(self) -> None:
+        """An empty scripts/skills list does not crash the template."""
+        manager = PromptManager()
+        rendered = manager.render(
+            "claude_md_tune",
+            {
+                "project_name": "alpha",
+                "language": "python",
+                "scripts": [],
+                "skills": [],
+                "claude_md_reference": "# Reference",
+                "quality_reference": "Q",
+            },
+        )
+        assert "(none)" in rendered
+
+    def test_each_phase_4_template_validates(self) -> None:
+        """`validate_template` confirms each new template is loadable."""
+        manager = PromptManager()
+        for name in ("claude_md_tune", "ci_enhance", "content_tune"):
+            assert manager.validate_template(name), f"{name} failed validation"

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -185,7 +185,7 @@ class TestContentTunerSystemBlocks:
         assert "Django project" in joined
 
     def test_system_blocks_include_six_component_headings(self) -> None:
-        """Phase 4: the rendered system prompt carries the 6-component framework."""
+        """The rendered system prompt carries the 6-component framework."""
         blocks = ContentTuner._build_system_blocks(
             "Source", "Target", preserve_sections=None
         )
@@ -481,7 +481,6 @@ class TestContentTunerTuneAsync:
 
         keyword = orchestrator.generate_tool_use_async.call_args.kwargs
         joined = " ".join(str(b["text"]) for b in keyword["system_blocks"])
-        # Phase 4: preserve list rendered through the content_tune template.
         assert "PRESERVE THESE SECTIONS UNCHANGED" in joined
         assert '"License"' in joined
         assert '"Credits"' in joined

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -237,6 +237,10 @@ class TestContentTunerSystemBlocks:
         blocks = ContentTuner._build_system_blocks(
             "Source", "Target", preserve_sections=None
         )
+        # The cache prefix is a single block by design — splitting it
+        # back into two would re-introduce the partition the
+        # consolidation removed, so pin the count.
+        assert len(blocks) == 1
         # Earlier blocks must not be marked or the cache key partition
         # would leak per-call deltas into the cached prefix.
         for block in blocks[:-1]:

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -184,36 +184,46 @@ class TestContentTunerSystemBlocks:
         assert "FastAPI project" in joined
         assert "Django project" in joined
 
-    def test_system_blocks_include_requirements(self) -> None:
-        """Requirements are part of the cached prefix."""
+    def test_system_blocks_include_six_component_headings(self) -> None:
+        """Phase 4: the rendered system prompt carries the 6-component framework."""
         blocks = ContentTuner._build_system_blocks(
             "Source", "Target", preserve_sections=None
         )
         joined = " ".join(str(b["text"]) for b in blocks)
-        assert "REQUIREMENTS:" in joined
+        for heading in (
+            "## Role",
+            "## Goal",
+            "## Context",
+            "## Output Format",
+            "## Examples",
+            "## Requirements",
+        ):
+            assert heading in joined, f"missing {heading} from system prompt"
+        # Specific behavioural directives the model must see.
         assert "Preserve the structure and format" in joined
-        assert "Adapt terminology" in joined
+        assert "report_tuning" in joined
 
     def test_system_blocks_omit_preserve_when_none(self) -> None:
-        """No preserve list → no preserve sentence in the instructions."""
+        """No preserve list → no preserve sentence in the rendered prompt."""
         blocks = ContentTuner._build_system_blocks(
             "Source", "Target", preserve_sections=None
         )
         joined = " ".join(str(b["text"]) for b in blocks)
-        assert "Leave the following sections unchanged" not in joined
+        assert "PRESERVE THESE SECTIONS UNCHANGED" not in joined
 
     def test_system_blocks_include_preserve_list(self) -> None:
-        """Preserve sections appear inline in the instructions block."""
+        """Preserve sections are listed in the rendered prompt."""
         blocks = ContentTuner._build_system_blocks(
             "Source",
             "Target",
             preserve_sections=["Introduction", "License"],
         )
         joined = " ".join(str(b["text"]) for b in blocks)
-        assert (
-            'Leave the following sections unchanged: "Introduction", "License"'
-            in joined
-        )
+        # Each section appears verbatim, regardless of whether the
+        # template renders inline or as a bullet list.
+        assert '"Introduction"' in joined
+        assert '"License"' in joined
+        assert "PRESERVE THESE SECTIONS UNCHANGED" in joined
 
     def test_last_system_block_is_cache_controlled(self) -> None:
         """Cache marker on the final block caches everything before it.
@@ -244,9 +254,10 @@ class TestContentTunerSystemBlocks:
         message = ContentTuner._build_user_message("# Original\n\nBody")
         assert "# Original" in message
         assert "Body" in message
-        # Sanity: the system prefix's distinctive markers must NOT
-        # appear here.
-        assert "REQUIREMENTS:" not in message
+        # Sanity: the system prefix's distinctive markers must NOT appear
+        # here — the user message is the per-call delta only.
+        assert "## Role" not in message
+        assert "## Requirements" not in message
         assert "SOURCE CONTEXT:" not in message
 
 
@@ -376,7 +387,8 @@ class TestContentTunerTuneAsync:
         prompt_arg = positional[0]
         assert isinstance(prompt_arg, str)
         # The user message must NOT carry the cached prefix content.
-        assert "REQUIREMENTS:" not in prompt_arg
+        assert "## Role" not in prompt_arg
+        assert "## Requirements" not in prompt_arg
         assert "Original" in prompt_arg
         # System blocks must include both contexts and end with a
         # cache_control marker — the cache-hit guarantee for back-to-
@@ -469,7 +481,10 @@ class TestContentTunerTuneAsync:
 
         keyword = orchestrator.generate_tool_use_async.call_args.kwargs
         joined = " ".join(str(b["text"]) for b in keyword["system_blocks"])
-        assert 'Leave the following sections unchanged: "License", "Credits"' in joined
+        # Phase 4: preserve list rendered through the content_tune template.
+        assert "PRESERVE THESE SECTIONS UNCHANGED" in joined
+        assert '"License"' in joined
+        assert '"Credits"' in joined
 
     @pytest.mark.asyncio
     async def test_tune_handles_generation_error(self) -> None:


### PR DESCRIPTION
## Summary

Phase 4 of the optimization roadmap: every inline f-string generator prompt is now a versioned Jinja2 template under `start_green_stay_green/ai/prompts/templates/`, conforming to the 6-component prompt-engineering framework (Role / Goal / Context / Output Format / Examples / Requirements).

## What landed

### Three new templates

| Template | Replaces | Role |
|---|---|---|
| `claude_md_tune.jinja2` | `ClaudeMdGenerator._build_generation_prompt`'s f-string | senior technical-documentation engineer |
| `ci_enhance.jinja2` | `CIGenerator._generate_with_ai`'s f-string | senior CI/CD engineer |
| `content_tune.jinja2` | `ContentTuner._build_system_blocks`'s inline instructions | senior agent designer |

`content_tune` is shared by both the subagents and skills generators (they share the tuner).

### Plumbing

- `PromptManager.SUPPORTED_TEMPLATE_TYPES` extended from 5 to 8 entries — the three new template names land alongside the existing five stubs (kept untouched).
- New `get_default_manager()` lazy singleton on `ai/prompts/manager.py` so generators don't re-parse the templates directory on every call. Construction is deferred until first call so test isolation with custom `template_dir` keeps working.
- Three callers refactored to `get_default_manager().render(name, ctx)`:
  - `ClaudeMdGenerator._build_generation_prompt`
  - `CIGenerator._generate_with_ai`
  - `ContentTuner._build_system_blocks`

### Behavioural change

`ContentTuner._build_system_blocks` now returns a **single** cache-controlled system block (rather than two). The cache contract is unchanged — the marked block at the tail still pins the entire stable prefix for ~5 minutes — but expressing "everything cacheable lives here" as one block is cleaner now that the prompt body is template-driven. Phase 2c's cache plumbing is unaffected.

## Tests (6 new)

- `TestPhase4TemplatesSixComponent` (4) — one assertion per new template that all six framework headings (`## Role` through `## Requirements`) are present in the rendered output, plus an empty-list defaults check on `claude_md_tune` and a preserve-section flow-through check on `content_tune`.
- `test_each_phase_4_template_validates` — pins `validate_template` returns `True` for each new entry so a template-rename refactor that drops one of these files is loud.
- `test_init_supported_template_types_constant` and the mutation-killer `test_supported_template_types_exact_set` updated to match the 8-element set.
- Existing `ContentTuner` system-block tests updated for the new rendering: assert `## Role` etc are present (rather than the previous `REQUIREMENTS:` text-anchor) and that preserve sections appear with their `"Identity"`-style quoted-string rendering. Test intent is the same — surface area moved.

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck, security, complexity — every function grade A).
- 1700 unit + 130 integration/e2e tests pass.

## Test plan

- [ ] CI green on this PR.
- [ ] Smoke: `green init` against a real API key — verify the model still produces a valid CLAUDE.md and 8 subagents (the prompt rewrite shouldn't change output validity, but the structure is more directive).
- [ ] Smoke: confirm `cache_read_tokens` still surfaces in `_timing.json` (Phase 2c regression guard — caching contract preserved).

## Roadmap status

- ✅ Phase 0 (telemetry) — PR #305
- ✅ Phase 1 (de-AI generators) — PR #305
- ✅ Phase 2 (subagent parallelism) — PR #305
- ✅ Phase 3a (two-pass split + flags) — PR #308
- ✅ Phase 3b (`green enhance` MVP) — PR #309
- ✅ Phase 3c (state file + skip logic) — PR #310
- ✅ Phase 2c (prompt caching + `tool_use`) — PR #311
- ⏳ **Phase 4 (this PR)** — prompt-engineering cleanup
- 🔜 Phase 5 (batch mode, optional), Phase 6 (UX/docs)

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_