### PR TITLE
feat(batch): Phase 5a — Batches API primitives + state + ADR

### DIFF
--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -27,10 +27,19 @@ Shipped:
   `CIGenerator`, and `ContentTuner` inline f-string prompts hoisted
   into `ai/prompts/templates/{claude_md_tune,ci_enhance,content_tune}.jinja2`,
   each conforming to the 6-component framework; routed through a
-  lazy `get_default_manager()` singleton) — branch
-  `claude/phase-4-prompt-cleanup`.
+  lazy `get_default_manager()` singleton) — PR #312 merged onto
+  main as commit `f094695`.
+- Phase 5a (Batches API primitives: `ai/batch.py` with
+  `ToolUseBatchRequest`, `BatchSubmission`, `BatchPoll`,
+  `BatchError`, `BatchResultsBundle`, `parse_batch_result_entry`;
+  three new orchestrator methods `submit_tool_use_batch`,
+  `poll_batch`, `fetch_batch_results`; `ContentTuner.build_batch_request`
+  + `parse_batch_tuning_result`; `EnhanceState.batch` + `BatchProgress`;
+  shared `ai/types.py` to break the orchestrator ↔ batch cycle;
+  ADR-001-batch-enhance.md) — branch
+  `claude/phase-5-batch-mode`. CLI wiring deferred to Phase 5b.
 
-Remaining: batch mode (5), UX/docs (6).
+Remaining: batch CLI wiring (5b), UX/docs (6).
 
 ---
 

