### PR TITLE
feat(skills): import await-claude-review helper from well-worn-tools PR #6

### DIFF
--- a/.claude/skills/address-feedback/SKILL.md
+++ b/.claude/skills/address-feedback/SKILL.md
@@ -112,9 +112,16 @@ For each item, after the fix lands locally:
 2. **Top-level Claude review comment** — there is no thread to resolve. Post a single summary reply via `mcp__github__add_issue_comment` listing each addressed item and the SHA(s) that fixed it.
 3. After pushing, request a fresh review by posting `@claude please re-review` via `mcp__github__add_issue_comment`. The GitHub Action runs again and writes a new verdict comment — that becomes the comment you parse on the next pass.
 
-### Step 5: Push Once and Watch CI
+### Step 5: Push Once and Await the Next Verdict
 
-Push the branch (single push, not one per fix). Optionally `mcp__github__subscribe_pr_activity` so review and CI events surface here. If CI fails, switch to `ci-debugging`; otherwise wait for the new Claude verdict comment.
+Push the branch (single push, not one per fix). Then delegate the wait to `await-claude-review` — it pins the new HEAD, calls `mcp__github__subscribe_pr_activity`, and ends the turn so the session wakes on the bot's verdict comment via `<github-webhook-activity>`. **Do not poll** with `sleep` or repeated `get_comments` calls, and do not wait on CI passes — the webhook does not deliver them; only the comment event is the wake signal.
+
+When the helper wakes the session:
+
+- Verdict `LGTM` for the current HEAD → continue to Step 6.
+- Verdict `CHANGES_REQUESTED` → loop back to Step 2 with the new comment body.
+- Verdict `COMMENTS` → user decides; if skipping, Step 6.
+- CI failure event for the current HEAD → if the failing job is the reviewer action, the helper retriggers it and stays subscribed; if it's other CI, hand off to `ci-debugging` and keep the subscription open. Either way, do not advance to merge.
 
 ### Step 6: Merge Gate — All Must Hold
 