--- a/plans/architecture/ADR-001-batch-enhance.md
+++ b/plans/architecture/ADR-001-batch-enhance.md
@@ -1,0 +1,151 @@
+# ADR-001 — Batch-Mode `green enhance`
+
+**Status**: Accepted
+**Date**: 2026-05-09
+**Phase**: 5a (primitives), 5b (CLI wiring — follow-up)
+
+## Context
+
+The Anthropic Message Batches API offers a 50 % discount for
+asynchronous bulk submissions (up to 100k requests per submission,
+≤24 h SLA). `green enhance` runs N independent per-target tunings
+(8 subagents + 0–N skills) — exactly the workload the Batches API
+was designed for, and the natural place to surface the discount.
+
+Phase 4 left us with a tuner that already builds its per-call payload
+through `_build_system_blocks` + `_build_user_message`, and a state
+file (Phase 3c) that already persists per-target completion records.
+The two together are 80 % of what a batch path needs; the remaining
+20 % is the SDK-level bridge (submit / poll / fetch) and a state
+extension for the in-flight batch id.
+
+## Decisions
+
+### D1 — Two-call CLI pattern, not an in-process polling loop
+
+When the user runs `green enhance --batch`:
+
+1. **First invocation**: build per-target requests, call
+   `submit_tool_use_batch`, persist the batch id to
+   `.claude/.enhance-state.json`, print a one-liner ("submitted, run
+   again to fetch"), exit 0.
+2. **Second invocation** (any time within ≤24 h): detect the
+   in-flight batch from state, call `poll_batch`. If still
+   running → print status, exit 0. If `ended` → call
+   `fetch_batch_results`, write per-target outputs, mark targets
+   completed, clear the batch field, exit 0.
+
+A `--wait` flag (Phase 5b, optional) drives an in-process
+`asyncio.sleep(30)` + poll loop for users who want a single blocking
+call. The two-call pattern is the **default** because:
+
+- It is friendly to CI (no long-running step waiting on a 50 %-cheaper
+  but multi-minute-to-multi-hour API).
+- It is naturally idempotent — losing the shell or hitting Ctrl-C
+  between submission and fetch is harmless; the state file carries
+  the recovery cursor.
+- The user-visible mental model is "I submitted; now I'll come back
+  and pick it up", which matches how the API actually works.
+
+### D2 — Batch types live in `ai/batch.py`, methods on `AIOrchestrator`
+
+`ai/batch.py` defines the dataclasses (`ToolUseBatchRequest`,
+`BatchSubmission`, `BatchPoll`, `BatchError`, `BatchResultsBundle`)
+and the per-result parser (`parse_batch_result_entry`).
+`AIOrchestrator` keeps the SDK calls (`submit_tool_use_batch`,
+`poll_batch`, `fetch_batch_results`).
+
+Why split? The parser and dataclasses are pure-data and unit-testable
+without any Anthropic client at all; the SDK calls are integration
+concerns. Splitting keeps each side small and lets the parser ship
+test doubles (plain dicts) instead of forcing tests to construct SDK
+Pydantic models.
+
+The cycle (`orchestrator` ↔ `batch`) is broken with **lazy local
+imports** inside the parser body — the only place a runtime
+construction of `ToolUseResult`/`TokenUsage` is needed. All other
+references are type annotations behind `from __future__ import
+annotations`, so they evaluate as strings and never trigger the
+cycle.
+
+### D3 — State extension is additive, schema version stays at 1
+
+`EnhanceState` gains an optional `batch: BatchProgress | None` field.
+When `None` (or empty `batch_id`), `to_dict` omits the `batch` key
+entirely so an existing state file written by a pre-batch CLI is
+byte-identical after a no-op round-trip. `from_dict` tolerates a
+missing `batch` key (returns `None`) and a malformed one (drops it,
+returns `None`) — same philosophy the rest of the loader follows.
+
+A pre-batch reader sees the new `batch` key as an unknown top-level
+field and ignores it; the docstring already commits us to that
+forward-compat contract. No version bump is required.
+
+### D4 — Per-request failures do not abort the batch reconciliation
+
+`fetch_batch_results` returns a `BatchResultsBundle` with two parallel
+maps (`successes` and `failures`) keyed by `custom_id`. The CLI's
+resume path can decide per-target whether to retry (Phase 5b) or
+report and skip — but a single `errored` request never raises through
+the orchestrator, because doing so would leak the cost of all the
+sibling `succeeded` requests that the user has already paid for.
+
+## Alternatives Considered
+
+### A1 — Submit + block in one CLI call
+
+A `green enhance --batch` that submits and blocks for the whole batch
+to finish was rejected because:
+
+- The 50 % discount comes with the trade-off that the SLA is
+  ≤24 h. A blocking CLI invocation can in principle hang for hours.
+  Operators routinely kill processes that have not progressed in
+  minutes; the batch then leaks (already paid for, never harvested).
+- Two-call works trivially in CI; one-call needs a "what if my CI
+  step times out?" story that the two-call pattern just does not
+  generate.
+
+### A2 — Consolidate all targets into one mega-prompt
+
+Submit one `messages.create` with a prompt that asks the model to
+adapt all 8 subagents at once. Rejected because it loses
+**per-target token accounting and per-target retry**, both of which
+the existing telemetry (Phase 0) and skip-unchanged (Phase 3c) paths
+depend on. The Batches API submits N independent requests inside one
+submission — that gives us the 50 % discount **without** flattening
+the per-request shape.
+
+### A3 — Move batch types into `orchestrator.py`
+
+Originally drafted that way. Reverted because the parser is the
+biggest single component (~80 lines), and it is testable without
+spinning up any SDK client. Keeping it in its own module makes the
+test seam wider.
+
+## Consequences
+
+**Positive**:
+- Bulk runs (CI projects, demo repos, batch enhancement of
+  multi-language scaffolds) get a 50 % cost reduction.
+- The state file becomes the single source of truth for both
+  "what was last completed?" and "what is currently in flight?".
+- The parser is a thin pure function — easy to unit-test, easy to
+  swap if the SDK shape changes.
+
+**Negative**:
+- Two-call UX is unfamiliar; users who expect a long-running command
+  may run the second invocation too soon and see a status line. The
+  `--wait` flag (Phase 5b) covers that case for users who want it.
+- Recovery from a state-file corruption between submit and fetch
+  costs the user the batch — they pay but cannot retrieve. This
+  matches the existing state-file philosophy ("worst case re-tune");
+  documenting that explicitly in `green enhance --help` is part of
+  Phase 5b.
+
+## Phase 5 Scope
+
+- **5a (this PR)**: orchestrator primitives + tuner request builder
+  + state extension + this ADR. No CLI wiring; no user-visible flag.
+- **5b (follow-up PR)**: `green enhance --batch` flag, the two-call
+  flow, optional `--wait` for in-process polling, README + `--help`
+  copy.

--- a/plans/architecture/ADR-001-batch-enhance.md
+++ b/plans/architecture/ADR-001-batch-enhance.md
@@ -61,12 +61,15 @@ concerns. Splitting keeps each side small and lets the parser ship
 test doubles (plain dicts) instead of forcing tests to construct SDK
 Pydantic models.
 
-The cycle (`orchestrator` ↔ `batch`) is broken with **lazy local
-imports** inside the parser body — the only place a runtime
-construction of `ToolUseResult`/`TokenUsage` is needed. All other
-references are type annotations behind `from __future__ import
-annotations`, so they evaluate as strings and never trigger the
-cycle.
+The cycle (`orchestrator` needs `ai/batch.py`'s types to declare its
+new methods; `ai/batch.py`'s parser builds `ToolUseResult`/`TokenUsage`
+from result entries) is broken with a third module:
+**`ai/types.py`** holds `GenerationError`, `TokenUsage`,
+`GenerationResult`, and `ToolUseResult`. Both `orchestrator` and
+`batch` import from `ai.types` at the top level — no lazy imports,
+no runtime cycle. `orchestrator.py` re-exports the same names so
+existing `from start_green_stay_green.ai.orchestrator import
+ToolUseResult` callsites across the codebase keep working.
 
 ### D3 — State extension is additive, schema version stays at 1
 

--- a/start_green_stay_green/ai/batch.py
+++ b/start_green_stay_green/ai/batch.py
@@ -84,9 +84,15 @@ class BatchPoll:
         processing_count: Requests still being processed.
         succeeded_count: Requests that completed with a usable
             response.
-        errored_count: Requests that failed; these still incur cost
-            and need handling per-target rather than aborting the
-            whole batch.
+        errored_count: Requests that failed for reasons other than
+            user cancel or 24 h SLA expiry.
+        canceled_count: Requests aborted by an explicit batch
+            cancel. Phase 5b reconciliation should leave these alone
+            (the user already chose to drop them).
+        expired_count: Requests that hit the 24 h SLA without
+            completing. Distinct from ``errored`` so the CLI can
+            decide to re-submit only the SLA-breach subset rather
+            than retrying every failure type uniformly.
     """
 
     batch_id: str
@@ -94,6 +100,8 @@ class BatchPoll:
     processing_count: int
     succeeded_count: int
     errored_count: int
+    canceled_count: int = 0
+    expired_count: int = 0
 
     @property
     def is_ended(self) -> bool:

--- a/start_green_stay_green/ai/batch.py
+++ b/start_green_stay_green/ai/batch.py
@@ -1,0 +1,303 @@
+"""Batch-mode types and helpers for the Anthropic Message Batches API.
+
+Phase 5a of the optimization roadmap. Defines the request/response
+dataclasses and the parser that lifts a batch result back into the
+existing :class:`ToolUseResult` shape, so batch and sync paths share a
+single downstream codepath.
+
+The Batches API submits up to 100k requests per submission, returns
+results within 24 h at a 50 % discount versus sync. Per-request token
+accounting and failure modes are preserved — batch mode is *cheaper*
+parallelism, not consolidation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class ToolUseBatchRequest:
+    """A single ``tool_use`` request bundled into a batch submission.
+
+    Mirrors the inputs :meth:`AIOrchestrator.generate_tool_use_async`
+    consumes for a sync call: a per-call user message, the ordered
+    system blocks, the forced-tool schema. The added ``custom_id`` is
+    what the Anthropic API uses to key the per-request result on the
+    way back; callers map it to whatever target identifier they need
+    (e.g. ``"subagent:architecture-review"``).
+
+    Attributes:
+        custom_id: Caller-chosen identifier, unique within one batch.
+            Echoed back in the result so the caller can correlate
+            outputs with the originating target.
+        prompt: User-message body (per-call delta).
+        system_blocks: Ordered list of system-prompt blocks; the same
+            shape :meth:`generate_tool_use_async` accepts.
+        tool_schema: Anthropic-SDK-shaped tool definition.
+    """
+
+    custom_id: str
+    prompt: str
+    system_blocks: list[dict[str, object]]
+    tool_schema: dict[str, object]
+
+
+@dataclass(frozen=True)
+class BatchSubmission:
+    """Metadata returned by :meth:`AIOrchestrator.submit_tool_use_batch`.
+
+    Attributes:
+        batch_id: Anthropic's identifier for the submission. Persist
+            this so a follow-up invocation can resume polling without
+            re-submitting.
+        custom_ids: The exact list of ``custom_id`` values submitted,
+            in order. Lets a caller verify nothing was dropped, and
+            lets the resume path know which targets to expect back.
+        submitted_at: ISO-8601 UTC timestamp of when the batch was
+            accepted by the API. Diagnostic only.
+    """
+
+    batch_id: str
+    custom_ids: list[str]
+    submitted_at: str
+
+
+@dataclass(frozen=True)
+class BatchPoll:
+    """Snapshot of an in-flight batch's state.
+
+    Attributes:
+        batch_id: The batch this snapshot describes.
+        status: Anthropic-defined lifecycle state. ``"in_progress"``
+            and ``"canceling"`` mean keep polling; ``"ended"`` means
+            results are ready (some may still have errored).
+        processing_count: Requests still being processed.
+        succeeded_count: Requests that completed with a usable
+            response.
+        errored_count: Requests that failed; these still incur cost
+            and need handling per-target rather than aborting the
+            whole batch.
+    """
+
+    batch_id: str
+    status: str
+    processing_count: int
+    succeeded_count: int
+    errored_count: int
+
+    @property
+    def is_ended(self) -> bool:
+        """``True`` when results are ready to fetch."""
+        return self.status == "ended"
+
+
+@dataclass(frozen=True)
+class BatchError:
+    """Per-request failure stand-in for a missing :class:`ToolUseResult`.
+
+    Returned in place of a result when a single request inside a batch
+    failed (the rest of the batch is unaffected). The caller decides
+    whether to retry, skip, or abort.
+
+    Attributes:
+        custom_id: Echo of the originating request's custom id.
+        result_type: Anthropic's result-type label —
+            ``"errored"``, ``"canceled"``, or ``"expired"``.
+        message: Best-effort diagnostic string lifted from the API
+            error body; empty when the API gave none.
+    """
+
+    custom_id: str
+    result_type: str
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class BatchResultsBundle:
+    """Successful + failed per-request outcomes from a finished batch.
+
+    Two parallel maps so callers do not have to inspect a union type
+    on every lookup. Both keyed by ``custom_id``.
+
+    Attributes:
+        successes: ``custom_id`` → :class:`ToolUseResult` for each
+            request the model completed.
+        failures: ``custom_id`` → :class:`BatchError` for each request
+            that errored, was canceled, or expired.
+    """
+
+    successes: dict[str, ToolUseResult] = field(default_factory=dict)
+    failures: dict[str, BatchError] = field(default_factory=dict)
+
+    @property
+    def total(self) -> int:
+        """Combined count of successes and failures."""
+        return len(self.successes) + len(self.failures)
+
+
+def parse_batch_result_entry(entry: object) -> tuple[str, ToolUseResult | BatchError]:
+    """Lift one streamed result entry into the parallel-map shape.
+
+    The Anthropic SDK returns each entry of
+    ``client.messages.batches.results(batch_id)`` as an object with a
+    ``custom_id``, a ``result.type`` discriminator, and either
+    ``result.message`` (on success) or an error payload. This
+    function discriminates on that shape and returns either a
+    :class:`ToolUseResult` (success) or a :class:`BatchError`
+    (any non-success type).
+
+    Kept separate from :class:`AIOrchestrator` so the parser is unit-
+    testable against fakes without touching network code, and so a
+    future SDK shape-change is one focused diff.
+
+    Args:
+        entry: One element of the streamed batch results. Duck-typed
+            against the SDK's ``BatchResult`` shape so this works
+            with both real responses and dict-shaped test doubles.
+
+    Returns:
+        ``(custom_id, ToolUseResult | BatchError)`` — caller keys the
+        appropriate map with the id.
+
+    Raises:
+        GenerationError: If the entry is shaped so unexpectedly that
+            no useful ``custom_id`` can be recovered. Per-request
+            failures (``errored``, etc.) do not raise — they return a
+            :class:`BatchError`.
+    """
+    custom_id = _extract_attr(entry, "custom_id")
+    if not isinstance(custom_id, str) or not custom_id:
+        msg = "Batch result entry is missing a usable custom_id"
+        raise GenerationError(msg)
+
+    result = _extract_attr(entry, "result")
+    result_type = _extract_attr(result, "type")
+    if not isinstance(result_type, str):
+        return custom_id, BatchError(
+            custom_id=custom_id,
+            result_type="unknown",
+            message="Batch result entry is missing result.type",
+        )
+
+    if result_type == "succeeded":
+        message = _extract_attr(result, "message")
+        return custom_id, _tool_use_result_from_message(message)
+
+    return custom_id, BatchError(
+        custom_id=custom_id,
+        result_type=result_type,
+        message=_extract_error_message(result),
+    )
+
+
+def _tool_use_result_from_message(message: object) -> ToolUseResult:
+    """Build a :class:`ToolUseResult` from a batch's success ``message``.
+
+    The success-side payload is the same shape as a normal
+    ``messages.create`` response, so the lift is mechanical: pull the
+    first ``ToolUseBlock``, copy ``input`` and token usage. Cache
+    tokens are surfaced when present so batch users see the same
+    telemetry sync users get.
+    """
+    tool_block = _required_tool_block(message)
+    tool_input = _required_tool_input(tool_block)
+    usage = _extract_attr(message, "usage")
+    return ToolUseResult(
+        tool_name=str(_extract_attr(tool_block, "name") or ""),
+        tool_input=dict(tool_input),
+        token_usage=TokenUsage(
+            input_tokens=_int_attr(usage, "input_tokens"),
+            output_tokens=_int_attr(usage, "output_tokens"),
+        ),
+        model=str(_extract_attr(message, "model") or ""),
+        message_id=str(_extract_attr(message, "id") or ""),
+        cache_read_tokens=_int_attr(usage, "cache_read_input_tokens"),
+        cache_creation_tokens=_int_attr(usage, "cache_creation_input_tokens"),
+    )
+
+
+def _required_tool_block(message: object) -> object:
+    """Return the message's first ``ToolUseBlock`` or raise."""
+    content = _extract_attr(message, "content") or []
+    block = _first_tool_use_block(content)
+    if block is None:
+        msg = "Batch result message did not contain a ToolUseBlock"
+        raise GenerationError(msg)
+    return block
+
+
+def _required_tool_input(tool_block: object) -> dict[str, object]:
+    """Return the block's ``input`` dict or raise on a non-dict."""
+    tool_input = _extract_attr(tool_block, "input")
+    if not isinstance(tool_input, dict):
+        msg = "Batch ToolUseBlock.input was not a JSON object"
+        raise GenerationError(msg)
+    return tool_input
+
+
+def _int_attr(obj: object, name: str) -> int:
+    """Read ``name`` off ``obj`` as an int, defaulting to ``0`` when absent."""
+    value = _extract_attr(obj, name)
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return 0
+
+
+def _first_tool_use_block(content: object) -> object | None:
+    """Return the first content block that looks like a ``ToolUseBlock``.
+
+    Duck-typed: a block qualifies if ``type == "tool_use"`` (real
+    SDK objects, JSON dicts, and test doubles all expose this the
+    same way).
+    """
+    for block in _iter_blocks(content):
+        if _extract_attr(block, "type") == "tool_use":
+            return block
+    return None
+
+
+def _iter_blocks(content: object) -> Iterable[object]:
+    """Iterate over a content payload that might be a list or a single block."""
+    if isinstance(content, list):
+        return content
+    if content is None:
+        return []
+    return [content]
+
+
+def _extract_attr(obj: object, name: str) -> object:
+    """Read ``name`` from ``obj`` whether it is a dict, an SDK model, or ``None``.
+
+    The Anthropic SDK exposes responses as Pydantic models; tests
+    drive this code with plain dicts. ``getattr`` first, ``[]`` next,
+    ``None`` if neither — keeps the parser tolerant of either shape
+    without conditioning on isinstance everywhere.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _extract_error_message(result: object) -> str:
+    """Best-effort error-string lift from a non-success result entry."""
+    error = _extract_attr(result, "error")
+    if error is None:
+        return ""
+    message = _extract_attr(error, "message")
+    if isinstance(message, str):
+        return message
+    return str(error)

--- a/start_green_stay_green/ai/batch.py
+++ b/start_green_stay_green/ai/batch.py
@@ -24,6 +24,15 @@ from start_green_stay_green.ai.types import ToolUseResult
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+__all__ = [
+    "BatchError",
+    "BatchPoll",
+    "BatchResultsBundle",
+    "BatchSubmission",
+    "ToolUseBatchRequest",
+    "parse_batch_result_entry",
+]
+
 
 @dataclass(frozen=True)
 class ToolUseBatchRequest:

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
 import time
 from typing import Final
 from typing import Literal
@@ -17,31 +19,53 @@ from anthropic import AsyncAnthropic
 from anthropic.types import TextBlock
 from anthropic.types import ToolUseBlock
 
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.batch import parse_batch_result_entry
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import GenerationResult
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
 from start_green_stay_green.utils.timing import APICallRecord
 from start_green_stay_green.utils.timing import get_active_report
 
+# Re-export shared types so existing
+# ``from start_green_stay_green.ai.orchestrator import ToolUseResult``
+# imports keep working after the Phase-5a relocation to ``ai.types``.
+__all__ = [
+    "AIOrchestrator",
+    "GenerationError",
+    "GenerationResult",
+    "ModelConfig",
+    "PromptTemplateError",
+    "TokenUsage",
+    "ToolUseResult",
+]
+
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from collections.abc import Iterator
+    from collections.abc import Sequence
 
     from start_green_stay_green.utils.timing import TimingReport
 
 
-class GenerationError(Exception):
-    """Raised when AI generation fails.
+async def _aiter(stream: object) -> AsyncIterator[object]:
+    """Yield from an async iterator OR a sync iterable.
 
-    Attributes:
-        cause: Optional underlying exception that caused this error.
+    The Anthropic SDK's ``messages.batches.results`` returns an
+    async iterator at runtime, but unit tests construct fakes that
+    are easier to write as plain lists. Accept both shapes so the
+    test seam is wide.
     """
-
-    def __init__(self, message: str, *, cause: Exception | None = None) -> None:
-        """Initialize GenerationError.
-
-        Args:
-            message: Error message describing the failure.
-            cause: Optional underlying exception that caused this error.
-        """
-        super().__init__(message)
-        self.cause = cause
+    if hasattr(stream, "__aiter__"):
+        async for item in stream:
+            yield item
+        return
+    for item in stream:  # type: ignore[attr-defined]
+        yield item
 
 
 class PromptTemplateError(Exception):
@@ -57,83 +81,6 @@ class ModelConfig:
 
     OPUS: Final[str] = "claude-opus-4-5-20251101"
     SONNET: Final[str] = "claude-sonnet-4-5-20250929"
-
-
-@dataclass(frozen=True)
-class TokenUsage:
-    """Token usage information from API response.
-
-    Attributes:
-        input_tokens: Number of tokens in the prompt.
-        output_tokens: Number of tokens in the response.
-    """
-
-    input_tokens: int
-    output_tokens: int
-
-    @property
-    def total_tokens(self) -> int:
-        """Calculate total tokens used.
-
-        Returns:
-            Sum of input and output tokens.
-        """
-        return self.input_tokens + self.output_tokens
-
-
-@dataclass(frozen=True)
-class GenerationResult:
-    """Result from AI generation request.
-
-    Attributes:
-        content: Generated content from the AI model.
-        format: Output format (yaml, toml, markdown, bash).
-        token_usage: Token usage statistics for the request.
-        cache_read_tokens: Subset of input tokens served from the
-            prompt cache. ``0`` when caching is disabled or the
-            response did not report this field.
-        cache_creation_tokens: Tokens written to the prompt cache on
-            this call (billed at a higher rate than reads).
-        model: Model identifier used for generation.
-        message_id: Unique identifier for the API message.
-    """
-
-    content: str
-    format: str
-    token_usage: TokenUsage
-    model: str
-    message_id: str
-    cache_read_tokens: int = 0
-    cache_creation_tokens: int = 0
-
-
-@dataclass(frozen=True)
-class ToolUseResult:
-    """Result from a structured (``tool_use``) API call.
-
-    The Claude API returns a JSON object validated against the tool's
-    ``input_schema``; ``tool_input`` is that object verbatim. Replaces
-    free-form text parsing for callers that need typed fields out of
-    the model.
-
-    Attributes:
-        tool_name: Name of the tool the model invoked.
-        tool_input: Parsed JSON input the model passed to the tool.
-        token_usage: Token usage statistics for the request.
-        cache_read_tokens: Subset of input tokens served from the
-            prompt cache.
-        cache_creation_tokens: Tokens written to the prompt cache.
-        model: Model identifier used for generation.
-        message_id: Unique identifier for the API message.
-    """
-
-    tool_name: str
-    tool_input: dict[str, object]
-    token_usage: TokenUsage
-    model: str
-    message_id: str
-    cache_read_tokens: int = 0
-    cache_creation_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -745,3 +692,185 @@ class AIOrchestrator:
         if self._async_client is not None:
             await self._async_client.close()
             self._async_client = None
+
+    async def submit_tool_use_batch(
+        self,
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> BatchSubmission:
+        """Submit ``requests`` as a single Message Batches API call.
+
+        Each :class:`ToolUseBatchRequest` is translated into the
+        Batches-API request envelope (``custom_id`` + ``params``) and
+        the whole list is passed to
+        ``client.messages.batches.create``. Returns the batch id and
+        an echo of the submitted ``custom_id`` order so callers can
+        persist both for a later resume.
+
+        The forced ``tool_choice`` mirrors :meth:`generate_tool_use_async`
+        — the model is required to invoke the supplied tool, so the
+        result message is guaranteed to contain a
+        ``ToolUseBlock``. This keeps the result parser
+        (:func:`parse_batch_result_entry`) simple.
+
+        Args:
+            requests: One or more :class:`ToolUseBatchRequest`
+                payloads. Empty input is rejected (the SDK would reject
+                it server-side; failing locally keeps the error close
+                to the caller).
+
+        Returns:
+            :class:`BatchSubmission` with the new ``batch_id`` and the
+            ``custom_id`` echo list.
+
+        Raises:
+            ValueError: If ``requests`` is empty or contains duplicate
+                ``custom_id`` values.
+            GenerationError: If the API call fails.
+        """
+        custom_ids = self._validate_batch_requests(requests)
+        payload = [self._batch_request_envelope(r) for r in requests]
+        batch = await self._create_batch(payload)
+        return BatchSubmission(
+            batch_id=str(getattr(batch, "id", "") or ""),
+            custom_ids=list(custom_ids),
+            submitted_at=datetime.now(UTC).isoformat(),
+        )
+
+    @staticmethod
+    def _validate_batch_requests(
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> list[str]:
+        """Pre-flight validation; returns the ordered ``custom_id`` list."""
+        if not requests:
+            msg = "submit_tool_use_batch requires at least one request"
+            raise ValueError(msg)
+        custom_ids = [r.custom_id for r in requests]
+        if len(set(custom_ids)) != len(custom_ids):
+            msg = "submit_tool_use_batch requests must have unique custom_id values"
+            raise ValueError(msg)
+        return custom_ids
+
+    async def _create_batch(self, payload: list[dict[str, object]]) -> object:
+        """Wrap the SDK call so callers see ``GenerationError`` on failure."""
+        client = self._get_async_client()
+        try:
+            return await client.messages.batches.create(
+                requests=payload,  # type: ignore[arg-type]
+            )
+        except Exception as exc:  # pragma: no cover - exercised via integration
+            msg = "Batch submission failed"
+            raise GenerationError(msg, cause=exc) from exc
+
+    async def poll_batch(self, batch_id: str) -> BatchPoll:
+        """Return the current state of an in-flight batch.
+
+        Single retrieve call — no internal polling loop. Callers that
+        want a blocking wait drive their own sleep/poll cycle (see the
+        ADR for why the two-call CLI pattern is preferred over a
+        long-running command).
+
+        Args:
+            batch_id: Identifier returned from
+                :meth:`submit_tool_use_batch`.
+
+        Returns:
+            :class:`BatchPoll` with status and per-state counts.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the API call fails.
+        """
+        self._require_batch_id(batch_id, "poll_batch")
+        batch = await self._retrieve_batch(batch_id)
+        counts = getattr(batch, "request_counts", None)
+        return BatchPoll(
+            batch_id=batch_id,
+            status=str(getattr(batch, "processing_status", "") or ""),
+            processing_count=int(getattr(counts, "processing", 0) or 0),
+            succeeded_count=int(getattr(counts, "succeeded", 0) or 0),
+            errored_count=int(getattr(counts, "errored", 0) or 0),
+        )
+
+    async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
+        """Stream a finished batch's results into ``(successes, failures)``.
+
+        Calls ``client.messages.batches.results(batch_id)`` and folds
+        each entry through :func:`parse_batch_result_entry`. Successes
+        land in :attr:`BatchResultsBundle.successes` keyed by
+        ``custom_id``; non-success entries (errored, canceled,
+        expired) land in :attr:`BatchResultsBundle.failures`.
+
+        Args:
+            batch_id: Identifier of an ``ended`` batch.
+
+        Returns:
+            :class:`BatchResultsBundle` with per-``custom_id`` results.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the API call fails or any entry's
+                shape is unrecoverably malformed (per-request
+                failures do *not* raise — they populate ``failures``).
+        """
+        self._require_batch_id(batch_id, "fetch_batch_results")
+        stream = await self._open_results_stream(batch_id)
+        bundle = BatchResultsBundle()
+        async for entry in _aiter(stream):
+            custom_id, outcome = parse_batch_result_entry(entry)
+            if isinstance(outcome, ToolUseResult):
+                bundle.successes[custom_id] = outcome
+            else:
+                bundle.failures[custom_id] = outcome
+        return bundle
+
+    @staticmethod
+    def _require_batch_id(batch_id: str, op: str) -> None:
+        """Reject empty/missing ``batch_id`` close to the caller."""
+        if not batch_id:
+            msg = f"{op} requires a non-empty batch_id"
+            raise ValueError(msg)
+
+    async def _retrieve_batch(self, batch_id: str) -> object:
+        """Wrap the SDK retrieve so callers see ``GenerationError`` on failure."""
+        client = self._get_async_client()
+        try:
+            return await client.messages.batches.retrieve(batch_id)
+        except Exception as exc:  # pragma: no cover - exercised via integration
+            msg = f"Batch retrieve failed for {batch_id}"
+            raise GenerationError(msg, cause=exc) from exc
+
+    async def _open_results_stream(self, batch_id: str) -> object:
+        """Wrap the SDK results call so callers see ``GenerationError`` on failure."""
+        client = self._get_async_client()
+        try:
+            return await client.messages.batches.results(batch_id)
+        except Exception as exc:  # pragma: no cover - exercised via integration
+            msg = f"Batch results stream failed for {batch_id}"
+            raise GenerationError(msg, cause=exc) from exc
+
+    def _batch_request_envelope(
+        self,
+        request: ToolUseBatchRequest,
+    ) -> dict[str, object]:
+        """Wrap one :class:`ToolUseBatchRequest` in Batches-API shape.
+
+        The Anthropic Batches API expects a list of
+        ``{"custom_id": ..., "params": {...}}`` dicts where ``params``
+        is a normal ``messages.create`` body. The body fields here
+        mirror :meth:`_call_tool_api_async` so the per-request
+        contract is identical between sync and batch paths.
+        """
+        tool_name = str(request.tool_schema["name"])
+        return {
+            "custom_id": request.custom_id,
+            "params": {
+                "model": self.model,
+                "max_tokens": 4096,
+                "system": list(request.system_blocks),
+                "tools": [request.tool_schema],
+                "tool_choice": {"type": "tool", "name": tool_name},
+                "messages": [
+                    {"role": "user", "content": request.prompt},
+                ],
+            },
+        }

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -19,6 +19,7 @@ from anthropic import AsyncAnthropic
 from anthropic.types import TextBlock
 from anthropic.types import ToolUseBlock
 
+from start_green_stay_green.ai.batch import BatchError
 from start_green_stay_green.ai.batch import BatchPoll
 from start_green_stay_green.ai.batch import BatchResultsBundle
 from start_green_stay_green.ai.batch import BatchSubmission
@@ -757,7 +758,7 @@ class AIOrchestrator:
             return await client.messages.batches.create(
                 requests=payload,  # type: ignore[arg-type]
             )
-        except Exception as exc:  # pragma: no cover - exercised via integration
+        except Exception as exc:
             msg = "Batch submission failed"
             raise GenerationError(msg, cause=exc) from exc
 
@@ -814,14 +815,21 @@ class AIOrchestrator:
         """
         self._require_batch_id(batch_id, "fetch_batch_results")
         stream = await self._open_results_stream(batch_id)
-        bundle = BatchResultsBundle()
+        # Collect into local dicts and construct the frozen bundle at
+        # the end. Mutating the bundle's fields in-place after
+        # construction worked (``frozen=True`` doesn't deep-freeze
+        # mutable containers) but read as a contradiction — a reader
+        # seeing ``frozen=True`` reasonably expects the object to be
+        # fully immutable.
+        successes: dict[str, ToolUseResult] = {}
+        failures: dict[str, BatchError] = {}
         async for entry in _aiter(stream):
             custom_id, outcome = parse_batch_result_entry(entry)
             if isinstance(outcome, ToolUseResult):
-                bundle.successes[custom_id] = outcome
+                successes[custom_id] = outcome
             else:
-                bundle.failures[custom_id] = outcome
-        return bundle
+                failures[custom_id] = outcome
+        return BatchResultsBundle(successes=successes, failures=failures)
 
     @staticmethod
     def _require_batch_id(batch_id: str, op: str) -> None:
@@ -835,7 +843,7 @@ class AIOrchestrator:
         client = self._get_async_client()
         try:
             return await client.messages.batches.retrieve(batch_id)
-        except Exception as exc:  # pragma: no cover - exercised via integration
+        except Exception as exc:
             msg = f"Batch retrieve failed for {batch_id}"
             raise GenerationError(msg, cause=exc) from exc
 
@@ -844,7 +852,7 @@ class AIOrchestrator:
         client = self._get_async_client()
         try:
             return await client.messages.batches.results(batch_id)
-        except Exception as exc:  # pragma: no cover - exercised via integration
+        except Exception as exc:
             msg = f"Batch results stream failed for {batch_id}"
             raise GenerationError(msg, cause=exc) from exc
 

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -6,6 +6,7 @@ Coordinates AI-powered generation tasks using Claude API.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
@@ -33,6 +34,14 @@ from start_green_stay_green.ai.types import ToolUseResult
 from start_green_stay_green.utils.timing import APICallRecord
 from start_green_stay_green.utils.timing import get_active_report
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from collections.abc import Iterable
+    from collections.abc import Iterator
+    from collections.abc import Sequence
+
+    from start_green_stay_green.utils.timing import TimingReport
+
 # Re-export shared types so existing
 # ``from start_green_stay_green.ai.orchestrator import ToolUseResult``
 # imports keep working after the Phase-5a relocation to ``ai.types``.
@@ -45,16 +54,6 @@ __all__ = [
     "TokenUsage",
     "ToolUseResult",
 ]
-
-from collections.abc import AsyncIterable
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-    from collections.abc import Iterable
-    from collections.abc import Iterator
-    from collections.abc import Sequence
-
-    from start_green_stay_green.utils.timing import TimingReport
 
 
 async def _aiter(
@@ -863,9 +862,19 @@ class AIOrchestrator:
             raise GenerationError(msg, cause=exc) from exc
 
     async def _open_results_stream(
-        self, batch_id: str,
+        self,
+        batch_id: str,
     ) -> AsyncIterable[object] | Iterable[object]:
         """Open the batch's result stream as an iterable.
+
+        ``AsyncBatches.results()`` is ``async def`` (a coroutine
+        function — *not* an async-generator function); it returns a
+        coroutine that resolves to an
+        ``AsyncJSONLDecoder[MessageBatchIndividualResponse]``. The
+        decoder is itself an async iterable, hence the
+        ``await`` then ``async for`` pattern in the caller.
+        Verified against ``anthropic`` SDK 0.97.0 by reading
+        ``inspect.iscoroutinefunction(AsyncBatches.results)``.
 
         Returns the iterable shape ``_aiter`` expects directly, so
         callers do not have to cast. SDK errors are remapped to

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -939,12 +939,20 @@ class AIOrchestrator:
         mirror :meth:`_call_tool_api_async` so the per-request
         contract is identical between sync and batch paths.
 
-        Uses ``request.tool_schema.get("name", "")`` rather than the
-        bracket form so a malformed schema produces an empty
-        ``tool_choice.name`` (the API rejects it with a clear error)
-        instead of an opaque ``KeyError`` at a future call site.
+        Validates ``tool_schema["name"]`` is non-empty before
+        constructing the envelope. The API would reject a missing
+        name with an opaque HTTP 400 wrapped in a generic
+        ``GenerationError``; failing close to the caller with a
+        named-field error is more debuggable.
         """
-        tool_name = str(request.tool_schema.get("name", ""))
+        raw_name = request.tool_schema.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            msg = (
+                f"tool_schema for custom_id {request.custom_id!r} "
+                "must include a non-empty 'name' string"
+            )
+            raise GenerationError(msg)
+        tool_name = raw_name
         return {
             "custom_id": request.custom_id,
             "params": {

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Sequence
 
+    from anthropic.types.messages.batch_create_params import (
+        Request as BatchCreateRequest,
+    )
+
     from start_green_stay_green.utils.timing import TimingReport
 
 # Re-export shared types so existing
@@ -54,6 +58,16 @@ __all__ = [
     "TokenUsage",
     "ToolUseResult",
 ]
+
+
+def _count(obj: object, name: str) -> int:
+    """Read a count attribute off ``obj``, defaulting to ``0``.
+
+    SDK response objects expose ``request_counts.processing`` etc. as
+    plain ``int`` attributes; tests pass ``MagicMock`` doubles. Keeps
+    ``poll_batch``'s body short enough to stay grade-A complex.
+    """
+    return int(getattr(obj, name, 0) or 0)
 
 
 async def _aiter(
@@ -766,11 +780,24 @@ class AIOrchestrator:
         return custom_ids
 
     async def _create_batch(self, payload: list[dict[str, object]]) -> object:
-        """Wrap the SDK call so callers see ``GenerationError`` on failure."""
+        """Wrap the SDK call so callers see ``GenerationError`` on failure.
+
+        The SDK signature is
+        ``create(*, requests: Iterable[batch_create_params.Request])``.
+        We construct each envelope as a ``dict[str, object]`` matching
+        the ``Request`` ``TypedDict`` shape (verified by
+        ``test_request_envelope_carries_tool_choice_and_system``).
+        Mypy cannot prove the dict matches the TypedDict's deeply-nested
+        ``MessageCreateParamsNonStreaming`` shape without re-typing the
+        ``ToolUseBatchRequest.system_blocks`` chain end-to-end, so we
+        use one ``cast()`` at the SDK boundary to assert the contract
+        rather than a ``# type: ignore`` to suppress it. ``cast`` is
+        documented narrowing; ``type: ignore`` is suppression.
+        """
         client = self._get_async_client()
         try:
             return await client.messages.batches.create(
-                requests=payload,  # type: ignore[arg-type]
+                requests=cast("Iterable[BatchCreateRequest]", payload),
             )
         except Exception as exc:
             msg = "Batch submission failed"
@@ -797,13 +824,20 @@ class AIOrchestrator:
         """
         self._require_batch_id(batch_id, "poll_batch")
         batch = await self._retrieve_batch(batch_id)
+        return self._batch_poll_from_response(batch_id, batch)
+
+    @staticmethod
+    def _batch_poll_from_response(batch_id: str, batch: object) -> BatchPoll:
+        """Pull the ``BatchPoll`` snapshot fields off a SDK response object."""
         counts = getattr(batch, "request_counts", None)
         return BatchPoll(
             batch_id=batch_id,
             status=str(getattr(batch, "processing_status", "") or ""),
-            processing_count=int(getattr(counts, "processing", 0) or 0),
-            succeeded_count=int(getattr(counts, "succeeded", 0) or 0),
-            errored_count=int(getattr(counts, "errored", 0) or 0),
+            processing_count=_count(counts, "processing"),
+            succeeded_count=_count(counts, "succeeded"),
+            errored_count=_count(counts, "errored"),
+            canceled_count=_count(counts, "canceled"),
+            expired_count=_count(counts, "expired"),
         )
 
     async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
@@ -904,8 +938,13 @@ class AIOrchestrator:
         is a normal ``messages.create`` body. The body fields here
         mirror :meth:`_call_tool_api_async` so the per-request
         contract is identical between sync and batch paths.
+
+        Uses ``request.tool_schema.get("name", "")`` rather than the
+        bracket form so a malformed schema produces an empty
+        ``tool_choice.name`` (the API rejects it with a clear error)
+        instead of an opaque ``KeyError`` at a future call site.
         """
-        tool_name = str(request.tool_schema["name"])
+        tool_name = str(request.tool_schema.get("name", ""))
         return {
             "custom_id": request.custom_id,
             "params": {

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -46,9 +46,15 @@ if TYPE_CHECKING:
 
     from start_green_stay_green.utils.timing import TimingReport
 
-# Re-export shared types so existing
+# Re-export shared types from ``ai.types`` so existing
 # ``from start_green_stay_green.ai.orchestrator import ToolUseResult``
-# imports keep working after the Phase-5a relocation to ``ai.types``.
+# imports keep working after the Phase-5a relocation. The names
+# below look unused locally but ARE the public API surface of this
+# module — do not remove without a coordinated migration of every
+# downstream call site (and the corresponding tests). The
+# back-compat contract is asserted by
+# tests/unit/ai/test_orchestrator.py — any removal here without
+# that test update will fail import-time mypy in callers.
 __all__ = [
     "AIOrchestrator",
     "GenerationError",
@@ -564,8 +570,13 @@ class AIOrchestrator:
         response. The block's ``input`` (already validated against the
         tool's ``input_schema`` server-side) is the structured payload
         the caller wants.
+
+        Delegates the request-envelope construction to
+        :meth:`_tool_request_params` so the sync and batch paths
+        share one source of truth — a future change to ``system``,
+        ``tool_choice``, or ``max_tokens`` shape lands in one place.
         """
-        tool_name = str(tool_schema["name"])
+        params = self._tool_request_params(prompt, system_blocks, tool_schema)
         # The Anthropic SDK exposes ``system``, ``tools``, and
         # ``tool_choice`` as deeply-nested TypedDict unions. Threading
         # those through the generic ``dict[str, object]`` shapes we
@@ -573,19 +584,7 @@ class AIOrchestrator:
         # internal types just to satisfy mypy, with no runtime
         # benefit. The SDK validates the payload server-side; we
         # type-ignore the single call site instead.
-        response = await client.messages.create(  # type: ignore[call-overload]
-            model=self.model,
-            max_tokens=_MAX_TOKENS,
-            system=system_blocks,
-            tools=[tool_schema],
-            tool_choice={"type": "tool", "name": tool_name},
-            messages=[
-                {
-                    "role": "user",
-                    "content": prompt,
-                },
-            ],
-        )
+        response = await client.messages.create(**params)  # type: ignore[call-overload]
 
         tool_block = next(
             (b for b in response.content if isinstance(b, ToolUseBlock)),
@@ -935,34 +934,54 @@ class AIOrchestrator:
 
         The Anthropic Batches API expects a list of
         ``{"custom_id": ..., "params": {...}}`` dicts where ``params``
-        is a normal ``messages.create`` body. The body fields here
-        mirror :meth:`_call_tool_api_async` so the per-request
-        contract is identical between sync and batch paths.
-
-        Validates ``tool_schema["name"]`` is non-empty before
-        constructing the envelope. The API would reject a missing
-        name with an opaque HTTP 400 wrapped in a generic
-        ``GenerationError``; failing close to the caller with a
-        named-field error is more debuggable.
+        is a normal ``messages.create`` body. ``params`` is built by
+        :meth:`_tool_request_params` — the same helper
+        :meth:`_call_tool_api_async` uses — so sync and batch paths
+        cannot drift apart on envelope shape.
         """
-        raw_name = request.tool_schema.get("name")
-        if not isinstance(raw_name, str) or not raw_name:
-            msg = (
-                f"tool_schema for custom_id {request.custom_id!r} "
-                "must include a non-empty 'name' string"
-            )
-            raise GenerationError(msg)
-        tool_name = raw_name
         return {
             "custom_id": request.custom_id,
-            "params": {
-                "model": self.model,
-                "max_tokens": _MAX_TOKENS,
-                "system": list(request.system_blocks),
-                "tools": [request.tool_schema],
-                "tool_choice": {"type": "tool", "name": tool_name},
-                "messages": [
-                    {"role": "user", "content": request.prompt},
-                ],
-            },
+            "params": self._tool_request_params(
+                request.prompt,
+                request.system_blocks,
+                request.tool_schema,
+                custom_id=request.custom_id,
+            ),
+        }
+
+    def _tool_request_params(
+        self,
+        prompt: str,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+        *,
+        custom_id: str = "",
+    ) -> dict[str, object]:
+        """Build the Anthropic ``messages.create`` body shared by sync + batch.
+
+        Every field here is identical between the two transports —
+        a single source of truth so a future change to ``system``,
+        ``tool_choice``, ``max_tokens``, or ``messages`` shape lands
+        once and applies to both. ``custom_id`` is optional context
+        for the validation error (named in the message when present).
+
+        Validates ``tool_schema["name"]`` is non-empty before
+        construction; the API would otherwise reject a missing name
+        with an opaque HTTP 400 wrapped in a generic
+        ``GenerationError``.
+        """
+        raw_name = tool_schema.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            qualifier = f" for custom_id {custom_id!r}" if custom_id else ""
+            msg = f"tool_schema{qualifier} must include a non-empty " "'name' string"
+            raise GenerationError(msg)
+        return {
+            "model": self.model,
+            "max_tokens": _MAX_TOKENS,
+            "system": list(system_blocks),
+            "tools": [tool_schema],
+            "tool_choice": {"type": "tool", "name": raw_name},
+            "messages": [
+                {"role": "user", "content": prompt},
+            ],
         }

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -13,6 +13,7 @@ import time
 from typing import Final
 from typing import Literal
 from typing import TYPE_CHECKING
+from typing import cast
 
 from anthropic import Anthropic
 from anthropic import AsyncAnthropic
@@ -45,27 +46,35 @@ __all__ = [
     "ToolUseResult",
 ]
 
+from collections.abc import AsyncIterable
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+    from collections.abc import Iterable
     from collections.abc import Iterator
     from collections.abc import Sequence
 
     from start_green_stay_green.utils.timing import TimingReport
 
 
-async def _aiter(stream: object) -> AsyncIterator[object]:
-    """Yield from an async iterator OR a sync iterable.
+async def _aiter(
+    stream: AsyncIterable[object] | Iterable[object],
+) -> AsyncIterator[object]:
+    """Yield from an async iterable OR a sync iterable.
 
     The Anthropic SDK's ``messages.batches.results`` returns an
     async iterator at runtime, but unit tests construct fakes that
     are easier to write as plain lists. Accept both shapes so the
     test seam is wide.
+
+    ``isinstance(stream, AsyncIterable)`` narrows the union for
+    mypy on both branches, so neither path needs a ``type: ignore``.
     """
-    if hasattr(stream, "__aiter__"):
+    if isinstance(stream, AsyncIterable):
         async for item in stream:
             yield item
         return
-    for item in stream:  # type: ignore[attr-defined]
+    for item in stream:
         yield item
 
 
@@ -82,6 +91,12 @@ class ModelConfig:
 
     OPUS: Final[str] = "claude-opus-4-5-20251101"
     SONNET: Final[str] = "claude-sonnet-4-5-20250929"
+
+
+# Per-call max_tokens for every Claude request the orchestrator
+# issues — sync, async, tool-use, and batch alike. Single source of
+# truth so a future limit change is one edit instead of four.
+_MAX_TOKENS: Final[int] = 4096
 
 
 @dataclass(frozen=True)
@@ -243,7 +258,7 @@ class AIOrchestrator:
         """
         response = client.messages.create(
             model=self.model,
-            max_tokens=4096,
+            max_tokens=_MAX_TOKENS,
             system=(
                 f"Generate {output_format} output. "
                 "Follow the instructions precisely."
@@ -430,7 +445,7 @@ class AIOrchestrator:
         """Async counterpart of :meth:`_call_api`."""
         response = await client.messages.create(
             model=self.model,
-            max_tokens=4096,
+            max_tokens=_MAX_TOKENS,
             system=(
                 f"Generate {output_format} output. "
                 "Follow the instructions precisely."
@@ -547,7 +562,7 @@ class AIOrchestrator:
         # type-ignore the single call site instead.
         response = await client.messages.create(  # type: ignore[call-overload]
             model=self.model,
-            max_tokens=4096,
+            max_tokens=_MAX_TOKENS,
             system=system_blocks,
             tools=[tool_schema],
             tool_choice={"type": "tool", "name": tool_name},
@@ -847,14 +862,27 @@ class AIOrchestrator:
             msg = f"Batch retrieve failed for {batch_id}"
             raise GenerationError(msg, cause=exc) from exc
 
-    async def _open_results_stream(self, batch_id: str) -> object:
-        """Wrap the SDK results call so callers see ``GenerationError`` on failure."""
+    async def _open_results_stream(
+        self, batch_id: str,
+    ) -> AsyncIterable[object] | Iterable[object]:
+        """Open the batch's result stream as an iterable.
+
+        Returns the iterable shape ``_aiter`` expects directly, so
+        callers do not have to cast. SDK errors are remapped to
+        :class:`GenerationError` to keep the public surface uniform
+        with the sync path.
+        """
         client = self._get_async_client()
         try:
-            return await client.messages.batches.results(batch_id)
+            stream = await client.messages.batches.results(batch_id)
         except Exception as exc:
             msg = f"Batch results stream failed for {batch_id}"
             raise GenerationError(msg, cause=exc) from exc
+        # The SDK returns an async iterator at runtime; tests pass a
+        # plain list via ``AsyncMock``. Both satisfy the union, so
+        # the cast is a type-check-only narrowing — no isinstance
+        # at runtime.
+        return cast("AsyncIterable[object] | Iterable[object]", stream)
 
     def _batch_request_envelope(
         self,
@@ -873,7 +901,7 @@ class AIOrchestrator:
             "custom_id": request.custom_id,
             "params": {
                 "model": self.model,
-                "max_tokens": 4096,
+                "max_tokens": _MAX_TOKENS,
                 "system": list(request.system_blocks),
                 "tools": [request.tool_schema],
                 "tool_choice": {"type": "tool", "name": tool_name},

--- a/start_green_stay_green/ai/tuner.py
+++ b/start_green_stay_green/ai/tuner.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import cast
 
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError
 from start_green_stay_green.ai.prompts.manager import get_default_manager
@@ -261,6 +262,85 @@ class ContentTuner:
         raw_content, raw_changes = cls._validate_tool_use_input(tool_input)
         changes = [c for c in raw_changes if isinstance(c, str) and c.strip()]
         return raw_content, changes
+
+    def build_batch_request(
+        self,
+        custom_id: str,
+        source_content: str,
+        source_context: str,
+        target_context: str,
+        preserve_sections: Sequence[str] | None = None,
+    ) -> ToolUseBatchRequest:
+        """Render the per-call payload for one tune as a batch request.
+
+        Same inputs as :meth:`tune`, plus a caller-chosen
+        ``custom_id`` that the Anthropic Batches API echoes back so
+        results can be correlated to the originating target. Returns
+        the dataclass :meth:`AIOrchestrator.submit_tool_use_batch`
+        accepts without firing a sync API call — the caller owns the
+        submission.
+
+        The returned request reuses :meth:`_build_system_blocks` and
+        :meth:`_build_user_message` so the cache prefix (and
+        therefore the cache hit ratio) is identical between sync and
+        batch paths.
+
+        Args:
+            custom_id: Unique identifier within the batch the caller
+                will submit. Conventional shape:
+                ``"<kind>:<name>"`` (e.g. ``"subagent:architecture"``).
+            source_content: Original content to adapt.
+            source_context: Description of source repository.
+            target_context: Description of target repository.
+            preserve_sections: Sections to leave unchanged.
+
+        Returns:
+            :class:`ToolUseBatchRequest` ready to bundle alongside
+            sibling targets in a single
+            ``submit_tool_use_batch`` call.
+
+        Raises:
+            ValueError: If any input fails the same validation
+                :meth:`tune` applies.
+        """
+        if not custom_id or not custom_id.strip():
+            msg = "custom_id cannot be empty"
+            raise ValueError(msg)
+        self._validate_content(source_content)
+        self._validate_context(source_context, "Source context")
+        self._validate_context(target_context, "Target context")
+
+        return ToolUseBatchRequest(
+            custom_id=custom_id,
+            prompt=self._build_user_message(source_content),
+            system_blocks=self._build_system_blocks(
+                source_context,
+                target_context,
+                preserve_sections,
+            ),
+            tool_schema=_REPORT_TUNING_TOOL,
+        )
+
+    @classmethod
+    def parse_batch_tuning_result(
+        cls,
+        tool_result: ToolUseResult,
+    ) -> TuningResult:
+        """Lift a ``ToolUseResult`` from a batch into a :class:`TuningResult`.
+
+        Same parser :meth:`tune` uses on its sync result, exposed
+        publicly so the batch resume path (which fetches the result
+        long after the originating ``tune`` call would have returned)
+        can build the same downstream dataclass.
+        """
+        content, changes = cls._parse_tool_use_input(tool_result.tool_input)
+        return TuningResult(
+            content=content,
+            changes=changes,
+            dry_run=False,
+            token_usage_input=tool_result.token_usage.input_tokens,
+            token_usage_output=tool_result.token_usage.output_tokens,
+        )
 
     async def tune(
         self,

--- a/start_green_stay_green/ai/types.py
+++ b/start_green_stay_green/ai/types.py
@@ -1,0 +1,113 @@
+"""Shared types for the AI subsystem.
+
+Lives in its own module so :mod:`start_green_stay_green.ai.orchestrator`
+and :mod:`start_green_stay_green.ai.batch` can both import these
+freely without forming a cycle. ``orchestrator`` is the SDK-bridge
+layer; ``batch`` is the pure-data layer over the Batches API; they
+both need :class:`ToolUseResult`, :class:`TokenUsage`, and
+:class:`GenerationError`, but neither one is a natural home for the
+types when the *other* needs to construct them.
+
+Existing callers continue to import these from
+``ai.orchestrator`` — that module re-exports each of them for
+back-compat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class GenerationError(Exception):
+    """Raised when AI generation fails.
+
+    Attributes:
+        cause: Optional underlying exception that caused this error.
+    """
+
+    def __init__(self, message: str, *, cause: Exception | None = None) -> None:
+        """Initialize GenerationError.
+
+        Args:
+            message: Error message describing the failure.
+            cause: Optional underlying exception that caused this error.
+        """
+        super().__init__(message)
+        self.cause = cause
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Token usage information from API response.
+
+    Attributes:
+        input_tokens: Number of tokens in the prompt.
+        output_tokens: Number of tokens in the response.
+    """
+
+    input_tokens: int
+    output_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        """Calculate total tokens used.
+
+        Returns:
+            Sum of input and output tokens.
+        """
+        return self.input_tokens + self.output_tokens
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    """Result from AI generation request.
+
+    Attributes:
+        content: Generated content from the AI model.
+        format: Output format (yaml, toml, markdown, bash).
+        token_usage: Token usage statistics for the request.
+        cache_read_tokens: Subset of input tokens served from the
+            prompt cache. ``0`` when caching is disabled or the
+            response did not report this field.
+        cache_creation_tokens: Tokens written to the prompt cache on
+            this call (billed at a higher rate than reads).
+        model: Model identifier used for generation.
+        message_id: Unique identifier for the API message.
+    """
+
+    content: str
+    format: str
+    token_usage: TokenUsage
+    model: str
+    message_id: str
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class ToolUseResult:
+    """Result from a structured (``tool_use``) API call.
+
+    The Claude API returns a JSON object validated against the tool's
+    ``input_schema``; ``tool_input`` is that object verbatim. Replaces
+    free-form text parsing for callers that need typed fields out of
+    the model.
+
+    Attributes:
+        tool_name: Name of the tool the model invoked.
+        tool_input: Parsed JSON input the model passed to the tool.
+        token_usage: Token usage statistics for the request.
+        cache_read_tokens: Subset of input tokens served from the
+            prompt cache.
+        cache_creation_tokens: Tokens written to the prompt cache.
+        model: Model identifier used for generation.
+        message_id: Unique identifier for the API message.
+    """
+
+    tool_name: str
+    tool_input: dict[str, object]
+    token_usage: TokenUsage
+    model: str
+    message_id: str
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -54,6 +54,32 @@ STATE_FILE_RELATIVE = ".claude/.enhance-state.json"
 
 
 @dataclass(frozen=True)
+class BatchProgress:
+    """In-flight batch metadata persisted across ``green enhance`` calls.
+
+    Phase 5a — present iff a batch was submitted but not yet
+    fetched. The CLI's resume path checks for this on every
+    invocation so an interrupted run can be picked up without
+    re-submitting (which would burn cost on duplicate work).
+
+    Attributes:
+        batch_id: Anthropic identifier returned by
+            :meth:`AIOrchestrator.submit_tool_use_batch`. Empty in a
+            default-constructed state — :meth:`EnhanceState.has_batch`
+            treats that as "no batch in flight".
+        submitted_at: ISO-8601 UTC timestamp of submission. Diagnostic
+            only.
+        custom_id_map: ``custom_id`` → target name. Lets the resume
+            path correlate per-request results back to the targets
+            the original submission was tracking.
+    """
+
+    batch_id: str = ""
+    submitted_at: str = ""
+    custom_id_map: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class TargetCompletion:
     """Completion record for a single ``green enhance`` target.
 
@@ -89,6 +115,42 @@ class EnhanceState:
     version: int = STATE_FILE_VERSION
     last_run: str = ""
     completed: dict[str, TargetCompletion] = field(default_factory=dict)
+    batch: BatchProgress | None = None
+
+    def has_batch(self) -> bool:
+        """``True`` if a submitted-but-not-yet-fetched batch is recorded."""
+        return self.batch is not None and bool(self.batch.batch_id)
+
+    def start_batch(
+        self,
+        batch_id: str,
+        custom_id_map: dict[str, str],
+        submitted_at: str,
+    ) -> None:
+        """Record a freshly-submitted batch.
+
+        Refuses to overwrite an existing in-flight batch — the caller
+        must :meth:`clear_batch` first, signalling that the prior run
+        was reconciled. Without this guard a re-run of
+        ``green enhance --batch`` would silently abandon the previous
+        batch's results and the user would pay twice.
+        """
+        if self.has_batch():
+            msg = (
+                "An in-flight batch is already recorded; clear it via "
+                "clear_batch() before starting another."
+            )
+            raise ValueError(msg)
+        self.batch = BatchProgress(
+            batch_id=batch_id,
+            submitted_at=submitted_at,
+            custom_id_map=dict(custom_id_map),
+        )
+        self.last_run = submitted_at
+
+    def clear_batch(self) -> None:
+        """Drop the in-flight batch record after results are reconciled."""
+        self.batch = None
 
     def is_unchanged(self, target: str, current_hash: str) -> bool:
         """Return ``True`` if ``target`` was last tuned at ``current_hash``.
@@ -128,7 +190,7 @@ class EnhanceState:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-friendly mapping."""
-        return {
+        payload: dict[str, Any] = {
             "version": self.version,
             "last_run": self.last_run,
             "completed": {
@@ -140,6 +202,13 @@ class EnhanceState:
                 for target, rec in self.completed.items()
             },
         }
+        if self.batch is not None and self.batch.batch_id:
+            payload["batch"] = {
+                "batch_id": self.batch.batch_id,
+                "submitted_at": self.batch.submitted_at,
+                "custom_id_map": dict(self.batch.custom_id_map),
+            }
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> EnhanceState:
@@ -157,6 +226,7 @@ class EnhanceState:
             ),
             last_run=str(payload.get("last_run", "") or ""),
             completed=_parse_completed_records(payload.get("completed")),
+            batch=_parse_batch_progress(payload.get("batch")),
         )
 
 
@@ -195,6 +265,33 @@ def _parse_completed_records(raw: object) -> dict[str, TargetCompletion]:
         if record is not None:
             completed[str(name)] = record
     return completed
+
+
+def _parse_batch_progress(raw: object) -> BatchProgress | None:
+    """Parse an optional ``batch`` payload, returning ``None`` when absent.
+
+    A malformed batch record degrades to "no batch in flight",
+    matching the rest of the state-file philosophy: worst case, the
+    caller re-submits — a duplicate batch is recoverable, an
+    aborted run from a parse failure is not.
+    """
+    if not isinstance(raw, dict):
+        return None
+    batch_id = _valid_hash(raw.get("batch_id"))
+    if batch_id is None:
+        return None
+    return BatchProgress(
+        batch_id=batch_id,
+        submitted_at=str(raw.get("submitted_at", "") or ""),
+        custom_id_map=_parse_custom_id_map(raw.get("custom_id_map")),
+    )
+
+
+def _parse_custom_id_map(raw: object) -> dict[str, str]:
+    """Coerce a stored ``custom_id_map`` into the typed shape, dropping garbage."""
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
 
 
 def state_path_for(project_path: Path) -> Path:

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -40,6 +40,8 @@ import json
 from typing import Any
 from typing import TYPE_CHECKING
 
+from start_green_stay_green.ai.types import GenerationError
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
@@ -52,6 +54,18 @@ STATE_FILE_VERSION = 1
 # it under ``.claude/`` matches the existing convention for tool
 # scratch state and keeps a future ``.gitignore`` rule narrow.
 STATE_FILE_RELATIVE = ".claude/.enhance-state.json"
+
+
+class BatchStateError(GenerationError):
+    """Raised on a state-machine violation in :class:`EnhanceState`.
+
+    Subclasses :class:`GenerationError` so callers handling AI-domain
+    failures with a single ``except GenerationError`` clause catch
+    state-file misuse without separate plumbing. Currently raised
+    by :meth:`EnhanceState.start_batch` when a caller tries to
+    overwrite an in-flight batch without first calling
+    :meth:`EnhanceState.clear_batch`.
+    """
 
 
 @dataclass(frozen=True)
@@ -206,13 +220,19 @@ class EnhanceState:
         was reconciled. Without this guard a re-run of
         ``green enhance --batch`` would silently abandon the previous
         batch's results and the user would pay twice.
+
+        Raises:
+            BatchStateError: When an in-flight batch is already
+                recorded. Subclasses :class:`GenerationError` so
+                callers can ``except GenerationError`` to catch all
+                AI-domain failures uniformly.
         """
         if self.has_batch():
             msg = (
                 "An in-flight batch is already recorded; clear it via "
                 "clear_batch() before starting another."
             )
-            raise ValueError(msg)
+            raise BatchStateError(msg)
         self.batch = BatchProgress(
             batch_id=batch_id,
             submitted_at=submitted_at,

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -69,9 +69,14 @@ class BatchProgress:
             treats that as "no batch in flight".
         submitted_at: ISO-8601 UTC timestamp of submission. Diagnostic
             only.
-        custom_id_map: ``custom_id`` → target name. Lets the resume
-            path correlate per-request results back to the targets
-            the original submission was tracking.
+        custom_id_map: Map from each submitted ``custom_id`` to the
+            top-level :class:`EnhanceState` ``completed`` target it
+            belongs under (e.g. ``"subagent:architecture-review"
+            → "subagents"``). The direction is **custom_id → target**
+            because the Phase 5b reconciliation path iterates
+            :attr:`BatchResultsBundle.successes` (already keyed by
+            ``custom_id``) and looks each target up directly without
+            inverting the map.
     """
 
     batch_id: str = ""

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from datetime import UTC
 from datetime import datetime
+from datetime import timedelta
 import hashlib
 import json
 from typing import Any
@@ -62,13 +63,21 @@ class BatchProgress:
     invocation so an interrupted run can be picked up without
     re-submitting (which would burn cost on duplicate work).
 
+    **Lifecycle**: a ``green enhance --batch`` run flows
+    submit → :meth:`EnhanceState.start_batch` (persist record) →
+    poll → reconcile → :meth:`EnhanceState.clear_batch` (drop
+    record). Phase 5b's CLI must call :meth:`is_potentially_expired`
+    before the poll step so a state file that crossed Anthropic's
+    24 h SLA boundary can be cleared and re-submitted instead of
+    hitting an opaque ``404`` on the stale ``batch_id``.
+
     Attributes:
         batch_id: Anthropic identifier returned by
             :meth:`AIOrchestrator.submit_tool_use_batch`. Empty in a
             default-constructed state — :meth:`EnhanceState.has_batch`
             treats that as "no batch in flight".
-        submitted_at: ISO-8601 UTC timestamp of submission. Diagnostic
-            only.
+        submitted_at: ISO-8601 UTC timestamp of submission. Used as
+            the basis for the 24 h SLA expiry check.
         custom_id_map: Map from each submitted ``custom_id`` to the
             top-level :class:`EnhanceState` ``completed`` target it
             belongs under (e.g. ``"subagent:architecture-review"
@@ -82,6 +91,54 @@ class BatchProgress:
     batch_id: str = ""
     submitted_at: str = ""
     custom_id_map: dict[str, str] = field(default_factory=dict)
+
+    def is_potentially_expired(self, *, now: datetime | None = None) -> bool:
+        """Return ``True`` when this batch may have crossed the 24 h SLA.
+
+        Anthropic batches have a hard ≤24 h server-side TTL; after
+        that the ``batch_id`` is no longer valid and any
+        ``poll_batch`` / ``fetch_batch_results`` call returns a
+        ``404``-class error. Phase 5b's CLI must call this before
+        polling so a stale record can be cleared (and the user
+        prompted to re-submit) instead of bubbling an opaque error.
+
+        Best-effort — uses :attr:`submitted_at` plus the local
+        clock, both of which can drift relative to the Anthropic
+        server. Tuned to over-report (24 h, not 23) so a borderline
+        batch is treated as live and the API gets the final say.
+
+        Args:
+            now: Override the current-time source (testing hook).
+                Defaults to :func:`datetime.now(UTC)`.
+
+        Returns:
+            ``False`` if no batch is recorded, the timestamp is
+            unparseable, or less than 24 h has elapsed; ``True``
+            otherwise.
+        """
+        submitted = self._parsed_submitted_at()
+        if submitted is None:
+            return False
+        current = now if now is not None else datetime.now(UTC)
+        return (current - submitted) >= _BATCH_TTL
+
+    def _parsed_submitted_at(self) -> datetime | None:
+        """Return :attr:`submitted_at` as a tz-aware datetime, or ``None``."""
+        if not self.batch_id or not self.submitted_at:
+            return None
+        try:
+            parsed = datetime.fromisoformat(self.submitted_at)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed
+
+
+# Anthropic Message Batches API server-side TTL. Documented at
+# https://docs.claude.com/en/api/creating-message-batches —
+# batches that have not completed within 24 h are expired.
+_BATCH_TTL: timedelta = timedelta(hours=24)
 
 
 @dataclass(frozen=True)

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -108,6 +108,13 @@ class TargetCompletion:
 class EnhanceState:
     """Persistent state for ``green enhance``.
 
+    Mutable by design — the CLI layer drives the lifecycle through
+    :meth:`mark_completed`, :meth:`start_batch`, and :meth:`clear_batch`,
+    which would all need replace-and-reassign workarounds under
+    ``frozen=True``. The on-disk file is the durable contract;
+    in-memory mutation is bounded to the duration of one
+    ``green enhance`` invocation.
+
     Attributes:
         version: Schema version. Always equal to
             :data:`STATE_FILE_VERSION` on round-trip.
@@ -115,6 +122,9 @@ class EnhanceState:
             ``enhance`` invocation that wrote this file.
         completed: Map from target name (e.g. ``"claude-md"``,
             ``"subagents"``) to its :class:`TargetCompletion` record.
+        batch: In-flight :class:`BatchProgress` recorded after a
+            ``--batch`` submission and cleared once results are
+            reconciled. ``None`` when no batch is in flight.
     """
 
     version: int = STATE_FILE_VERSION
@@ -242,6 +252,21 @@ def _valid_hash(raw: object) -> str | None:
     return None
 
 
+def _nonempty_str(raw: object) -> str | None:
+    """Return ``raw`` when it's a non-empty string; else ``None``.
+
+    Same predicate as :func:`_valid_hash` today, but separate by intent:
+    ``_valid_hash`` validates a SHA-256 digest string and a future
+    tightening (e.g. enforcing the ``sha256:`` prefix) would be
+    correct. ``_nonempty_str`` validates an Anthropic-side opaque
+    identifier (``batch_id``) and must NOT add format requirements
+    — the only contract is "must be present and non-empty."
+    """
+    if isinstance(raw, str) and raw:
+        return raw
+    return None
+
+
 def _parse_record(raw: object) -> TargetCompletion | None:
     """Validate and build a single ``TargetCompletion`` from a stored payload.
 
@@ -282,7 +307,7 @@ def _parse_batch_progress(raw: object) -> BatchProgress | None:
     """
     if not isinstance(raw, dict):
         return None
-    batch_id = _valid_hash(raw.get("batch_id"))
+    batch_id = _nonempty_str(raw.get("batch_id"))
     if batch_id is None:
         return None
     return BatchProgress(

--- a/tests/unit/ai/test_batch.py
+++ b/tests/unit/ai/test_batch.py
@@ -20,9 +20,9 @@ from start_green_stay_green.ai.batch import BatchResultsBundle
 from start_green_stay_green.ai.batch import BatchSubmission
 from start_green_stay_green.ai.batch import ToolUseBatchRequest
 from start_green_stay_green.ai.batch import parse_batch_result_entry
-from start_green_stay_green.ai.orchestrator import GenerationError
-from start_green_stay_green.ai.orchestrator import TokenUsage
-from start_green_stay_green.ai.orchestrator import ToolUseResult
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
 
 _DEFAULT_USAGE: dict[str, int] = {
     "input_tokens": 100,

--- a/tests/unit/ai/test_batch.py
+++ b/tests/unit/ai/test_batch.py
@@ -1,0 +1,282 @@
+"""Unit tests for the batch primitives in ``ai/batch.py``.
+
+The orchestrator's batch methods are integration concerns covered
+elsewhere; this file pins the pure-data parser
+(:func:`parse_batch_result_entry`) and the dataclass shapes against
+both real-SDK-shaped payloads (Pydantic-style attribute access) and
+plain-dict test doubles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from start_green_stay_green.ai.batch import BatchError
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.batch import parse_batch_result_entry
+from start_green_stay_green.ai.orchestrator import GenerationError
+from start_green_stay_green.ai.orchestrator import TokenUsage
+from start_green_stay_green.ai.orchestrator import ToolUseResult
+
+_DEFAULT_USAGE: dict[str, int] = {
+    "input_tokens": 100,
+    "output_tokens": 50,
+    "cache_read_input_tokens": 10,
+    "cache_creation_input_tokens": 5,
+}
+
+
+def _success_entry(
+    custom_id: str = "subagent:foo",
+    *,
+    tool_input: dict[str, Any] | None = None,
+    usage: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Plain-dict double of one streamed batch result on the success path."""
+    return {
+        "custom_id": custom_id,
+        "result": {
+            "type": "succeeded",
+            "message": {
+                "id": "msg_123",
+                "model": "claude-sonnet",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "report_tuning",
+                        "input": tool_input or {"tuned_content": "X", "changes": ["c"]},
+                    },
+                ],
+                "usage": usage if usage is not None else dict(_DEFAULT_USAGE),
+            },
+        },
+    }
+
+
+class TestParseBatchResultEntrySuccess:
+    """Successful entries lift into ``ToolUseResult`` with full telemetry."""
+
+    def test_returns_tool_use_result_for_succeeded_entry(self) -> None:
+        custom_id, outcome = parse_batch_result_entry(_success_entry())
+
+        assert custom_id == "subagent:foo"
+        assert isinstance(outcome, ToolUseResult)
+        assert outcome.tool_name == "report_tuning"
+        assert outcome.tool_input == {"tuned_content": "X", "changes": ["c"]}
+
+    def test_token_usage_is_threaded_through(self) -> None:
+        _, outcome = parse_batch_result_entry(_success_entry())
+        assert isinstance(outcome, ToolUseResult)
+
+        assert outcome.token_usage.input_tokens == 100
+        assert outcome.token_usage.output_tokens == 50
+
+    def test_cache_telemetry_is_surfaced(self) -> None:
+        """Phase 2c cache columns reach batch users too — pin that."""
+        _, outcome = parse_batch_result_entry(_success_entry())
+        assert isinstance(outcome, ToolUseResult)
+
+        assert outcome.cache_read_tokens == 10
+        assert outcome.cache_creation_tokens == 5
+
+    def test_works_with_attribute_access_payload(self) -> None:
+        """Real SDK responses expose attributes; tests sometimes pass dicts.
+
+        Mix the two forms in a single payload to verify
+        ``_extract_attr`` does not silently prefer one shape.
+        """
+
+        @dataclass
+        class _Usage:
+            input_tokens: int = 7
+            output_tokens: int = 3
+            cache_read_input_tokens: int = 0
+            cache_creation_input_tokens: int = 0
+
+        @dataclass
+        class _ToolBlock:
+            type: str = "tool_use"
+            name: str = "report_tuning"
+            input: dict[str, Any] | None = None
+
+        @dataclass
+        class _Message:
+            id: str = "msg_attr"
+            model: str = "claude"
+            content: list[Any] | None = None
+            usage: _Usage | None = None
+
+        @dataclass
+        class _Result:
+            type: str = "succeeded"
+            message: _Message | None = None
+
+        @dataclass
+        class _Entry:
+            custom_id: str = "skill:bar"
+            result: _Result | None = None
+
+        entry = _Entry(
+            result=_Result(
+                message=_Message(
+                    content=[
+                        _ToolBlock(input={"tuned_content": "Y", "changes": []}),
+                    ],
+                    usage=_Usage(),
+                ),
+            ),
+        )
+
+        custom_id, outcome = parse_batch_result_entry(entry)
+        assert custom_id == "skill:bar"
+        assert isinstance(outcome, ToolUseResult)
+        assert outcome.tool_input == {"tuned_content": "Y", "changes": []}
+        assert outcome.message_id == "msg_attr"
+
+
+class TestParseBatchResultEntryFailures:
+    """Per-request failure types do *not* raise — they return BatchError."""
+
+    @pytest.mark.parametrize("failure_type", ["errored", "canceled", "expired"])
+    def test_failure_types_yield_batch_error(self, failure_type: str) -> None:
+        entry = {
+            "custom_id": "subagent:bad",
+            "result": {
+                "type": failure_type,
+                "error": {"message": f"upstream {failure_type}"},
+            },
+        }
+
+        custom_id, outcome = parse_batch_result_entry(entry)
+        assert custom_id == "subagent:bad"
+        assert isinstance(outcome, BatchError)
+        assert outcome.result_type == failure_type
+        assert f"upstream {failure_type}" in outcome.message
+
+    def test_unknown_result_type_is_recorded_as_batcherror(self) -> None:
+        entry = {
+            "custom_id": "subagent:weird",
+            "result": {"type": "future_status_we_havent_heard_of"},
+        }
+
+        _, outcome = parse_batch_result_entry(entry)
+        assert isinstance(outcome, BatchError)
+        assert outcome.result_type == "future_status_we_havent_heard_of"
+
+    def test_missing_custom_id_raises_generation_error(self) -> None:
+        with pytest.raises(GenerationError, match="custom_id"):
+            parse_batch_result_entry({"custom_id": "", "result": {}})
+
+    def test_missing_tool_use_block_raises(self) -> None:
+        entry = {
+            "custom_id": "subagent:empty",
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "id": "msg_x",
+                    "model": "claude",
+                    "content": [{"type": "text", "text": "no tool here"}],
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            },
+        }
+        with pytest.raises(GenerationError, match="ToolUseBlock"):
+            parse_batch_result_entry(entry)
+
+    def test_non_dict_tool_input_raises(self) -> None:
+        entry = _success_entry()
+        entry["result"]["message"]["content"][0]["input"] = "not-a-dict"
+        with pytest.raises(GenerationError, match="JSON object"):
+            parse_batch_result_entry(entry)
+
+
+class TestBatchPoll:
+    """The :class:`BatchPoll` snapshot exposes a clear is_ended hook."""
+
+    def test_is_ended_true_only_for_status_ended(self) -> None:
+        ended = BatchPoll(
+            batch_id="b",
+            status="ended",
+            processing_count=0,
+            succeeded_count=3,
+            errored_count=0,
+        )
+        in_progress = BatchPoll(
+            batch_id="b",
+            status="in_progress",
+            processing_count=3,
+            succeeded_count=0,
+            errored_count=0,
+        )
+        canceling = BatchPoll(
+            batch_id="b",
+            status="canceling",
+            processing_count=0,
+            succeeded_count=2,
+            errored_count=1,
+        )
+
+        assert ended.is_ended
+        assert not in_progress.is_ended
+        assert not canceling.is_ended
+
+
+class TestBatchResultsBundle:
+    """The bundle keeps successes and failures in parallel maps."""
+
+    def test_total_counts_both_maps(self) -> None:
+        bundle = BatchResultsBundle(
+            successes={"a": _make_tool_use_result()},
+            failures={
+                "b": BatchError(custom_id="b", result_type="errored"),
+                "c": BatchError(custom_id="c", result_type="expired"),
+            },
+        )
+        assert bundle.total == 3
+
+    def test_default_constructor_yields_empty_maps(self) -> None:
+        bundle = BatchResultsBundle()
+        assert bundle.successes == {}
+        assert bundle.failures == {}
+        assert bundle.total == 0
+
+
+class TestDataclassBasics:
+    """Smoke checks on the request/submission dataclasses."""
+
+    def test_tool_use_batch_request_holds_all_fields(self) -> None:
+        req = ToolUseBatchRequest(
+            custom_id="subagent:a",
+            prompt="hello",
+            system_blocks=[{"type": "text", "text": "S"}],
+            tool_schema={"name": "t"},
+        )
+        assert req.custom_id == "subagent:a"
+        assert req.prompt == "hello"
+        assert req.system_blocks[0]["type"] == "text"
+        assert req.tool_schema["name"] == "t"
+
+    def test_batch_submission_preserves_custom_id_order(self) -> None:
+        sub = BatchSubmission(
+            batch_id="msgbatch_x",
+            custom_ids=["a", "b", "c"],
+            submitted_at="2026-05-09T00:00:00+00:00",
+        )
+        assert sub.custom_ids == ["a", "b", "c"]
+
+
+def _make_tool_use_result() -> ToolUseResult:
+    """Tiny test double — saves wiring 6 fields per assertion."""
+    return ToolUseResult(
+        tool_name="report_tuning",
+        tool_input={"tuned_content": "X", "changes": []},
+        token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+        model="claude",
+        message_id="msg_x",
+    )

--- a/tests/unit/ai/test_batch.py
+++ b/tests/unit/ai/test_batch.py
@@ -169,6 +169,23 @@ class TestParseBatchResultEntryFailures:
         assert isinstance(outcome, BatchError)
         assert outcome.result_type == "future_status_we_havent_heard_of"
 
+    def test_missing_result_type_attribute_yields_unknown_batcherror(self) -> None:
+        """A ``result`` payload with no ``type`` field at all degrades soft.
+
+        Pins the contract: a SDK shape change that drops ``result.type``
+        produces a recoverable ``BatchError`` (caller can decide), not
+        a ``GenerationError`` that aborts the whole batch reconciliation.
+        """
+        entry = {
+            "custom_id": "subagent:no_type",
+            "result": {"message": {"content": []}},  # no "type" key
+        }
+
+        custom_id, outcome = parse_batch_result_entry(entry)
+        assert custom_id == "subagent:no_type"
+        assert isinstance(outcome, BatchError)
+        assert outcome.result_type == "unknown"
+
     def test_missing_custom_id_raises_generation_error(self) -> None:
         with pytest.raises(GenerationError, match="custom_id"):
             parse_batch_result_entry({"custom_id": "", "result": {}})

--- a/tests/unit/ai/test_orchestrator.py
+++ b/tests/unit/ai/test_orchestrator.py
@@ -1125,8 +1125,11 @@ class TestGenerateToolUseAsync:
             await orchestrator.aclose()
 
         kwargs = mock_client.messages.create.call_args.kwargs
-        # Cache marker survives intact through to the API call.
-        assert kwargs["system"] is system_blocks
+        # Cache marker survives intact through to the API call. Equality
+        # rather than identity because ``_tool_request_params`` makes a
+        # defensive ``list(...)`` copy of the blocks (so callers cannot
+        # mutate the API payload after handing it off).
+        assert kwargs["system"] == system_blocks
         assert kwargs["system"][-1]["cache_control"] == {"type": "ephemeral"}
         # Forced tool_use prevents free-form text drifts.
         assert kwargs["tool_choice"] == {"type": "tool", "name": "report_tuning"}

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -171,6 +171,32 @@ class TestPollBatch:
         with pytest.raises(ValueError, match="non-empty batch_id"):
             await orchestrator.poll_batch("")
 
+    @pytest.mark.asyncio
+    async def test_canceled_and_expired_counts_threaded_through(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """Phase 5b reconciliation needs canceled/expired distinct from errored."""
+        batches = _wire_batches(orchestrator)
+        batches.retrieve = AsyncMock(
+            return_value=MagicMock(
+                processing_status="ended",
+                request_counts=MagicMock(
+                    processing=0,
+                    succeeded=5,
+                    errored=1,
+                    canceled=2,
+                    expired=3,
+                ),
+            ),
+        )
+
+        poll = await orchestrator.poll_batch("msgbatch_42")
+
+        assert poll.errored_count == 1
+        assert poll.canceled_count == 2
+        assert poll.expired_count == 3
+
 
 class TestFetchBatchResults:
     """``fetch_batch_results`` folds a streamed result iterable into bundle maps."""

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -118,6 +118,27 @@ class TestSubmitToolUseBatch:
                 ]
             )
 
+    @pytest.mark.asyncio
+    async def test_missing_tool_schema_name_raises_generation_error(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """Empty / missing ``tool_schema['name']`` fails close to the caller.
+
+        Without this guard the API would return an opaque HTTP 400
+        wrapped in a generic ``GenerationError("Batch submission
+        failed")`` — much harder to debug than a named-field error
+        that points at the offending request.
+        """
+        bad_request = ToolUseBatchRequest(
+            custom_id="subagent:nameless",
+            prompt="hi",
+            system_blocks=[{"type": "text", "text": "S"}],
+            tool_schema={"input_schema": {"type": "object"}},  # no "name"
+        )
+        with pytest.raises(GenerationError, match="non-empty 'name'"):
+            await orchestrator.submit_tool_use_batch([bad_request])
+
 
 class TestPollBatch:
     """``poll_batch`` snapshots the SDK ``BatchObject`` into ``BatchPoll``."""
@@ -248,6 +269,29 @@ class TestFetchBatchResults:
     ) -> None:
         with pytest.raises(ValueError, match="non-empty batch_id"):
             await orchestrator.fetch_batch_results("")
+
+    @pytest.mark.asyncio
+    async def test_unparseable_entry_propagates_generation_error(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """A stream entry the parser rejects aborts the fold (current contract).
+
+        ``parse_batch_result_entry`` raises ``GenerationError`` only
+        for shapes so malformed that no ``custom_id`` can be
+        recovered (per-request failures land in ``failures`` instead).
+        Pin the propagation so a future refactor that swallows the
+        error in :meth:`fetch_batch_results` is loud, not silent.
+        """
+        batches = _wire_batches(orchestrator)
+        batches.results = AsyncMock(
+            return_value=[
+                _success_entry("subagent:a"),
+                {"custom_id": "", "result": {}},  # missing custom_id
+            ]
+        )
+        with pytest.raises(GenerationError, match="custom_id"):
+            await orchestrator.fetch_batch_results("msgbatch_x")
 
 
 class TestBatchSDKErrorMapping:

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -238,6 +238,47 @@ class TestBatchSDKErrorMapping:
         with pytest.raises(GenerationError, match="Batch submission failed"):
             await orchestrator.submit_tool_use_batch([_request()])
 
+    @pytest.mark.asyncio
+    async def test_poll_failure_wraps_in_generation_error(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """``poll_batch`` lifts SDK errors into ``GenerationError`` like submit does.
+
+        Without this test the orchestrator's wrapper around
+        ``client.messages.batches.retrieve`` is uncovered; a refactor
+        that drops the wrapper would silently surface raw SDK
+        exceptions to callers.
+        """
+        batches = _wire_batches(orchestrator)
+        batches.retrieve = AsyncMock(side_effect=RuntimeError("upstream gone"))
+
+        with pytest.raises(
+            GenerationError,
+            match="Batch retrieve failed for msgbatch_x",
+        ):
+            await orchestrator.poll_batch("msgbatch_x")
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_wraps_in_generation_error(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """``fetch_batch_results`` lifts stream-open errors into ``GenerationError``.
+
+        Pins the SDK-error → ``GenerationError`` contract for the third
+        SDK-touching method so all three error paths
+        (``submit`` / ``poll`` / ``fetch``) are uniformly covered.
+        """
+        batches = _wire_batches(orchestrator)
+        batches.results = AsyncMock(side_effect=RuntimeError("stream closed"))
+
+        with pytest.raises(
+            GenerationError,
+            match="Batch results stream failed for msgbatch_x",
+        ):
+            await orchestrator.fetch_batch_results("msgbatch_x")
+
 
 def _success_entry(custom_id: str) -> dict[str, Any]:
     """Minimal succeeded-entry dict the parser will lift to a ``ToolUseResult``."""

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -1,0 +1,271 @@
+"""Unit tests for the batch methods on :class:`AIOrchestrator`.
+
+The Anthropic SDK's ``client.messages.batches`` namespace is mocked
+out so these tests exercise the orchestrator's contract (envelope
+shape, error mapping, results streaming) without any network. The
+parser side is covered separately in ``test_batch.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.orchestrator import AIOrchestrator
+from start_green_stay_green.ai.orchestrator import GenerationError
+from start_green_stay_green.ai.orchestrator import ToolUseResult
+
+
+def _wire_batches(orchestrator: AIOrchestrator) -> MagicMock:
+    """Replace the cached async client with a mock exposing ``messages.batches``.
+
+    Returns the ``batches`` mock so tests can ``.create``/``.retrieve``/
+    ``.results`` against it directly. Bypasses the lazy
+    ``_get_async_client`` construction so no real ``AsyncAnthropic``
+    instance is created.
+    """
+    client = MagicMock()
+    orchestrator._async_client = client
+    batches: MagicMock = client.messages.batches
+    return batches
+
+
+def _request(custom_id: str = "subagent:a") -> ToolUseBatchRequest:
+    return ToolUseBatchRequest(
+        custom_id=custom_id,
+        prompt="hello",
+        system_blocks=[{"type": "text", "text": "S"}],
+        tool_schema={
+            "name": "report_tuning",
+            "input_schema": {"type": "object"},
+        },
+    )
+
+
+@pytest.fixture
+def orchestrator() -> AIOrchestrator:
+    """Bare orchestrator with no real client yet — tests inject one."""
+    return AIOrchestrator(api_key="sk-test", max_retries=1, retry_delay=0.01)
+
+
+class TestSubmitToolUseBatch:
+    """``submit_tool_use_batch`` wraps the SDK and validates inputs."""
+
+    @pytest.mark.asyncio
+    async def test_returns_batch_submission_with_id_and_custom_ids(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        batches.create = AsyncMock(return_value=MagicMock(id="msgbatch_42"))
+
+        result = await orchestrator.submit_tool_use_batch(
+            [_request("subagent:a"), _request("subagent:b")],
+        )
+
+        assert isinstance(result, BatchSubmission)
+        assert result.batch_id == "msgbatch_42"
+        assert result.custom_ids == ["subagent:a", "subagent:b"]
+        assert result.submitted_at  # ISO timestamp populated
+
+    @pytest.mark.asyncio
+    async def test_request_envelope_carries_tool_choice_and_system(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        """Each submitted request mirrors ``_call_tool_api_async``'s shape."""
+        batches = _wire_batches(orchestrator)
+        batches.create = AsyncMock(return_value=MagicMock(id="msgbatch_x"))
+
+        await orchestrator.submit_tool_use_batch([_request("subagent:a")])
+
+        kwargs = batches.create.await_args.kwargs
+        payload = kwargs["requests"]
+        assert len(payload) == 1
+        envelope = payload[0]
+        assert envelope["custom_id"] == "subagent:a"
+        params = envelope["params"]
+        assert params["model"] == orchestrator.model
+        assert params["tool_choice"] == {"type": "tool", "name": "report_tuning"}
+        assert params["system"] == [{"type": "text", "text": "S"}]
+        assert params["messages"] == [{"role": "user", "content": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_empty_request_list_raises(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            await orchestrator.submit_tool_use_batch([])
+
+    @pytest.mark.asyncio
+    async def test_duplicate_custom_id_raises(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        with pytest.raises(ValueError, match="unique custom_id"):
+            await orchestrator.submit_tool_use_batch(
+                [
+                    _request("dup"),
+                    _request("dup"),
+                ]
+            )
+
+
+class TestPollBatch:
+    """``poll_batch`` snapshots the SDK ``BatchObject`` into ``BatchPoll``."""
+
+    @pytest.mark.asyncio
+    async def test_returns_batch_poll_with_counts(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        counts = MagicMock(processing=2, succeeded=5, errored=1)
+        batches.retrieve = AsyncMock(
+            return_value=MagicMock(
+                processing_status="in_progress",
+                request_counts=counts,
+            ),
+        )
+
+        poll = await orchestrator.poll_batch("msgbatch_42")
+
+        assert isinstance(poll, BatchPoll)
+        assert poll.batch_id == "msgbatch_42"
+        assert poll.status == "in_progress"
+        assert (poll.processing_count, poll.succeeded_count, poll.errored_count) == (
+            2,
+            5,
+            1,
+        )
+        assert not poll.is_ended
+
+    @pytest.mark.asyncio
+    async def test_ended_status_flips_is_ended(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        batches.retrieve = AsyncMock(
+            return_value=MagicMock(
+                processing_status="ended",
+                request_counts=MagicMock(processing=0, succeeded=8, errored=0),
+            ),
+        )
+        poll = await orchestrator.poll_batch("msgbatch_42")
+        assert poll.is_ended
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_id_raises(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        with pytest.raises(ValueError, match="non-empty batch_id"):
+            await orchestrator.poll_batch("")
+
+
+class TestFetchBatchResults:
+    """``fetch_batch_results`` folds a streamed result iterable into bundle maps."""
+
+    @pytest.mark.asyncio
+    async def test_streams_succeeded_into_successes_map(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        batches.results = AsyncMock(
+            return_value=[
+                _success_entry("subagent:a"),
+                _success_entry("subagent:b"),
+            ]
+        )
+
+        bundle = await orchestrator.fetch_batch_results("msgbatch_x")
+
+        assert isinstance(bundle, BatchResultsBundle)
+        assert set(bundle.successes) == {"subagent:a", "subagent:b"}
+        assert bundle.failures == {}
+        assert isinstance(bundle.successes["subagent:a"], ToolUseResult)
+
+    @pytest.mark.asyncio
+    async def test_mixed_stream_partitions_correctly(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        batches.results = AsyncMock(
+            return_value=[
+                _success_entry("subagent:a"),
+                _failure_entry("subagent:b", "errored"),
+                _failure_entry("subagent:c", "expired"),
+            ]
+        )
+
+        bundle = await orchestrator.fetch_batch_results("msgbatch_x")
+
+        assert set(bundle.successes) == {"subagent:a"}
+        assert set(bundle.failures) == {"subagent:b", "subagent:c"}
+        assert bundle.failures["subagent:b"].result_type == "errored"
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_id_raises(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        with pytest.raises(ValueError, match="non-empty batch_id"):
+            await orchestrator.fetch_batch_results("")
+
+
+class TestBatchSDKErrorMapping:
+    """SDK-side exceptions get wrapped in ``GenerationError`` for the caller."""
+
+    @pytest.mark.asyncio
+    async def test_submission_failure_wraps_in_generation_error(
+        self,
+        orchestrator: AIOrchestrator,
+    ) -> None:
+        batches = _wire_batches(orchestrator)
+        batches.create = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(GenerationError, match="Batch submission failed"):
+            await orchestrator.submit_tool_use_batch([_request()])
+
+
+def _success_entry(custom_id: str) -> dict[str, Any]:
+    """Minimal succeeded-entry dict the parser will lift to a ``ToolUseResult``."""
+    return {
+        "custom_id": custom_id,
+        "result": {
+            "type": "succeeded",
+            "message": {
+                "id": f"msg_{custom_id}",
+                "model": "claude-sonnet",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "report_tuning",
+                        "input": {"tuned_content": "X", "changes": []},
+                    },
+                ],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+    }
+
+
+def _failure_entry(custom_id: str, result_type: str) -> dict[str, Any]:
+    return {
+        "custom_id": custom_id,
+        "result": {
+            "type": result_type,
+            "error": {"message": f"upstream {result_type}"},
+        },
+    }

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -768,3 +768,34 @@ class TestContentTunerParseBatchResult:
         assert result.token_usage_input == 100
         assert result.token_usage_output == 50
         assert not result.dry_run
+
+    def test_missing_tuned_content_raises_generation_error(self) -> None:
+        """A malformed ``tool_input`` (missing ``tuned_content``) raises.
+
+        Pins the negative-path behaviour explicitly — the parser is
+        shared with the sync path's ``_parse_tool_use_input``, but a
+        future refactor that bypasses the shared validator on the
+        batch resume path would silently lose this guard if no
+        dedicated test pinned it.
+        """
+        tool_result = ToolUseResult(
+            tool_name="report_tuning",
+            tool_input={"changes": []},  # no ``tuned_content``
+            token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+            model="claude",
+            message_id="msg_bad",
+        )
+        with pytest.raises(GenerationError, match="tuned_content"):
+            ContentTuner.parse_batch_tuning_result(tool_result)
+
+    def test_non_list_changes_raises_generation_error(self) -> None:
+        """``changes`` must be a list — a string-shaped value is rejected."""
+        tool_result = ToolUseResult(
+            tool_name="report_tuning",
+            tool_input={"tuned_content": "x", "changes": "not a list"},
+            token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+            model="claude",
+            message_id="msg_bad",
+        )
+        with pytest.raises(GenerationError, match="list of strings"):
+            ContentTuner.parse_batch_tuning_result(tool_result)

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -674,3 +674,97 @@ class TestContentTunerLoggerBehavior:
         assert result.content == original  # Same value
         assert result.dry_run
         assert result.changes == ["[DRY RUN] No changes made"]
+
+
+class TestContentTunerBuildBatchRequest:
+    """Pin ``build_batch_request`` builds the same payload ``tune`` sends."""
+
+    @pytest.fixture
+    def tuner(self) -> ContentTuner:
+        return ContentTuner(MagicMock(spec=AIOrchestrator))
+
+    def test_request_carries_custom_id_prompt_and_tool(
+        self,
+        tuner: ContentTuner,
+    ) -> None:
+        """The request envelope keeps every field the orchestrator needs."""
+        req = tuner.build_batch_request(
+            custom_id="subagent:architecture",
+            source_content="# Original\n\nbody",
+            source_context="Source repo",
+            target_context="Target repo",
+        )
+        assert req.custom_id == "subagent:architecture"
+        assert "Original" in req.prompt
+        assert req.tool_schema["name"] == "report_tuning"
+
+    def test_system_blocks_match_what_tune_would_send(
+        self,
+        tuner: ContentTuner,
+    ) -> None:
+        """Cache prefix is identical between sync and batch — pin it."""
+        req = tuner.build_batch_request(
+            custom_id="subagent:a",
+            source_content="X",
+            source_context="A",
+            target_context="B",
+        )
+        sync_blocks = ContentTuner._build_system_blocks("A", "B", None)
+        assert req.system_blocks == sync_blocks
+
+    def test_preserve_sections_flow_through(
+        self,
+        tuner: ContentTuner,
+    ) -> None:
+        req = tuner.build_batch_request(
+            custom_id="subagent:a",
+            source_content="X",
+            source_context="A",
+            target_context="B",
+            preserve_sections=["Identity", "Workflow"],
+        )
+        joined = " ".join(str(b["text"]) for b in req.system_blocks)
+        assert '"Identity"' in joined
+        assert '"Workflow"' in joined
+
+    def test_empty_custom_id_rejected(self, tuner: ContentTuner) -> None:
+        with pytest.raises(ValueError, match="custom_id cannot be empty"):
+            tuner.build_batch_request(
+                custom_id="   ",
+                source_content="X",
+                source_context="A",
+                target_context="B",
+            )
+
+    def test_input_validation_mirrors_tune(self, tuner: ContentTuner) -> None:
+        """Same content / context validation runs on the batch path."""
+        with pytest.raises(ValueError, match="Source context"):
+            tuner.build_batch_request(
+                custom_id="ok",
+                source_content="X",
+                source_context="",
+                target_context="B",
+            )
+
+
+class TestContentTunerParseBatchResult:
+    """Pin ``parse_batch_tuning_result`` lifts a batch result correctly."""
+
+    def test_returns_tuning_result_with_content_and_changes(self) -> None:
+        tool_result = ToolUseResult(
+            tool_name="report_tuning",
+            tool_input={
+                "tuned_content": "# Adapted\n",
+                "changes": ["Renamed FastAPI to Django", "Updated paths"],
+            },
+            token_usage=TokenUsage(input_tokens=100, output_tokens=50),
+            model="claude",
+            message_id="msg_1",
+        )
+
+        result = ContentTuner.parse_batch_tuning_result(tool_result)
+        assert result.content == "# Adapted\n"
+        assert result.changes == ["Renamed FastAPI to Django", "Updated paths"]
+        assert result.token_usage_input == 100
+        assert result.token_usage_output == 50
+        assert not result.dry_run

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -408,3 +408,22 @@ class TestBatchProgressExpiry:
             custom_id_map={"subagent:foo": "subagents"},
         )
         assert not progress.is_potentially_expired()
+
+    def test_handles_tz_naive_submitted_at(self) -> None:
+        """A tz-naive ISO string is treated as UTC.
+
+        Pins the ``replace(tzinfo=UTC)`` branch in
+        :meth:`BatchProgress._parsed_submitted_at`. Without this
+        coverage a refactor that drops the tz-naive promotion would
+        produce a ``TypeError: can't subtract offset-naive and
+        offset-aware datetimes`` at runtime — exactly the kind of
+        regression mutation testing is meant to catch.
+        """
+        # Submitted 25h ago in tz-naive form; should still flag expired.
+        now = datetime(2026, 5, 10, 1, 0, tzinfo=UTC)
+        progress = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T00:00:00",  # no offset suffix
+            custom_id_map={"subagent:foo": "subagents"},
+        )
+        assert progress.is_potentially_expired(now=now)

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from start_green_stay_green.utils.enhance_state import BatchProgress
 from start_green_stay_green.utils.enhance_state import EnhanceState
 from start_green_stay_green.utils.enhance_state import STATE_FILE_VERSION
 from start_green_stay_green.utils.enhance_state import TargetCompletion
@@ -204,3 +205,119 @@ def test_target_completion_is_immutable() -> None:
     rec = TargetCompletion(hash="sha256:abc", model="x", timestamp="y")
     with pytest.raises(AttributeError):
         rec.hash = "sha256:def"  # type: ignore[misc]
+
+
+class TestBatchProgressExtension:
+    """Phase 5a: optional in-flight batch field on ``EnhanceState``."""
+
+    def test_default_state_has_no_batch(self) -> None:
+        state = EnhanceState()
+        assert state.batch is None
+        assert not state.has_batch()
+
+    def test_start_batch_records_id_and_map(self) -> None:
+        state = EnhanceState()
+        state.start_batch(
+            "msgbatch_42",
+            {"a": "subagent:foo", "b": "skill:bar"},
+            "2026-05-09T12:00:00+00:00",
+        )
+
+        assert state.has_batch()
+        assert isinstance(state.batch, BatchProgress)
+        assert state.batch.batch_id == "msgbatch_42"
+        assert state.batch.custom_id_map == {
+            "a": "subagent:foo",
+            "b": "skill:bar",
+        }
+        assert state.batch.submitted_at == "2026-05-09T12:00:00+00:00"
+        # last_run is also bumped so a future read knows when this happened
+        assert state.last_run == "2026-05-09T12:00:00+00:00"
+
+    def test_start_batch_refuses_to_overwrite_in_flight(self) -> None:
+        state = EnhanceState()
+        state.start_batch("msgbatch_first", {"a": "x"}, "2026-05-09T00:00:00Z")
+
+        with pytest.raises(ValueError, match="already recorded"):
+            state.start_batch("msgbatch_second", {"b": "y"}, "2026-05-09T01:00:00Z")
+
+    def test_clear_batch_drops_record(self) -> None:
+        state = EnhanceState()
+        state.start_batch("msgbatch_42", {"a": "subagent:foo"}, "2026-05-09T00:00:00Z")
+        assert state.has_batch()
+
+        state.clear_batch()
+        assert state.batch is None
+        assert not state.has_batch()
+        # And start_batch is allowed again after a clear
+        state.start_batch("msgbatch_43", {"a": "subagent:foo"}, "2026-05-09T01:00:00Z")
+        assert state.batch is not None
+        assert state.batch.batch_id == "msgbatch_43"
+
+    def test_to_dict_omits_batch_when_none(self) -> None:
+        """A batchless state round-trips to the same JSON pre-Phase-5a wrote."""
+        state = EnhanceState()
+        payload = state.to_dict()
+        assert "batch" not in payload
+
+    def test_to_dict_includes_batch_when_present(self) -> None:
+        state = EnhanceState()
+        state.start_batch(
+            "msgbatch_42",
+            {"a": "subagent:foo"},
+            "2026-05-09T00:00:00+00:00",
+        )
+
+        payload = state.to_dict()
+        assert payload["batch"] == {
+            "batch_id": "msgbatch_42",
+            "submitted_at": "2026-05-09T00:00:00+00:00",
+            "custom_id_map": {"a": "subagent:foo"},
+        }
+
+    def test_round_trip_preserves_batch(self) -> None:
+        original = EnhanceState()
+        original.start_batch(
+            "msgbatch_42",
+            {"a": "subagent:foo", "b": "skill:bar"},
+            "2026-05-09T00:00:00+00:00",
+        )
+
+        restored = EnhanceState.from_dict(original.to_dict())
+        assert restored.has_batch()
+        assert restored.batch is not None
+        assert restored.batch.batch_id == "msgbatch_42"
+        assert restored.batch.custom_id_map == {
+            "a": "subagent:foo",
+            "b": "skill:bar",
+        }
+
+    def test_from_dict_drops_malformed_batch(self) -> None:
+        """A malformed ``batch`` payload degrades to ``None`` (no in-flight record)."""
+        # Missing batch_id → drop
+        state = EnhanceState.from_dict({"batch": {"submitted_at": "x"}})
+        assert state.batch is None
+        # batch field is not a dict → drop
+        state = EnhanceState.from_dict({"batch": "garbage"})
+        assert state.batch is None
+        # Missing batch field → still None (forward-compat with pre-5a writers)
+        state = EnhanceState.from_dict({"completed": {}})
+        assert state.batch is None
+
+    def test_pre_phase_5a_state_file_loads_unchanged(self) -> None:
+        """A state file produced by the Phase 3c writer must keep working."""
+        legacy_payload = {
+            "version": 1,
+            "last_run": "2026-04-01T00:00:00+00:00",
+            "completed": {
+                "claude-md": {
+                    "hash": "sha256:abc",
+                    "model": "claude-sonnet",
+                    "timestamp": "2026-04-01T00:00:00+00:00",
+                },
+            },
+        }
+        state = EnhanceState.from_dict(legacy_payload)
+        assert "claude-md" in state.completed
+        assert state.batch is None
+        assert not state.has_batch()

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from start_green_stay_green.ai.types import GenerationError
 from start_green_stay_green.utils.enhance_state import BatchProgress
+from start_green_stay_green.utils.enhance_state import BatchStateError
 from start_green_stay_green.utils.enhance_state import EnhanceState
 from start_green_stay_green.utils.enhance_state import STATE_FILE_VERSION
 from start_green_stay_green.utils.enhance_state import TargetCompletion
@@ -249,12 +251,15 @@ class TestBatchProgressExtension:
             "2026-05-09T00:00:00Z",
         )
 
-        with pytest.raises(ValueError, match="already recorded"):
+        with pytest.raises(BatchStateError, match="already recorded") as exc:
             state.start_batch(
                 "msgbatch_second",
                 {"subagent:bar": "subagents"},
                 "2026-05-09T01:00:00Z",
             )
+        # Subclasses GenerationError so callers catching the AI-domain
+        # parent class handle state-file violations uniformly.
+        assert isinstance(exc.value, GenerationError)
 
     def test_clear_batch_drops_record(self) -> None:
         state = EnhanceState()

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
 import json
 from typing import TYPE_CHECKING
 
@@ -344,3 +347,59 @@ class TestBatchProgressExtension:
         assert "claude-md" in state.completed
         assert state.batch is None
         assert not state.has_batch()
+
+
+class TestBatchProgressExpiry:
+    """``is_potentially_expired`` guards against stale 24 h batches."""
+
+    def test_returns_false_when_no_batch_recorded(self) -> None:
+        """A default-constructed BatchProgress can never be expired."""
+        progress = BatchProgress()
+        assert not progress.is_potentially_expired()
+
+    def test_returns_false_within_24h_of_submission(self) -> None:
+        """A 23 h-old batch is still live — defer to the API."""
+
+        submitted = datetime(2026, 5, 9, 0, 0, tzinfo=UTC)
+        progress = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at=submitted.isoformat(),
+            custom_id_map={"subagent:foo": "subagents"},
+        )
+        # 23h59m later — still under the SLA.
+        now = submitted + timedelta(hours=23, minutes=59)
+        assert not progress.is_potentially_expired(now=now)
+
+    def test_returns_true_at_24h_boundary(self) -> None:
+        """Exactly 24h after submission counts as expired (over-report)."""
+
+        submitted = datetime(2026, 5, 9, 0, 0, tzinfo=UTC)
+        progress = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at=submitted.isoformat(),
+            custom_id_map={"subagent:foo": "subagents"},
+        )
+        now = submitted + timedelta(hours=24)
+        assert progress.is_potentially_expired(now=now)
+
+    def test_returns_true_well_past_24h(self) -> None:
+        """A 48 h-old batch is unambiguously expired."""
+
+        submitted = datetime(2026, 5, 9, 0, 0, tzinfo=UTC)
+        progress = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at=submitted.isoformat(),
+            custom_id_map={"subagent:foo": "subagents"},
+        )
+        assert progress.is_potentially_expired(
+            now=submitted + timedelta(hours=48),
+        )
+
+    def test_returns_false_for_unparseable_timestamp(self) -> None:
+        """A malformed ``submitted_at`` defers to the API rather than failing."""
+        progress = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="not an iso timestamp",
+            custom_id_map={"subagent:foo": "subagents"},
+        )
+        assert not progress.is_potentially_expired()

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -219,16 +219,20 @@ class TestBatchProgressExtension:
         state = EnhanceState()
         state.start_batch(
             "msgbatch_42",
-            {"a": "subagent:foo", "b": "skill:bar"},
+            {
+                "subagent:architecture-review": "subagents",
+                "skill:stay-green": "skills",
+            },
             "2026-05-09T12:00:00+00:00",
         )
 
         assert state.has_batch()
         assert isinstance(state.batch, BatchProgress)
         assert state.batch.batch_id == "msgbatch_42"
+        # Direction: custom_id (key) → top-level target (value).
         assert state.batch.custom_id_map == {
-            "a": "subagent:foo",
-            "b": "skill:bar",
+            "subagent:architecture-review": "subagents",
+            "skill:stay-green": "skills",
         }
         assert state.batch.submitted_at == "2026-05-09T12:00:00+00:00"
         # last_run is also bumped so a future read knows when this happened
@@ -236,21 +240,37 @@ class TestBatchProgressExtension:
 
     def test_start_batch_refuses_to_overwrite_in_flight(self) -> None:
         state = EnhanceState()
-        state.start_batch("msgbatch_first", {"a": "x"}, "2026-05-09T00:00:00Z")
+        state.start_batch(
+            "msgbatch_first",
+            {"subagent:foo": "subagents"},
+            "2026-05-09T00:00:00Z",
+        )
 
         with pytest.raises(ValueError, match="already recorded"):
-            state.start_batch("msgbatch_second", {"b": "y"}, "2026-05-09T01:00:00Z")
+            state.start_batch(
+                "msgbatch_second",
+                {"subagent:bar": "subagents"},
+                "2026-05-09T01:00:00Z",
+            )
 
     def test_clear_batch_drops_record(self) -> None:
         state = EnhanceState()
-        state.start_batch("msgbatch_42", {"a": "subagent:foo"}, "2026-05-09T00:00:00Z")
+        state.start_batch(
+            "msgbatch_42",
+            {"subagent:foo": "subagents"},
+            "2026-05-09T00:00:00Z",
+        )
         assert state.has_batch()
 
         state.clear_batch()
         assert state.batch is None
         assert not state.has_batch()
         # And start_batch is allowed again after a clear
-        state.start_batch("msgbatch_43", {"a": "subagent:foo"}, "2026-05-09T01:00:00Z")
+        state.start_batch(
+            "msgbatch_43",
+            {"subagent:foo": "subagents"},
+            "2026-05-09T01:00:00Z",
+        )
         assert state.batch is not None
         assert state.batch.batch_id == "msgbatch_43"
 
@@ -264,7 +284,7 @@ class TestBatchProgressExtension:
         state = EnhanceState()
         state.start_batch(
             "msgbatch_42",
-            {"a": "subagent:foo"},
+            {"subagent:architecture-review": "subagents"},
             "2026-05-09T00:00:00+00:00",
         )
 
@@ -272,14 +292,17 @@ class TestBatchProgressExtension:
         assert payload["batch"] == {
             "batch_id": "msgbatch_42",
             "submitted_at": "2026-05-09T00:00:00+00:00",
-            "custom_id_map": {"a": "subagent:foo"},
+            "custom_id_map": {"subagent:architecture-review": "subagents"},
         }
 
     def test_round_trip_preserves_batch(self) -> None:
         original = EnhanceState()
         original.start_batch(
             "msgbatch_42",
-            {"a": "subagent:foo", "b": "skill:bar"},
+            {
+                "subagent:architecture-review": "subagents",
+                "skill:stay-green": "skills",
+            },
             "2026-05-09T00:00:00+00:00",
         )
 
@@ -288,8 +311,8 @@ class TestBatchProgressExtension:
         assert restored.batch is not None
         assert restored.batch.batch_id == "msgbatch_42"
         assert restored.batch.custom_id_map == {
-            "a": "subagent:foo",
-            "b": "skill:bar",
+            "subagent:architecture-review": "subagents",
+            "skill:stay-green": "skills",
         }
 
     def test_from_dict_drops_malformed_batch(self) -> None:


### PR DESCRIPTION
## Summary

Phase 5a of the optimization roadmap: building blocks for `green enhance --batch`. The Anthropic Message Batches API submits up to 100k requests in one call with a 50% discount versus sync. This PR ships the SDK bridge, the per-target request builder, the state extension, and an ADR — all the pieces a future `--batch` flag needs. **CLI wiring is intentionally deferred to Phase 5b** so reviewers can focus on the new API and state schema in isolation, before any user-visible behaviour changes.

## What landed

### `ai/types.py` — shared type module

Breaks the `orchestrator` ↔ `batch` import cycle structurally rather than with lazy local imports. `GenerationError`, `TokenUsage`, `GenerationResult`, and `ToolUseResult` now live here; both files import from it freely. `orchestrator.py` keeps re-exports + `__all__` so existing `from start_green_stay_green.ai.orchestrator import ToolUseResult` imports across the codebase keep working unchanged.

### `ai/batch.py` — pure-data layer

Five dataclasses + one parser:

| Type | Role |
|---|---|
| `ToolUseBatchRequest` | Per-call payload bundled into a batch (`custom_id` + same `prompt`/`system_blocks`/`tool_schema` `generate_tool_use_async` accepts) |
| `BatchSubmission` | What `submit_tool_use_batch` returns |
| `BatchPoll` | Snapshot from `poll_batch` + `is_ended` property |
| `BatchError` | Per-request failure stand-in (errored/canceled/expired); per-request failures do **not** abort batch reconciliation |
| `BatchResultsBundle` | Parallel `successes` / `failures` maps |
| `parse_batch_result_entry` | Lifts one streamed entry into `(custom_id, ToolUseResult \| BatchError)`. Handles SDK Pydantic objects + plain-dict test doubles. Cache tokens threaded through — batch users get the same Phase-2c telemetry sync users do. |

### Three new `AIOrchestrator` async methods

- `submit_tool_use_batch(requests)` — wraps `client.messages.batches.create`. Validates non-empty + unique `custom_id` locally before hitting the API.
- `poll_batch(batch_id)` — single retrieve call. No internal sleep loop; callers drive their own (ADR explains why).
- `fetch_batch_results(batch_id)` — streams `client.messages.batches.results`, partitions each entry into the bundle's maps by `custom_id`.

The request envelope (`_batch_request_envelope`) mirrors `_call_tool_api_async` so the per-request contract is identical between sync and batch — same forced `tool_choice`, same `system` blocks, same model + max_tokens.

### `ContentTuner` factoring

- `build_batch_request(custom_id, source_content, source_context, target_context, preserve_sections=None)` — returns a `ToolUseBatchRequest`. Reuses `_build_system_blocks` + `_build_user_message` so the cache prefix is byte-identical between sync and batch.
- `parse_batch_tuning_result(tool_result)` — classmethod that lifts a fetched `ToolUseResult` into the existing `TuningResult`. Same parser `tune` already runs on its sync result.

### State extension — additive, schema v1 stays

- `BatchProgress` dataclass (`batch_id`, `submitted_at`, `custom_id_map: target → custom_id`).
- `EnhanceState.batch: BatchProgress | None` + three methods:
  - `has_batch()` — true iff a submitted-but-not-yet-fetched batch is recorded.
  - `start_batch(...)` — refuses to overwrite an in-flight batch (without this guard the user pays twice for the prior abandoned submission).
  - `clear_batch()` — drop the record once results are reconciled.
- `to_dict` omits the `batch` key when `None` — pre-Phase-5a state files round-trip byte-identical. `from_dict` tolerates a missing or malformed `batch` key. **No version bump** — the existing forward-compat contract covers it.

### `ADR-001-batch-enhance.md`

Documents the four key decisions (two-call CLI vs in-process polling, types in `ai/batch.py` vs `orchestrator.py`, additive state extension, per-request failures don't abort) and the alternatives considered.

## Tests (42 new)

| File | Count | Coverage |
|---|---|---|
| `tests/unit/ai/test_batch.py` | 16 | Parser success (token + cache telemetry), failure paths, Pydantic-shaped + dict-shaped payloads, malformed inputs raise `GenerationError` |
| `tests/unit/ai/test_orchestrator_batch.py` | 11 | Mocks `client.messages.batches.{create,retrieve,results}`; pins request envelope shape, validation, SDK-error → `GenerationError` mapping |
| `tests/unit/ai/test_tuner.py` (added) | 6 | Cache prefix identical to `tune()`'s, `preserve_sections` flow through, empty `custom_id` rejected |
| `tests/unit/utils/test_enhance_state.py` (added) | 9 | `BatchProgress` round-trip, `start_batch` refuses to overwrite, `clear_batch` drops, `to_dict` omits `batch` when `None`, pre-Phase-5a state files load unchanged |

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck, security, complexity — every function grade A; 4 functions refactored to keep grade A after the additions).
- **1745 unit + integration/e2e tests pass** (was 1703 → +42 new).

## Test plan

- [ ] CI green on this PR.
- [ ] Confirm `from start_green_stay_green.ai.orchestrator import ToolUseResult` (and the other re-exported types) still works in downstream imports — the migration is structural so this is the riskiest back-compat surface.
- [ ] Smoke that an existing pre-Phase-5a `.claude/.enhance-state.json` loads cleanly under the new reader.

## Roadmap status

- ✅ Phase 0–3, 2c, 4 — merged
- ⏳ **Phase 5a (this PR)** — Batches API primitives
- 🔜 Phase 5b — `green enhance --batch` CLI wiring
- 🔜 Phase 6 — UX/docs/release

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_