--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: await-claude-review
+description: >-
+  Subscribe to GitHub PR activity and wait — without polling — for the
+  Claude reviewer's verdict comment on the current HEAD. Use when a PR
+  has just been pushed and you need to know the verdict
+  (LGTM / CHANGES_REQUESTED / COMMENTS) before merging, addressing
+  feedback, or declaring work done. Wraps
+  `mcp__github__subscribe_pr_activity`, which delivers comments and CI
+  failures (NOT CI passes) as `<github-webhook-activity>` events. The
+  verdict comment itself is a comment event, so the bot's post wakes
+  the session directly — no need to proxy through CI status. After
+  subscribing, end the turn; events resume the session.
+  Called by `address-feedback`, `stay-green`, and
+  `comprehensive-pr-review`.
+  Do NOT use for waiting on arbitrary CI success (not deliverable by
+  the webhook), general PR babysitting unrelated to the verdict gate,
+  debugging CI failures themselves (use `ci-debugging`), or one-off
+  status polling (use `pull_request_read` directly).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Await Claude Review
+
+Wait for the Claude reviewer's `Verdict:` comment on the current HEAD via PR webhook events. No polling, no `sleep`, no CI-pass proxy.
+
+## What the Subscription Actually Delivers
+
+`mcp__github__subscribe_pr_activity` says, verbatim:
+
+> Once subscribed comments and CI failures will be delivered into this conversation as `<github-webhook-activity>` messages.
+
+So the deliverable set is:
+
+| Event                                         | Delivered? | Notes                                                          |
+| --------------------------------------------- | ---------- | -------------------------------------------------------------- |
+| Top-level PR comment (incl. reviewer verdict) | Yes        | This is the wake signal you want.                              |
+| Line-level review comment / thread reply      | Yes        | Treated as a comment event.                                    |
+| CI **failure** (any required check failing)   | Yes        | Triage on receipt — may indicate the reviewer action failed.   |
+| CI **success / pass**                         | **No**     | Do not write logic that waits on this — it never arrives.      |
+| Successful workflow_run completion            | **No**     | Same as above.                                                 |
+| PR merge / close                              | Implicit   | You should `unsubscribe_pr_activity` on these from the caller. |
+
+**Implication.** Don't treat "CI green" as a proxy for "review posted." The verdict comment is itself a delivered event — wait for it directly.
+
+## Canonical Verdict Line
+
+The reviewer (see `comprehensive-pr-review`) ends its top-level comment with a line matching, case-insensitive:
+
+```
+^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+```
+
+Examples that match:
+
+- `## Verdict: LGTM`
+- `**Verdict:** CHANGES_REQUESTED`
+- `Verdict: COMMENTS`
+
+If the regex does not match, treat the comment as malformed: do **not** infer a verdict from prose ("looks good to me" is not a verdict). Surface to the user.
+
+## Instructions
+
+### Step 1: Pin the HEAD You're Waiting For
+
+Before subscribing, record what "current" means so you can later distinguish a fresh verdict from a stale one.
+
+1. `mcp__github__pull_request_read` with `method: "get"` → record `head.sha`.
+2. `mcp__github__get_commit` with `sha: head.sha` → record `commit.committer.date` as `headPushedAt` (proxy for the latest push time).
+
+### Step 2: Subscribe and End the Turn
+
+```
+mcp__github__subscribe_pr_activity
+  owner: <owner>
+  repo:  <repo>
+  pullNumber: <N>
+```
+
+Then **stop**. Do not poll. Do not `sleep`. Do not call `pull_request_read get_comments` in a loop. Webhook events arrive as `<github-webhook-activity>` messages and resume the session on their own.
+
+### Step 3: On Wake — Classify the Event
+
+When a `<github-webhook-activity>` message arrives, decide what kind of event it is:
+
+- **Top-level PR comment from a reviewer bot** (`claude[bot]`, `github-actions[bot]`, or whichever account posts reviews on this repo) → go to Step 4.
+- **Line-level review comment** → not a verdict; if you're tracking thread resolutions for `address-feedback`, handle there. Otherwise stay subscribed and wait for the next event.
+- **CI failure event** → go to Step 5.
+- **Anything else** → stay subscribed; wait for the next event.
+
+### Step 4: Validate Currency and Parse Verdict
+
+Re-fetch the comments to read the full body (the webhook payload may be truncated):
+
+1. `mcp__github__pull_request_read` with `method: "get_comments"`.
+2. Filter to bot author + body containing the verdict regex.
+3. Sort by `created_at` desc; take the first.
+4. **Currency check**: require `created_at >= headPushedAt`. A verdict posted before the latest push describes an earlier state; ignore and keep waiting.
+5. Parse with the regex above. Return one of:
+   - `LGTM` → caller proceeds to merge gate.
+   - `CHANGES_REQUESTED` → caller enters fix loop.
+   - `COMMENTS` → caller decides (usually mergeable as-is).
+   - **Malformed** → surface to user; do not guess.
+
+### Step 5: On CI Failure for Current HEAD
+
+A CI failure event for `head.sha` may mean the reviewer action itself failed (timeout, rate limit, permissions) — in which case **the verdict comment will never arrive** and waiting is futile. Inspect the failed check:
+
+1. `mcp__github__pull_request_read` with `method: "get_check_runs"` for `head.sha`.
+2. If the failed run is the **review action** (look for the workflow that runs `@claude` review): post `@claude please review` via `mcp__github__add_issue_comment` to retrigger, then stay subscribed.
+3. If the failed run is **other CI** (lint, tests, build): surface the failure to the user and recommend handing off to `ci-debugging`. Stay subscribed — the reviewer action may still post.
+
+### Step 6: Cleanup
+
+The caller should call `mcp__github__unsubscribe_pr_activity` once the PR merges, closes, or the verdict gate is no longer needed. This helper does not unsubscribe on its own — leave the lifecycle to the caller.
+
+## Examples
+
+### Example 1: Push, Subscribe, Wake on LGTM
+
+1. Caller (`address-feedback` Step 5) finishes pushing fixes.
+2. Pin HEAD: `head.sha = abc123`, `headPushedAt = 2026-05-08T11:00:00Z`.
+3. `subscribe_pr_activity owner=acme repo=widgets pullNumber=42`. End turn.
+4. Wake: `<github-webhook-activity>` for a comment by `claude[bot]`.
+5. `get_comments` → latest matching at `2026-05-08T11:04:33Z`, body ends `## Verdict: LGTM`. `11:04:33Z >= 11:00:00Z` ✓.
+6. Return `LGTM` to caller. Caller proceeds to merge gate.
+
+### Example 2: Stale Verdict After Force-Push
+
+1. Pin HEAD: `head.sha = def456`, `headPushedAt = 2026-05-08T12:00:00Z`.
+2. Subscribe, end turn.
+3. Wake on a comment event. `get_comments` → latest verdict `LGTM` at `11:55:00Z` — that's *before* `headPushedAt`. The push superseded the verdict.
+4. Stay subscribed. Optionally post `@claude please re-review`. Return to waiting.
+
+### Example 3: Reviewer Action Failed in CI
+
+1. Subscribe after push, end turn.
+2. Wake: `<github-webhook-activity>` for a CI failure on `head.sha`.
+3. `get_check_runs` → the failing job is `claude-review` (timeout). No other failures.
+4. Post `@claude please review` to retrigger the action. Stay subscribed.
+5. Subsequent wake delivers the verdict comment normally.
+
+### Example 4: Other CI Failed; Verdict May Still Come
+
+1. Subscribe after push, end turn.
+2. Wake: CI failure on `head.sha`. `get_check_runs` → `pytest` failed; `claude-review` is still in progress.
+3. Surface the test failure to the user and recommend `ci-debugging` for that. Stay subscribed — the reviewer may still post a verdict (which the author will need to address regardless of test failures).
+
+## Troubleshooting
+
+### Error: Tempted to wait on "CI green" / `workflow_run.conclusion == success`
+
+Don't. The subscription does not deliver CI passes. Wait on the comment event directly — that *is* the delivered signal.
+
+### Error: Tempted to poll with `sleep` or `Bash run_in_background`
+
+Don't. The session is woken by `<github-webhook-activity>`. Polling burns time and conflicts with the harness's wake mechanism. Subscribe and end the turn.
+
+### Error: Webhook arrives but `get_comments` shows no matching verdict
+
+Possible causes, in order of likelihood:
+
+1. The event was a line-level review comment, not the top-level verdict. Stay subscribed.
+2. The reviewer posted a non-verdict comment (e.g., a status ping). Stay subscribed.
+3. The bot author login differs on this repo. Confirm the author and update the filter.
+
+### Error: Multiple bot accounts post comments
+
+Match by author login (`claude[bot]`, `github-actions[bot]`) AND require the body to contain the canonical Verdict regex. If still ambiguous, ask the user which account is authoritative — do not guess.
+
+### Error: PR merged or closed while waiting
+
+The caller should detect this and call `unsubscribe_pr_activity`. If you see no further events for a long time, ask the user before assuming the PR is still open.

--- a/.claude/skills/comprehensive-pr-review/SKILL.md
+++ b/.claude/skills/comprehensive-pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: comprehensive-pr-review
 description: >-
-  Structured 10-section PR review covering security, quality, testing,
+  Structured 11-section PR review covering security, quality, testing,
   and documentation. Use when reviewing pull requests, evaluating code
   changes, or doing code review. Produces verdicts with specific references.
   Do NOT use for backlog grooming or issue triage (use backlog-grooming)

--- a/.claude/skills/comprehensive-pr-review/SKILL.md
+++ b/.claude/skills/comprehensive-pr-review/SKILL.md
@@ -64,6 +64,28 @@ Medium-priority suggestions that would improve the PR.
 
 Include reasoning with specific file:line references.
 
+#### Verdict Line Format (load-bearing)
+
+End the review comment with a single canonical line so downstream automation (`address-feedback`, `await-claude-review`) can parse it deterministically:
+
+```
+## Verdict: LGTM
+## Verdict: CHANGES_REQUESTED
+## Verdict: COMMENTS
+```
+
+`await-claude-review` matches this regex (case-insensitive):
+
+```
+^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+```
+
+Don't paraphrase ("looks good to me", "approving"); the parser will refuse to infer a verdict from prose and the merge gate will block.
+
+### Step 11 (Iterative Reviewer): Wait for the Author's Response
+
+When you've delivered `CHANGES_REQUESTED` or actionable `COMMENTS` and want to follow the iteration without polling, delegate to `await-claude-review`. It subscribes to PR activity (comments + CI failures — the webhook does **not** deliver CI passes) and wakes the session on the next push's verdict comment. End the turn after subscribing.
+
 ## Examples
 
 ### Example 1: Approval with Suggestions

--- a/.claude/skills/stay-green/SKILL.md
+++ b/.claude/skills/stay-green/SKILL.md
@@ -52,6 +52,10 @@ Quality checks include: formatting (Black + isort), linting (Ruff), type checkin
 
 No exceptions.
 
+### After Push: Await the Reviewer (if applicable)
+
+If the repo runs the Claude reviewer GitHub Action, "done" extends past local gates: the latest verdict for HEAD must be `LGTM`. Don't poll, don't `sleep`, and don't wait on "CI green" as a proxy — the PR webhook does **not** deliver CI passes, only comments and CI failures. Use `await-claude-review` to subscribe and end the turn; the bot's verdict comment wakes the session via `<github-webhook-activity>`. From there, `address-feedback` handles the merge gate or the fix loop.
+
 ## Examples
 
 ### Example 1: Adding a New Function


### PR DESCRIPTION
## Summary

Mirrors [geoffe-ga/well-worn-tools#6](https://github.com/geoffe-ga/well-worn-tools/pull/6) — a new shared helper skill that waits for the Claude reviewer's verdict comment via PR webhook events instead of polling. The key insight: `mcp__github__subscribe_pr_activity` delivers comments and CI **failures** (NOT CI passes), so the verdict comment itself is the wake signal — no need to proxy through "CI green".

## Changes

- **New** `.claude/skills/await-claude-review/SKILL.md` (175 lines) — pin HEAD → subscribe → end turn → classify webhook events → validate currency → parse `Verdict:` line. Includes the canonical regex `^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)`, four worked examples, and troubleshooting for stale verdicts and reviewer-action failures.
- **Modified** `address-feedback` Step 5 — renamed "Push Once and Watch CI" → "Push Once and Await the Next Verdict". Delegates the wait to `await-claude-review` and lays out the four wake outcomes (LGTM, CHANGES_REQUESTED, COMMENTS, CI failure).
- **Modified** `stay-green` — adds an "After Push: Await the Reviewer" subsection for repos running the Claude reviewer Action.
- **Modified** `comprehensive-pr-review` — adds the load-bearing Verdict Line Format (with the canonical regex) under Step 10, plus a new Step 11 for iterative reviewers to follow author responses without polling.

The local `comprehensive-pr-review` description already had a project-specific tweak referencing `address-feedback` for the author side; that line is preserved untouched.

## Test plan

- [ ] CI / pre-commit passes on the four modified `SKILL.md` files (markdown only)
- [ ] `await-claude-review` skill is discoverable in the system reminder list on next session
- [ ] No drift from upstream `well-worn-tools@b6f0c8e` — diffs verified line-by-line

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>

---
_Generated by [Claude Code](https://claude.ai/code/session_019RVne1FDu9uTaMj5KX11iq)_