### PR TITLE
feat(batch): Phase 5b — green enhance --batch CLI wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,11 @@ Limits and trade-offs:
 * Batches expire after 24 h server-side. `green enhance --batch`
   detects an expired record on the resume side and clears it with
   a "submit a fresh batch" message rather than producing an opaque
-  error.
+  error. Note: the expiry check runs only at the *start* of a
+  resume call, so when `--wait` blocks across the 24 h boundary
+  the loop will surface as `--wait timed out` rather than `expired`
+  — re-running once afterwards picks up the (now-recognised)
+  expired record and clears it.
 * Per-request failures (`errored` / `canceled` / `expired`) do *not*
   abort the whole batch — successful agents land on disk, failed
   ones are listed with their names so the user can re-run.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,69 @@ These options work with all commands:
 - `--help`: Show help message and exit
 
 
+### `green enhance` — re-tune an existing project
+
+Re-runs Pass 2 (AI tuning) over a project that already has the
+deterministic scaffold in place. Useful after `green init --offline`
+when you're ready to add the AI-tuned subagents, or after the
+reference subagents in this repo are updated and you want to pull
+the new style into your project.
+
+```bash
+# Re-tune everything in the current directory:
+green enhance
+
+# Subset:
+green enhance --targets claude-md
+
+# Preview the token cost without writing anything:
+green enhance --dry-run
+```
+
+#### Batch mode (Phase 5)
+
+For bulk runs (CI projects, batch enhancement of many repos), the
+Anthropic Message Batches API is 50% cheaper at the cost of a ≤24 h
+SLA. `green enhance --batch` submits subagent tunings via that path
+and exits — re-run the same command to pick up results once the
+batch ends:
+
+```bash
+# Submit:
+green enhance --batch --targets subagents
+# → "Submitted batch msgbatch_42 covering 8 subagent(s).
+#    Re-run `green enhance --batch` to fetch results."
+
+# (later — minutes to hours later) Resume:
+green enhance --batch --targets subagents
+# → "✓ Batch reconciled: 8 agent(s) written, 0 failed."
+```
+
+For a single blocking command (typical in CI), pass `--wait`:
+
+```bash
+green enhance --batch --wait --targets subagents
+# Polls every 30 s until the batch ends or the timeout (default 1h)
+# elapses.
+```
+
+Limits and trade-offs:
+
+* Batch mode currently handles `--targets subagents` only —
+  `claude-md` uses a free-text path that the Batches API does not
+  yet wrap. Mixing the two errors before any API call.
+* Batches expire after 24 h server-side. `green enhance --batch`
+  detects an expired record on the resume side and clears it with
+  a "submit a fresh batch" message rather than producing an opaque
+  error.
+* Per-request failures (`errored` / `canceled` / `expired`) do *not*
+  abort the whole batch — successful agents land on disk, failed
+  ones are listed with their names so the user can re-run.
+
+See [`plans/architecture/ADR-001-batch-enhance.md`](plans/architecture/ADR-001-batch-enhance.md)
+for the full design rationale.
+
+
 ## Documentation
 
 Comprehensive documentation for using Start Green Stay Green:

--- a/plans/2026-05-03-claude-init-optimization-roadmap.md
+++ b/plans/2026-05-03-claude-init-optimization-roadmap.md
@@ -36,10 +36,17 @@ Shipped:
   `poll_batch`, `fetch_batch_results`; `ContentTuner.build_batch_request`
   + `parse_batch_tuning_result`; `EnhanceState.batch` + `BatchProgress`;
   shared `ai/types.py` to break the orchestrator ↔ batch cycle;
-  ADR-001-batch-enhance.md) — branch
-  `claude/phase-5-batch-mode`. CLI wiring deferred to Phase 5b.
+  ADR-001-batch-enhance.md) — PR #313 merged onto main as commit
+  `d43e697`.
+- Phase 5b (CLI wiring: `green enhance --batch` and `--wait` flags;
+  `ai/batch_dispatch.py` orchestration glue;
+  `SubagentsGenerator.build_batch_plan` + `apply_batch_result`;
+  per-target dispatch branch in `cli.py`; subagents-only with a
+  hard error when mixed with `claude-md`; expiry guard + per-agent
+  failure isolation; README `### green enhance` section + ADR
+  Phase-5b notes) — branch `claude/phase-5b-batch-cli`.
 
-Remaining: batch CLI wiring (5b), UX/docs (6).
+Remaining: UX/docs (6).
 
 ---
 

--- a/plans/architecture/ADR-001-batch-enhance.md
+++ b/plans/architecture/ADR-001-batch-enhance.md
@@ -147,8 +147,33 @@ test seam wider.
 
 ## Phase 5 Scope
 
-- **5a (this PR)**: orchestrator primitives + tuner request builder
-  + state extension + this ADR. No CLI wiring; no user-visible flag.
-- **5b (follow-up PR)**: `green enhance --batch` flag, the two-call
-  flow, optional `--wait` for in-process polling, README + `--help`
-  copy.
+- **5a (PR #313, merged)**: orchestrator primitives + tuner request
+  builder + state extension + this ADR. No CLI wiring; no
+  user-visible flag.
+- **5b (this PR)**: `green enhance --batch` flag, the two-call flow,
+  optional `--wait` for in-process polling, ``ai/batch_dispatch.py``
+  orchestration glue, README + `--help` copy.
+
+### 5b implementation notes
+
+* **Subagents-only**. Phase 5b's `--batch` only handles the
+  `subagents` target; the sync `claude-md` path uses free-text
+  generation (which the Batches API does not yet wrap). Mixing
+  `--batch` with `--targets claude-md` is rejected before any API
+  call with a message that names the working invocation
+  (`--targets subagents`).
+* **`--wait` semantics**. Default is the two-call pattern from D1
+  above. `--wait` opts into a sleep-then-poll loop bounded by a
+  one-hour timeout; the API SLA is 24 h, so `--wait` is for users
+  who want a single blocking command rather than a CI-friendly
+  resume cursor.
+* **Expiry guard**. Every resume run calls
+  :meth:`BatchProgress.is_potentially_expired` before polling, so a
+  state file that crossed the 24 h SLA is cleared with a clear
+  message ("submit a fresh batch") rather than producing an opaque
+  ``404``.
+* **Per-agent failure isolation**. The `BatchResultsBundle.failures`
+  partition surfaces in the CLI as a follow-up line listing the
+  failed agent names. Phase 5b does *not* auto-retry; the user
+  re-runs `green enhance --batch` to include the failed agents in
+  the next submission. Auto-retry with backoff is a Phase 6 polish.

--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -387,22 +387,33 @@ def _write_results(
     that survives a code change to the source agents still produces
     valid output.
 
-    Returns ``(succeeded_agent_names, failed_agent_names)``.
+    Returns ``(succeeded_agent_names, failed_agent_names)``. The
+    ``failed_agent_names`` list combines three sources, all surfaced
+    to the user so the reconciliation summary stays accurate:
+
+    * Per-request failures returned by the API (``bundle.failures``).
+    * Successes the API returned that the local source tree could no
+      longer write (e.g. the source agent file was deleted between
+      submit and fetch — see :func:`_persist_successes`).
+    * Successes whose ``custom_id`` did not match any known schema
+      — flagged with the synthetic prefix ``"unresolved:"`` so the
+      user can file a bug report rather than seeing them silently
+      vanish.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    succeeded = _persist_successes(
+    succeeded, locally_failed = _persist_successes(
         bundle=bundle,
         plan_lookup=plan_lookup,
         generator=generator,
         target_dir=target_dir,
         file_writer=file_writer,
     )
-    failed = [
+    api_failed = [
         name
         for custom_id in bundle.failures
         if (name := _agent_name_from_custom_id(custom_id, plan_lookup)) is not None
     ]
-    return succeeded, failed
+    return succeeded, locally_failed + api_failed
 
 
 def _persist_successes(
@@ -412,22 +423,49 @@ def _persist_successes(
     generator: SubagentsGenerator,
     target_dir: Path,
     file_writer: FileWriter | None,
-) -> list[str]:
-    """Write each success to disk; return the agent names in order."""
+) -> tuple[list[str], list[str]]:
+    """Write each success to disk; return ``(written, locally_failed)``.
+
+    Per-agent failure isolation: if writing one agent fails (source
+    file deleted between submit and fetch, custom_id schema we don't
+    recognise) the rest still land on disk. The failed entry's name
+    flows to the caller's ``failed_agents`` so the user sees an
+    accurate count and a retry hint.
+
+    * Unresolved custom IDs (no recognised schema) become
+      ``"unresolved:<custom_id>"`` so they are visible rather than
+      silently dropped — this catches Phase-6 schema-drift bugs
+      early.
+    * :class:`FileNotFoundError` from
+      :meth:`SubagentsGenerator.get_agent_frontmatter` (raised when
+      the source agent file no longer exists at fetch time) is
+      caught here, not at :func:`_write_one_agent` — the helper
+      stays simple and orchestration owns the failure-tracking.
+    """
     written: list[str] = []
+    locally_failed: list[str] = []
     for custom_id, tool_result in bundle.successes.items():
         agent_name = _agent_name_from_custom_id(custom_id, plan_lookup)
         if agent_name is None:
+            locally_failed.append(f"unresolved:{custom_id}")
             continue
-        _write_one_agent(
-            generator=generator,
-            agent_name=agent_name,
-            tool_result=tool_result,
-            target_dir=target_dir,
-            file_writer=file_writer,
-        )
+        try:
+            _write_one_agent(
+                generator=generator,
+                agent_name=agent_name,
+                tool_result=tool_result,
+                target_dir=target_dir,
+                file_writer=file_writer,
+            )
+        except FileNotFoundError:
+            # Source file vanished between submit and fetch — log
+            # the agent as failed and keep going so siblings still
+            # land. The reviewer's per-agent-isolation contract
+            # (round-3 review) holds.
+            locally_failed.append(agent_name)
+            continue
         written.append(agent_name)
-    return written
+    return written, locally_failed
 
 
 def _write_one_agent(

--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -406,7 +406,7 @@ def _write_one_agent(
     (one over successes, one over failures) without an embedded
     write block — keeps that function grade-A under xenon.
     """
-    frontmatter = _frontmatter_for(generator, agent_name)
+    frontmatter = generator.get_agent_frontmatter(agent_name)
     result = SubagentsGenerator.apply_batch_result(
         agent_name=agent_name,
         frontmatter=frontmatter,
@@ -428,6 +428,14 @@ def _lookup_from_state(state: EnhanceState) -> dict[str, str]:
     skip targets it does not handle). The agent-level mapping is
     encoded in the ``custom_id`` itself by convention
     (``"subagent:<agent_name>"``); this helper extracts it back.
+
+    Note: passes an explicit empty fallback dict to
+    :func:`_agent_name_from_custom_id` because Phase 5b only
+    supports the ``subagent:`` id schema. A future phase introducing
+    a new id shape (e.g. ``skill:<name>``) should also extend
+    :data:`BATCH_TARGET_SUBAGENTS` and thread its own lookup table
+    here — silently widening the fallback would route results to
+    the wrong target.
     """
     if state.batch is None:
         return {}
@@ -457,20 +465,6 @@ def _agent_name_from_custom_id(
         name = custom_id[len(prefix) :]
         return name or None
     return fallback_lookup.get(custom_id)
-
-
-def _frontmatter_for(generator: SubagentsGenerator, agent_name: str) -> str:
-    """Re-parse the source agent's frontmatter at fetch time.
-
-    Re-reading the source (rather than persisting frontmatter into
-    the state file) keeps :class:`BatchProgress` schema small and
-    means a frontmatter edit between submit and fetch is picked up
-    automatically. Only the body diverges across runs; frontmatter
-    is structurally fixed.
-    """
-    content = generator._load_agent_content(agent_name)  # noqa: SLF001
-    frontmatter, _ = generator._parse_frontmatter(content)  # noqa: SLF001
-    return frontmatter
 
 
 def _now() -> float:

--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -100,6 +100,34 @@ class ResumeStatus:
 
 
 @dataclass(frozen=True)
+class BatchWaitConfig:
+    """Wait-mode tuning passed to :func:`resume_subagent_batch`.
+
+    Bundles the three parameters that only matter when the user
+    runs ``green enhance --batch --wait``: whether to wait at all,
+    how often to poll, and the deadline. Grouping them drops
+    :func:`resume_subagent_batch`'s parameter count below the
+    ``PLR0913`` threshold and lets call sites that don't care
+    about wait-mode pass the default.
+
+    Attributes:
+        wait: If ``True``, block (with sleeps) until the batch ends
+            or :attr:`wait_timeout_seconds` passes.
+        poll_interval: Seconds between polls in ``wait`` mode.
+            Default 30 s — the API SLA is 24 h so polling more often
+            costs rate-limit budget without buying meaningful
+            latency.
+        wait_timeout_seconds: Maximum total wait. Defaults to
+            ``3600`` (one hour); callers wanting to wait the full
+            24 h SLA pass ``86400``.
+    """
+
+    wait: bool = False
+    poll_interval: float = _DEFAULT_POLL_INTERVAL_SECONDS
+    wait_timeout_seconds: float = 3600.0
+
+
+@dataclass(frozen=True)
 class ResumeOutcome:
     """What :func:`resume_subagent_batch` reports back to the CLI.
 
@@ -172,24 +200,23 @@ async def submit_subagent_batch(
     return BatchSubmitOutcome(submission=submission, agent_count=len(plan))
 
 
-async def resume_subagent_batch(  # noqa: PLR0913 - CLI integration glue
+async def resume_subagent_batch(  # noqa: PLR0913 - see #316
     *,
     orchestrator: AIOrchestrator,
     generator: SubagentsGenerator,
     state: EnhanceState,
     project_path: Path,
     file_writer: FileWriter | None = None,
-    wait: bool = False,
-    poll_interval: float = _DEFAULT_POLL_INTERVAL_SECONDS,
-    wait_timeout_seconds: float = 3600.0,
+    wait_config: BatchWaitConfig | None = None,
 ) -> ResumeOutcome:
     """Resume an in-flight batch: poll, optionally wait, fetch, write.
 
-    ``wait=False`` (default) returns after a single poll: callers
-    re-run ``green enhance --batch`` to pick up later. ``wait=True``
-    enters a sleep-then-poll loop bounded by ``wait_timeout_seconds``
-    — useful in CI scripts where a single command should block until
-    results land. The CLI surfaces both modes as ``--batch`` and
+    ``wait_config=None`` or ``wait_config.wait=False`` returns after
+    a single poll: callers re-run ``green enhance --batch`` to pick
+    up later. ``wait_config.wait=True`` enters a sleep-then-poll
+    loop bounded by ``wait_config.wait_timeout_seconds`` — useful in
+    CI scripts where a single command should block until results
+    land. The CLI surfaces both modes as ``--batch`` and
     ``--batch --wait``.
 
     Detects an expired batch via
@@ -207,16 +234,13 @@ async def resume_subagent_batch(  # noqa: PLR0913 - CLI integration glue
             here on every meaningful state transition.
         file_writer: Optional dry-run-aware writer. ``None`` in
             production; tests inject one.
-        wait: If ``True``, block (with sleeps) until the batch ends
-            or ``wait_timeout_seconds`` passes.
-        poll_interval: Seconds between polls in ``wait`` mode.
-        wait_timeout_seconds: Maximum total wait. Defaults to
-            ``3600`` (one hour); the API SLA is 24 h, so callers
-            who want to wait the full window pass ``86400``.
+        wait_config: Wait-mode tuning. ``None`` defaults to a
+            single-poll non-blocking check.
 
     Returns:
         :class:`ResumeOutcome` describing what happened.
     """
+    config = wait_config or BatchWaitConfig()
     pre_poll = _check_pre_poll(state, project_path)
     if pre_poll is not None:
         return pre_poll
@@ -229,13 +253,10 @@ async def resume_subagent_batch(  # noqa: PLR0913 - CLI integration glue
     poll = await _poll_until_terminal(
         orchestrator=orchestrator,
         batch_id=state.batch.batch_id,
-        wait=wait,
-        poll_interval=poll_interval,
-        wait_timeout_seconds=wait_timeout_seconds,
+        config=config,
     )
     if not poll.is_ended:
-        status = ResumeStatus.TIMED_OUT if wait else ResumeStatus.IN_PROGRESS
-        return ResumeOutcome(status=status, poll=poll)
+        return _non_terminal_outcome(poll, waiting=config.wait)
 
     return await _reconcile_ended_batch(
         orchestrator=orchestrator,
@@ -245,6 +266,17 @@ async def resume_subagent_batch(  # noqa: PLR0913 - CLI integration glue
         file_writer=file_writer,
         poll=poll,
     )
+
+
+def _non_terminal_outcome(poll: BatchPoll, *, waiting: bool) -> ResumeOutcome:
+    """Map a non-ended poll to its CLI-facing outcome.
+
+    Extracted so :func:`resume_subagent_batch` stays grade-A under
+    xenon — the inline ternary plus the surrounding branches tipped
+    it to grade B.
+    """
+    status = ResumeStatus.TIMED_OUT if waiting else ResumeStatus.IN_PROGRESS
+    return ResumeOutcome(status=status, poll=poll)
 
 
 def _check_pre_poll(
@@ -268,7 +300,7 @@ def _check_pre_poll(
     return None
 
 
-async def _reconcile_ended_batch(  # noqa: PLR0913 - dispatch glue
+async def _reconcile_ended_batch(  # noqa: PLR0913 - dispatch glue, see #316
     *,
     orchestrator: AIOrchestrator,
     generator: SubagentsGenerator,
@@ -312,23 +344,29 @@ async def _poll_until_terminal(
     *,
     orchestrator: AIOrchestrator,
     batch_id: str,
-    wait: bool,
-    poll_interval: float,
-    wait_timeout_seconds: float,
+    config: BatchWaitConfig,
 ) -> BatchPoll:
     """Single poll, or sleep-then-poll until ``ended`` or timeout.
 
     Extracted from :func:`resume_subagent_batch` so the wait-mode
     state machine is independently unit-testable. The deadline is
-    computed once at entry so a slow poll roundtrip cannot push the
-    actual wait past ``wait_timeout_seconds``.
+    computed once at entry so the per-iteration `_now()` check
+    bounds the total wait.
+
+    Note: the deadline check fires *before* the next ``poll_batch``
+    call, so a slow API round-trip mid-loop (rate-limit retry,
+    network timeout) is not itself bounded — total wall time can
+    exceed ``config.wait_timeout_seconds`` by one ``poll_batch``
+    RTT. Acceptable for the default 1 h wait window; callers
+    needing strict bounding should drive the deadline at a higher
+    layer (e.g. ``asyncio.wait_for``).
     """
     poll = await orchestrator.poll_batch(batch_id)
-    if not wait or poll.is_ended:
+    if not config.wait or poll.is_ended:
         return poll
-    deadline = _now() + wait_timeout_seconds
+    deadline = _now() + config.wait_timeout_seconds
     while not poll.is_ended and _now() < deadline:
-        await asyncio.sleep(poll_interval)
+        await asyncio.sleep(config.poll_interval)
         poll = await orchestrator.poll_batch(batch_id)
     return poll
 
@@ -399,12 +437,14 @@ def _write_one_agent(
     tool_result: ToolUseResult,
     target_dir: Path,
     file_writer: FileWriter | None,
-) -> str:
-    """Write one agent's tuned content to disk; return its name.
+) -> None:
+    """Write one agent's tuned content to disk.
 
-    Extracted so :func:`_write_results` is a pair of comprehensions
-    (one over successes, one over failures) without an embedded
-    write block — keeps that function grade-A under xenon.
+    Extracted so :func:`_persist_successes` stays focused on the
+    success-iteration loop without an embedded write block. The
+    caller already has ``agent_name`` in scope (it's the loop key),
+    so this function returns nothing rather than echoing it back —
+    avoids the misleading ``-> str`` annotation flagged by review.
     """
     frontmatter = generator.get_agent_frontmatter(agent_name)
     result = SubagentsGenerator.apply_batch_result(
@@ -417,7 +457,6 @@ def _write_one_agent(
         file_writer.write_file(agent_file, result.content)
     else:
         agent_file.write_text(result.content, encoding="utf-8")
-    return agent_name
 
 
 def _lookup_from_state(state: EnhanceState) -> dict[str, str]:

--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -1,0 +1,483 @@
+"""Phase 5b: orchestrate ``green enhance --batch`` over the 5a primitives.
+
+Two callable entry points cover the user-visible flow:
+
+* :func:`submit_subagent_batch` — build per-agent
+  :class:`ToolUseBatchRequest` payloads, submit via
+  :meth:`AIOrchestrator.submit_tool_use_batch`, persist a
+  :class:`BatchProgress` record so a later invocation can resume.
+* :func:`resume_subagent_batch` — read the persisted
+  :class:`BatchProgress`, optionally wait for the batch to end, fetch
+  results, write per-agent files, and clear the in-flight record.
+
+The CLI's ``green enhance --batch`` flag chooses between the two by
+inspecting :meth:`EnhanceState.has_batch`. The two-call pattern is
+documented in :doc:`/plans/architecture/ADR-001-batch-enhance` (D1) —
+keeping the CLI imperative makes a state-file corruption recoverable
+("just re-run") instead of locked.
+
+This module is intentionally CLI-agnostic: it returns dataclass
+verdicts and lets the caller render them. Tests cover the
+orchestration logic against mocked
+:class:`AIOrchestrator`/:class:`SubagentsGenerator`/:class:`EnhanceState`
+without touching the network or the filesystem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from start_green_stay_green.generators.subagents import SubagentsGenerator
+from start_green_stay_green.utils.enhance_state import save_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from start_green_stay_green.ai.batch import BatchPoll
+    from start_green_stay_green.ai.batch import BatchResultsBundle
+    from start_green_stay_green.ai.batch import BatchSubmission
+    from start_green_stay_green.ai.orchestrator import AIOrchestrator
+    from start_green_stay_green.ai.types import ToolUseResult
+    from start_green_stay_green.utils.enhance_state import EnhanceState
+    from start_green_stay_green.utils.file_writer import FileWriter
+
+__all__ = [
+    "BATCH_TARGET_SUBAGENTS",
+    "BatchSubmitOutcome",
+    "ResumeOutcome",
+    "ResumeStatus",
+    "resume_subagent_batch",
+    "submit_subagent_batch",
+]
+
+# Top-level enhance target name that batch mode supports today. Used
+# as the value side of :attr:`BatchProgress.custom_id_map` so Phase 6
+# CLI logic can map every recovered result back to the right
+# ``EnhanceState.completed`` slot.
+BATCH_TARGET_SUBAGENTS = "subagents"
+
+# Default poll interval inside ``--wait`` mode. The Anthropic Batches
+# API publishes a 24 h SLA; polling more often than every 30 s costs
+# rate-limit budget without buying meaningful latency. Tests override
+# via the ``poll_interval`` argument.
+_DEFAULT_POLL_INTERVAL_SECONDS: float = 30.0
+
+
+@dataclass(frozen=True)
+class BatchSubmitOutcome:
+    """What :func:`submit_subagent_batch` reports back to the CLI.
+
+    Attributes:
+        submission: The :class:`BatchSubmission` returned by the
+            Anthropic API. ``submission.batch_id`` is the resume
+            cursor.
+        agent_count: How many agents the batch covered. Identical
+            to ``len(submission.custom_ids)`` but pulled out for
+            readability when rendering CLI status messages.
+    """
+
+    submission: BatchSubmission
+    agent_count: int
+
+
+class ResumeStatus:
+    """Symbolic outcomes from :func:`resume_subagent_batch`.
+
+    Defined as a plain class with class attributes (rather than
+    :class:`enum.Enum`) so callers can compare against bare strings
+    in CLI rendering without importing the enum.
+    """
+
+    NO_BATCH: str = "no-batch"
+    EXPIRED: str = "expired"
+    IN_PROGRESS: str = "in-progress"
+    ENDED: str = "ended"
+    TIMED_OUT: str = "timed-out"
+
+
+@dataclass(frozen=True)
+class ResumeOutcome:
+    """What :func:`resume_subagent_batch` reports back to the CLI.
+
+    Attributes:
+        status: One of the :class:`ResumeStatus` constants. The CLI
+            switches its exit code and rendered message on this.
+        poll: Last :class:`BatchPoll` snapshot — ``None`` only on
+            ``NO_BATCH``.
+        bundle: Per-target results, present iff ``status == ENDED``.
+            ``None`` for every other status.
+        succeeded_agents: Names of agents whose output landed
+            on disk this run. Empty for non-``ENDED`` statuses.
+        failed_agents: Names of agents whose batch entry was
+            ``errored`` / ``canceled`` / ``expired``. Empty for
+            non-``ENDED`` statuses.
+    """
+
+    status: str
+    poll: BatchPoll | None = None
+    bundle: BatchResultsBundle | None = None
+    succeeded_agents: tuple[str, ...] = ()
+    failed_agents: tuple[str, ...] = ()
+
+
+async def submit_subagent_batch(
+    *,
+    orchestrator: AIOrchestrator,
+    generator: SubagentsGenerator,
+    target_context: str,
+    state: EnhanceState,
+    project_path: Path,
+) -> BatchSubmitOutcome:
+    """Submit every required subagent as one Message Batches API call.
+
+    Refuses to submit when an in-flight batch is already recorded —
+    :meth:`EnhanceState.start_batch` raises in that case (see
+    :class:`BatchStateError`); the CLI must call
+    :func:`resume_subagent_batch` first to either pick up or clear the
+    prior batch.
+
+    Args:
+        orchestrator: Configured :class:`AIOrchestrator`.
+        generator: :class:`SubagentsGenerator` that owns the source
+            agents and the :class:`ContentTuner`.
+        target_context: Human-readable description of the target
+            project — flows into every per-agent prompt.
+        state: Loaded :class:`EnhanceState`. Mutated in-place to
+            record the new batch; the caller persists.
+        project_path: Project root, used to write the state file.
+
+    Returns:
+        :class:`BatchSubmitOutcome` with the new batch id and the
+        agent count.
+
+    Raises:
+        GenerationError: If the SDK rejects the submission.
+        BatchStateError: If a batch is already in flight.
+    """
+    plan = generator.build_batch_plan(target_context)
+    submission = await orchestrator.submit_tool_use_batch(
+        [entry.request for entry in plan],
+    )
+    custom_id_map = {entry.custom_id: BATCH_TARGET_SUBAGENTS for entry in plan}
+    state.start_batch(
+        batch_id=submission.batch_id,
+        custom_id_map=custom_id_map,
+        submitted_at=submission.submitted_at,
+    )
+    save_state(project_path, state)
+    return BatchSubmitOutcome(submission=submission, agent_count=len(plan))
+
+
+async def resume_subagent_batch(  # noqa: PLR0913 - CLI integration glue
+    *,
+    orchestrator: AIOrchestrator,
+    generator: SubagentsGenerator,
+    state: EnhanceState,
+    project_path: Path,
+    file_writer: FileWriter | None = None,
+    wait: bool = False,
+    poll_interval: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    wait_timeout_seconds: float = 3600.0,
+) -> ResumeOutcome:
+    """Resume an in-flight batch: poll, optionally wait, fetch, write.
+
+    ``wait=False`` (default) returns after a single poll: callers
+    re-run ``green enhance --batch`` to pick up later. ``wait=True``
+    enters a sleep-then-poll loop bounded by ``wait_timeout_seconds``
+    — useful in CI scripts where a single command should block until
+    results land. The CLI surfaces both modes as ``--batch`` and
+    ``--batch --wait``.
+
+    Detects an expired batch via
+    :meth:`BatchProgress.is_potentially_expired` before polling, so a
+    state file that crossed the 24 h SLA is cleared with a clear
+    message rather than producing an opaque ``404``.
+
+    Args:
+        orchestrator: Configured :class:`AIOrchestrator`.
+        generator: :class:`SubagentsGenerator` (used to rebuild
+            per-agent files via :meth:`apply_batch_result`).
+        state: Loaded :class:`EnhanceState` with an in-flight
+            batch record.
+        project_path: Project root — the state file is updated
+            here on every meaningful state transition.
+        file_writer: Optional dry-run-aware writer. ``None`` in
+            production; tests inject one.
+        wait: If ``True``, block (with sleeps) until the batch ends
+            or ``wait_timeout_seconds`` passes.
+        poll_interval: Seconds between polls in ``wait`` mode.
+        wait_timeout_seconds: Maximum total wait. Defaults to
+            ``3600`` (one hour); the API SLA is 24 h, so callers
+            who want to wait the full window pass ``86400``.
+
+    Returns:
+        :class:`ResumeOutcome` describing what happened.
+    """
+    pre_poll = _check_pre_poll(state, project_path)
+    if pre_poll is not None:
+        return pre_poll
+    # ``_check_pre_poll`` returns ``None`` only when ``state.batch``
+    # exists; the second guard re-narrows the union for mypy without
+    # an ``assert`` (which Bandit B101 flags).
+    if state.batch is None:
+        return ResumeOutcome(status=ResumeStatus.NO_BATCH)
+
+    poll = await _poll_until_terminal(
+        orchestrator=orchestrator,
+        batch_id=state.batch.batch_id,
+        wait=wait,
+        poll_interval=poll_interval,
+        wait_timeout_seconds=wait_timeout_seconds,
+    )
+    if not poll.is_ended:
+        status = ResumeStatus.TIMED_OUT if wait else ResumeStatus.IN_PROGRESS
+        return ResumeOutcome(status=status, poll=poll)
+
+    return await _reconcile_ended_batch(
+        orchestrator=orchestrator,
+        generator=generator,
+        state=state,
+        project_path=project_path,
+        file_writer=file_writer,
+        poll=poll,
+    )
+
+
+def _check_pre_poll(
+    state: EnhanceState,
+    project_path: Path,
+) -> ResumeOutcome | None:
+    """Pre-poll guards: return a final outcome, or ``None`` to keep going.
+
+    Two conditions short-circuit before we even hit the API:
+
+    * No in-flight batch recorded → ``NO_BATCH``.
+    * Recorded batch crossed the 24 h SLA → ``EXPIRED`` (and clear
+      the stale record so the next CLI run falls through to submit).
+    """
+    if not state.has_batch() or state.batch is None:
+        return ResumeOutcome(status=ResumeStatus.NO_BATCH)
+    if state.batch.is_potentially_expired():
+        state.clear_batch()
+        save_state(project_path, state)
+        return ResumeOutcome(status=ResumeStatus.EXPIRED)
+    return None
+
+
+async def _reconcile_ended_batch(  # noqa: PLR0913 - dispatch glue
+    *,
+    orchestrator: AIOrchestrator,
+    generator: SubagentsGenerator,
+    state: EnhanceState,
+    project_path: Path,
+    file_writer: FileWriter | None,
+    poll: BatchPoll,
+) -> ResumeOutcome:
+    """Fetch results, write per-agent files, clear batch, build outcome.
+
+    ``state.batch`` is non-``None`` by caller contract (the resume
+    flow only reaches here after the pre-poll guard returned). The
+    runtime check below is a typed re-narrowing for mypy, not a
+    defensive assertion — calling this with no batch is a
+    programming error, but raising rather than asserting keeps
+    Bandit B101 quiet.
+    """
+    if state.batch is None:
+        msg = "_reconcile_ended_batch called without an in-flight batch"
+        raise RuntimeError(msg)
+    bundle = await orchestrator.fetch_batch_results(state.batch.batch_id)
+    succeeded, failed = _write_results(
+        generator=generator,
+        bundle=bundle,
+        plan_lookup=_lookup_from_state(state),
+        target_dir=project_path / ".claude" / "agents",
+        file_writer=file_writer,
+    )
+    state.clear_batch()
+    save_state(project_path, state)
+    return ResumeOutcome(
+        status=ResumeStatus.ENDED,
+        poll=poll,
+        bundle=bundle,
+        succeeded_agents=tuple(succeeded),
+        failed_agents=tuple(failed),
+    )
+
+
+async def _poll_until_terminal(
+    *,
+    orchestrator: AIOrchestrator,
+    batch_id: str,
+    wait: bool,
+    poll_interval: float,
+    wait_timeout_seconds: float,
+) -> BatchPoll:
+    """Single poll, or sleep-then-poll until ``ended`` or timeout.
+
+    Extracted from :func:`resume_subagent_batch` so the wait-mode
+    state machine is independently unit-testable. The deadline is
+    computed once at entry so a slow poll roundtrip cannot push the
+    actual wait past ``wait_timeout_seconds``.
+    """
+    poll = await orchestrator.poll_batch(batch_id)
+    if not wait or poll.is_ended:
+        return poll
+    deadline = _now() + wait_timeout_seconds
+    while not poll.is_ended and _now() < deadline:
+        await asyncio.sleep(poll_interval)
+        poll = await orchestrator.poll_batch(batch_id)
+    return poll
+
+
+def _write_results(
+    *,
+    generator: SubagentsGenerator,
+    bundle: BatchResultsBundle,
+    plan_lookup: dict[str, str],
+    target_dir: Path,
+    file_writer: FileWriter | None,
+) -> tuple[list[str], list[str]]:
+    """Write each ``successes`` entry to disk; tally failures.
+
+    ``plan_lookup`` is ``custom_id → agent_name`` (extracted from
+    :attr:`BatchProgress.custom_id_map`'s caller-side mirror). The
+    frontmatter is re-loaded from the source files so a state file
+    that survives a code change to the source agents still produces
+    valid output.
+
+    Returns ``(succeeded_agent_names, failed_agent_names)``.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    succeeded = _persist_successes(
+        bundle=bundle,
+        plan_lookup=plan_lookup,
+        generator=generator,
+        target_dir=target_dir,
+        file_writer=file_writer,
+    )
+    failed = [
+        name
+        for custom_id in bundle.failures
+        if (name := _agent_name_from_custom_id(custom_id, plan_lookup)) is not None
+    ]
+    return succeeded, failed
+
+
+def _persist_successes(
+    *,
+    bundle: BatchResultsBundle,
+    plan_lookup: dict[str, str],
+    generator: SubagentsGenerator,
+    target_dir: Path,
+    file_writer: FileWriter | None,
+) -> list[str]:
+    """Write each success to disk; return the agent names in order."""
+    written: list[str] = []
+    for custom_id, tool_result in bundle.successes.items():
+        agent_name = _agent_name_from_custom_id(custom_id, plan_lookup)
+        if agent_name is None:
+            continue
+        _write_one_agent(
+            generator=generator,
+            agent_name=agent_name,
+            tool_result=tool_result,
+            target_dir=target_dir,
+            file_writer=file_writer,
+        )
+        written.append(agent_name)
+    return written
+
+
+def _write_one_agent(
+    *,
+    generator: SubagentsGenerator,
+    agent_name: str,
+    tool_result: ToolUseResult,
+    target_dir: Path,
+    file_writer: FileWriter | None,
+) -> str:
+    """Write one agent's tuned content to disk; return its name.
+
+    Extracted so :func:`_write_results` is a pair of comprehensions
+    (one over successes, one over failures) without an embedded
+    write block — keeps that function grade-A under xenon.
+    """
+    frontmatter = _frontmatter_for(generator, agent_name)
+    result = SubagentsGenerator.apply_batch_result(
+        agent_name=agent_name,
+        frontmatter=frontmatter,
+        tool_result=tool_result,
+    )
+    agent_file = target_dir / f"{agent_name}.md"
+    if file_writer is not None:
+        file_writer.write_file(agent_file, result.content)
+    else:
+        agent_file.write_text(result.content, encoding="utf-8")
+    return agent_name
+
+
+def _lookup_from_state(state: EnhanceState) -> dict[str, str]:
+    """Build a ``custom_id → agent_name`` lookup from the state record.
+
+    Phase 5a's :attr:`BatchProgress.custom_id_map` stores
+    ``custom_id → top-level target`` (so Phase 5b reconciliation can
+    skip targets it does not handle). The agent-level mapping is
+    encoded in the ``custom_id`` itself by convention
+    (``"subagent:<agent_name>"``); this helper extracts it back.
+    """
+    if state.batch is None:
+        return {}
+    lookup: dict[str, str] = {}
+    for custom_id, target in state.batch.custom_id_map.items():
+        if target != BATCH_TARGET_SUBAGENTS:
+            continue
+        agent_name = _agent_name_from_custom_id(custom_id, {})
+        if agent_name is not None:
+            lookup[custom_id] = agent_name
+    return lookup
+
+
+def _agent_name_from_custom_id(
+    custom_id: str,
+    fallback_lookup: dict[str, str],
+) -> str | None:
+    """Return the agent name encoded in a ``subagent:<name>`` custom id.
+
+    Falls back to ``fallback_lookup`` for any unrecognised shape
+    (Phase 6 might introduce alternate id schemas). Returns ``None``
+    when no name is recoverable — the caller drops the entry rather
+    than mis-routing a result.
+    """
+    prefix = "subagent:"
+    if custom_id.startswith(prefix):
+        name = custom_id[len(prefix) :]
+        return name or None
+    return fallback_lookup.get(custom_id)
+
+
+def _frontmatter_for(generator: SubagentsGenerator, agent_name: str) -> str:
+    """Re-parse the source agent's frontmatter at fetch time.
+
+    Re-reading the source (rather than persisting frontmatter into
+    the state file) keeps :class:`BatchProgress` schema small and
+    means a frontmatter edit between submit and fetch is picked up
+    automatically. Only the body diverges across runs; frontmatter
+    is structurally fixed.
+    """
+    content = generator._load_agent_content(agent_name)  # noqa: SLF001
+    frontmatter, _ = generator._parse_frontmatter(content)  # noqa: SLF001
+    return frontmatter
+
+
+def _now() -> float:
+    """Wall-clock seconds — wrapper so tests can monkey-patch.
+
+    Uses :func:`datetime.now(UTC).timestamp()` rather than
+    :func:`time.time` so the same source-of-truth backs every wait
+    decision; reduces clock-source surprises during tests.
+    """
+    return datetime.now(UTC).timestamp()

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -33,6 +33,10 @@ from rich.console import Console
 from rich.panel import Panel
 import typer
 
+from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
+from start_green_stay_green.ai.batch_dispatch import ResumeStatus
+from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
+from start_green_stay_green.ai.batch_dispatch import submit_subagent_batch
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.generators.architecture import (
@@ -2397,6 +2401,204 @@ def _validate_enhance_path(project_path: Path) -> None:
         raise typer.Exit(code=1)
 
 
+_BATCH_SUPPORTED_TARGETS: frozenset[str] = frozenset({"subagents"})
+
+
+def _validate_batch_targets(selected_targets: tuple[str, ...]) -> None:
+    """Reject ``--batch`` when targets it cannot handle are selected.
+
+    Phase 5b only batches subagents (every other target uses a free-
+    text generation path that the Batches API does not yet wrap).
+    Failing fast here — rather than letting the dispatch silently
+    skip claude-md — keeps the user model honest: ``--batch`` either
+    runs the whole selection through the API once, or it errors.
+    """
+    unsupported = tuple(
+        t for t in selected_targets if t not in _BATCH_SUPPORTED_TARGETS
+    )
+    if not unsupported:
+        return
+    supported = ", ".join(sorted(_BATCH_SUPPORTED_TARGETS))
+    msg = (
+        f"[red]Error:[/red] --batch does not support targets "
+        f"{', '.join(unsupported)} (Phase 5a primitives only cover "
+        f"tool_use tunings — sync mode handles the rest). Re-run "
+        f"with --targets {supported} to use batch mode, or drop "
+        f"--batch to keep the sync flow."
+    )
+    console.print(msg)
+    raise typer.Exit(code=1)
+
+
+def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue
+    *,
+    project_path: Path,
+    project_name: str,
+    language: str,
+    orchestrator: AIOrchestrator,
+    file_writer: FileWriter,
+    dry_run: bool,
+    wait: bool,
+) -> None:
+    """Submit-or-resume the subagent batch path.
+
+    Branches on ``state.has_batch()``: if a batch is already
+    in flight (recorded by a prior ``--batch`` invocation), this run
+    polls / fetches; otherwise it builds the per-agent batch plan and
+    submits. ``dry_run`` short-circuits before any API call.
+    """
+    if dry_run:
+        console.print(
+            "[dim]--dry-run with --batch: nothing submitted, "
+            "no state file written.[/dim]"
+        )
+        return
+
+    state = load_state(project_path)
+    if state.has_batch():
+        _resume_subagent_batch_cli(
+            project_path=project_path,
+            orchestrator=orchestrator,
+            state=state,
+            file_writer=file_writer,
+            wait=wait,
+        )
+        return
+    _submit_subagent_batch_cli(
+        project_path=project_path,
+        project_name=project_name,
+        language=language,
+        orchestrator=orchestrator,
+        state=state,
+    )
+
+
+def _submit_subagent_batch_cli(
+    *,
+    project_path: Path,
+    project_name: str,
+    language: str,
+    orchestrator: AIOrchestrator,
+    state: EnhanceState,
+) -> None:
+    """Build the subagent batch plan, submit, and persist."""
+    target_context = (
+        f"Project: {project_name}, "
+        f"Language: {language}, "
+        f"Type: existing project being re-tuned via `green enhance --batch`"
+    )
+    generator = SubagentsGenerator(orchestrator)
+    outcome = run_async(
+        _run_with_orchestrator_close(
+            orchestrator,
+            submit_subagent_batch(
+                orchestrator=orchestrator,
+                generator=generator,
+                target_context=target_context,
+                state=state,
+                project_path=project_path,
+            ),
+        )
+    )
+    console.print(
+        f"[green]✓[/green] Submitted batch [bold]"
+        f"{outcome.submission.batch_id}[/bold] covering "
+        f"{outcome.agent_count} subagent(s). Re-run "
+        f"`green enhance --batch` to fetch results, or pass "
+        f"--wait to block in-process."
+    )
+
+
+def _resume_subagent_batch_cli(
+    *,
+    project_path: Path,
+    orchestrator: AIOrchestrator,
+    state: EnhanceState,
+    file_writer: FileWriter,
+    wait: bool,
+) -> None:
+    """Poll an in-flight batch; on ``ended``, fetch and write."""
+    generator = SubagentsGenerator(orchestrator)
+    outcome = run_async(
+        _run_with_orchestrator_close(
+            orchestrator,
+            resume_subagent_batch(
+                orchestrator=orchestrator,
+                generator=generator,
+                state=state,
+                project_path=project_path,
+                file_writer=file_writer,
+                wait=wait,
+            ),
+        )
+    )
+    _render_batch_resume_outcome(outcome)
+
+
+_BATCH_OUTCOME_STATIC: dict[str, str] = {
+    ResumeStatus.NO_BATCH: (
+        "[yellow]No batch is in flight; nothing to resume.[/yellow]"
+    ),
+    ResumeStatus.EXPIRED: (
+        "[yellow]Previous batch crossed the 24 h SLA and was cleared. "
+        "Re-run `green enhance --batch` to submit a fresh batch.[/yellow]"
+    ),
+    ResumeStatus.TIMED_OUT: (
+        "[yellow]--wait timed out before the batch ended. "
+        "Re-run `green enhance --batch` to pick up later.[/yellow]"
+    ),
+}
+
+
+def _render_batch_resume_outcome(outcome: ResumeOutcome) -> None:
+    """Translate a :class:`ResumeOutcome` into a CLI message.
+
+    Static-message statuses (``NO_BATCH``, ``EXPIRED``, ``TIMED_OUT``)
+    are rendered from the lookup table above. ``IN_PROGRESS`` and
+    ``ENDED`` need ``outcome.poll`` / ``outcome.bundle`` data woven
+    in, so they branch into dedicated helpers. Splitting on these
+    lines keeps the dispatcher itself grade-A under xenon.
+    """
+    static = _BATCH_OUTCOME_STATIC.get(outcome.status)
+    if static is not None:
+        console.print(static)
+        return
+    if outcome.status == ResumeStatus.IN_PROGRESS:
+        _render_batch_in_progress(outcome)
+        return
+    _render_batch_ended(outcome)
+
+
+def _render_batch_in_progress(outcome: ResumeOutcome) -> None:
+    """Render the ``IN_PROGRESS`` status line with poll counts."""
+    poll = outcome.poll
+    if poll is None:
+        return
+    console.print(
+        f"[dim]Batch {poll.batch_id}: still running "
+        f"({poll.processing_count} processing, "
+        f"{poll.succeeded_count} succeeded, "
+        f"{poll.errored_count} errored). Re-run later, or "
+        f"pass --wait to block.[/dim]"
+    )
+
+
+def _render_batch_ended(outcome: ResumeOutcome) -> None:
+    """Render the ``ENDED`` summary plus a failed-agents follow-up."""
+    console.print(
+        f"[green]✓[/green] Batch reconciled: "
+        f"{len(outcome.succeeded_agents)} agent(s) written, "
+        f"{len(outcome.failed_agents)} failed."
+    )
+    if outcome.failed_agents:
+        joined = ", ".join(outcome.failed_agents)
+        console.print(
+            f"[red]Failed agents:[/red] {joined}. Re-run "
+            f"`green enhance --batch` (the failed entries will be "
+            f"included in the next submission)."
+        )
+
+
 @app.command()
 def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
     project_path: Annotated[
@@ -2484,6 +2686,31 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
             help="Overwrite files without prompting. Off by default.",
         ),
     ] = False,
+    batch: Annotated[
+        bool,
+        typer.Option(
+            "--batch",
+            help=(
+                "Submit subagent tunings via the Anthropic Message "
+                "Batches API (50% cheaper, ≤24 h SLA). Use with "
+                "``--targets subagents``. The first run submits and "
+                "exits; re-run to fetch results, or pass ``--wait`` "
+                "to block until done. See ADR-001 for the rationale."
+            ),
+        ),
+    ] = False,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            help=(
+                "When used with ``--batch``: block in-process polling "
+                "every 30 s until the batch ends or the timeout is "
+                "reached. Default off (two-call submit-then-resume "
+                "pattern is friendlier for CI)."
+            ),
+        ),
+    ] = False,
 ) -> None:
     r"""Re-run Pass 2 (AI tuning) on an existing green-init project.
 
@@ -2512,6 +2739,11 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         api_key: Optional Claude API key.
         no_interactive: Disable interactive prompts.
         force: Overwrite files without prompting.
+        batch: Submit subagent tunings via the Anthropic Message
+            Batches API. Submit-then-resume two-call flow; pair
+            with ``--wait`` for in-process polling.
+        wait: Block in-process when ``--batch`` is set; polls every
+            30 s until the batch ends or the timeout elapses.
 
     Raises:
         typer.Exit: If the path is invalid, project metadata cannot
@@ -2528,6 +2760,11 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
     )
 
     selected_targets = _resolve_enhance_targets(targets)
+    if batch:
+        _validate_batch_targets(selected_targets)
+    if wait and not batch:
+        console.print("[red]Error:[/red] --wait only applies in --batch mode.")
+        raise typer.Exit(code=1)
     orchestrator = _require_enhance_orchestrator(api_key, no_interactive=no_interactive)
     file_writer = FileWriter(
         project_root=project_path,
@@ -2535,6 +2772,18 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         interactive=False,
         console=console,
     )
+
+    if batch:
+        _run_enhance_batch(
+            project_path=project_path,
+            project_name=resolved_name,
+            language=resolved_language,
+            orchestrator=orchestrator,
+            file_writer=file_writer,
+            dry_run=dry_run,
+            wait=wait,
+        )
+        return
 
     _run_enhance_pipeline(
         project_path=project_path,

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -33,6 +33,7 @@ from rich.console import Console
 from rich.panel import Panel
 import typer
 
+from start_green_stay_green.ai.batch_dispatch import BatchWaitConfig
 from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
 from start_green_stay_green.ai.batch_dispatch import ResumeStatus
 from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
@@ -2430,7 +2431,7 @@ def _validate_batch_targets(selected_targets: tuple[str, ...]) -> None:
     raise typer.Exit(code=1)
 
 
-def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue
+def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
     *,
     project_path: Path,
     project_name: str,
@@ -2537,7 +2538,7 @@ def _resume_subagent_batch_cli(
                 state=state,
                 project_path=project_path,
                 file_writer=file_writer,
-                wait=wait,
+                wait_config=BatchWaitConfig(wait=wait),
             ),
         )
     )
@@ -2581,7 +2582,16 @@ def _render_batch_resume_outcome(outcome: ResumeOutcome) -> None:
     if outcome.status == ResumeStatus.IN_PROGRESS:
         _render_batch_in_progress(outcome)
         return
-    _render_batch_ended(outcome)
+    if outcome.status == ResumeStatus.ENDED:
+        _render_batch_ended(outcome)
+        return
+    # Defensive guard: a future ``ResumeStatus`` constant added
+    # without updating this dispatcher would otherwise silently
+    # render the ENDED message — which prints "0 written, 0 failed"
+    # for a status that means something else entirely. Fail loudly
+    # at the source instead.
+    msg = f"Unhandled batch resume status: {outcome.status!r}"
+    raise ValueError(msg)
 
 
 def _render_batch_in_progress(outcome: ResumeOutcome) -> None:

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -2455,22 +2455,31 @@ def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue
         return
 
     state = load_state(project_path)
-    if state.has_batch():
-        _resume_subagent_batch_cli(
+    try:
+        if state.has_batch():
+            _resume_subagent_batch_cli(
+                project_path=project_path,
+                orchestrator=orchestrator,
+                state=state,
+                file_writer=file_writer,
+                wait=wait,
+            )
+            return
+        _submit_subagent_batch_cli(
             project_path=project_path,
+            project_name=project_name,
+            language=language,
             orchestrator=orchestrator,
             state=state,
-            file_writer=file_writer,
-            wait=wait,
         )
-        return
-    _submit_subagent_batch_cli(
-        project_path=project_path,
-        project_name=project_name,
-        language=language,
-        orchestrator=orchestrator,
-        state=state,
-    )
+    except AIGenerationError as ai_err:
+        # Unlike the ``green init`` Pass 2 flow (which downgrades AI
+        # failures to warnings + offline scaffold), the user
+        # explicitly opted into batch mode here — there is no
+        # silent fallback. Surface the API error and exit non-zero
+        # so the user can re-run when ready.
+        console.print(f"[red]Error:[/red] Batch API call failed: {ai_err}")
+        raise typer.Exit(code=1) from ai_err
 
 
 def _submit_subagent_batch_cli(
@@ -2535,6 +2544,12 @@ def _resume_subagent_batch_cli(
     _render_batch_resume_outcome(outcome)
 
 
+# Static-message statuses for :func:`_render_batch_resume_outcome`.
+# IN_PROGRESS and ENDED are deliberately absent — they need
+# ``outcome.poll`` / ``outcome.bundle`` data woven into the rendered
+# message, so they branch into ``_render_batch_in_progress`` /
+# ``_render_batch_ended`` instead. Adding them to this dict would
+# silently drop their dynamic data.
 _BATCH_OUTCOME_STATIC: dict[str, str] = {
     ResumeStatus.NO_BATCH: (
         "[yellow]No batch is in flight; nothing to resume.[/yellow]"

--- a/start_green_stay_green/generators/subagents.py
+++ b/start_green_stay_green/generators/subagents.py
@@ -416,6 +416,36 @@ class SubagentsGenerator(BaseGenerator):
             changes=tuning_result.changes,
         )
 
+    def get_agent_frontmatter(self, agent_name: str) -> str:
+        """Re-read the source agent's YAML frontmatter at fetch time.
+
+        Public sibling of :meth:`apply_batch_result` for the Phase 5b
+        batch resume path. The dispatch in
+        :mod:`start_green_stay_green.ai.batch_dispatch` calls this
+        rather than reaching into the private ``_load_agent_content``
+        / ``_parse_frontmatter`` helpers — the frontmatter capture is
+        intentionally re-read (not persisted in the state file) so a
+        local edit to the source agent between submit and fetch is
+        picked up automatically.
+
+        Args:
+            agent_name: Name of the agent (must be a
+                :data:`REQUIRED_AGENTS` key).
+
+        Returns:
+            The YAML frontmatter block, terminating delimiter
+            included — ready to prepend to a tuned body.
+
+        Raises:
+            FileNotFoundError: If the source agent file is missing
+                (raised by :meth:`_load_agent_content`).
+            ValueError: If the source file lacks a frontmatter block
+                (raised by :meth:`_parse_frontmatter`).
+        """
+        content = self._load_agent_content(agent_name)
+        frontmatter, _ = self._parse_frontmatter(content)
+        return frontmatter
+
     def generate(self) -> dict[str, Any]:
         """Generate subagents synchronously (not supported).
 

--- a/start_green_stay_green/generators/subagents.py
+++ b/start_green_stay_green/generators/subagents.py
@@ -21,7 +21,9 @@ from start_green_stay_green.generators.base import BaseGenerator
 DEFAULT_MAX_CONCURRENCY = 8
 
 if TYPE_CHECKING:
+    from start_green_stay_green.ai.batch import ToolUseBatchRequest
     from start_green_stay_green.ai.orchestrator import AIOrchestrator
+    from start_green_stay_green.ai.types import ToolUseResult
 
 
 # Default reference directory (can be overridden)
@@ -63,6 +65,35 @@ class SubagentGenerationResult:
     content: str
     tuned: bool
     changes: list[str]
+
+
+@dataclass(frozen=True)
+class SubagentBatchEntry:
+    """One per-agent slot in a Phase 5b batch submission.
+
+    Lets the submit and resume halves of ``green enhance --batch``
+    travel through the orchestrator with everything they need: the
+    Anthropic-side request payload, the agent name (so the result
+    file knows where to land), and the original YAML frontmatter
+    (so :meth:`SubagentsGenerator.apply_batch_result` can rebuild
+    the full agent file once results arrive).
+
+    Attributes:
+        agent_name: Logical name (e.g. ``"chief-architect"``).
+        custom_id: Anthropic ``custom_id`` for this request — by
+            convention ``"subagent:<agent_name>"``. Echoes back in
+            :attr:`BatchResultsBundle.successes` keyed by this id.
+        frontmatter: YAML frontmatter parsed off the source agent
+            file, captured here so it can be re-prepended to the
+            tuned body when the batch result arrives.
+        request: :class:`ToolUseBatchRequest` ready for
+            :meth:`AIOrchestrator.submit_tool_use_batch`.
+    """
+
+    agent_name: str
+    custom_id: str
+    frontmatter: str
+    request: ToolUseBatchRequest
 
 
 class SubagentsGenerator(BaseGenerator):
@@ -303,6 +334,87 @@ class SubagentsGenerator(BaseGenerator):
             *(_run_one(name) for name in agent_names),
         )
         return dict(zip(agent_names, results_list, strict=True))
+
+    def build_batch_plan(
+        self,
+        target_context: str,
+    ) -> list[SubagentBatchEntry]:
+        """Render every required subagent as a per-call batch request.
+
+        The Phase 5b ``green enhance --batch`` flow submits all
+        subagents in one Anthropic Message Batches API call. This
+        helper does the per-agent prep — load source content, parse
+        out the YAML frontmatter, build a
+        :class:`ToolUseBatchRequest` via the tuner — and returns one
+        entry per agent. The frontmatter is captured alongside each
+        request so :meth:`apply_batch_result` can reconstruct the
+        full agent file once the batch returns.
+
+        Args:
+            target_context: Description of target project context.
+
+        Returns:
+            List of :class:`SubagentBatchEntry` records, in the order
+            declared in :data:`REQUIRED_AGENTS`.
+        """
+        plan: list[SubagentBatchEntry] = []
+        for agent_name in REQUIRED_AGENTS:
+            content = self._load_agent_content(agent_name)
+            frontmatter, body = self._parse_frontmatter(content)
+            request = self.tuner.build_batch_request(
+                custom_id=f"subagent:{agent_name}",
+                source_content=body,
+                source_context=SOURCE_AGENT_CONTEXT,
+                target_context=target_context,
+                preserve_sections=[
+                    "## Identity",
+                    "## Scope",
+                    "## Workflow",
+                    "## Skills",
+                    "## Constraints",
+                ],
+            )
+            plan.append(
+                SubagentBatchEntry(
+                    agent_name=agent_name,
+                    custom_id=request.custom_id,
+                    frontmatter=frontmatter,
+                    request=request,
+                )
+            )
+        return plan
+
+    @staticmethod
+    def apply_batch_result(
+        agent_name: str,
+        frontmatter: str,
+        tool_result: ToolUseResult,
+    ) -> SubagentGenerationResult:
+        """Reconstruct a finished subagent file from a batch result.
+
+        Lifts the ``tool_use`` payload via
+        :meth:`ContentTuner.parse_batch_tuning_result` (same parser
+        the sync path uses) and re-attaches the original frontmatter
+        so the resulting file is byte-equivalent to what
+        :meth:`generate_agent` would have produced.
+
+        Args:
+            agent_name: Name of the agent the result is for.
+            frontmatter: YAML frontmatter captured by
+                :meth:`build_batch_plan`.
+            tool_result: One entry from
+                :attr:`BatchResultsBundle.successes`.
+
+        Returns:
+            :class:`SubagentGenerationResult` ready to write to disk.
+        """
+        tuning_result = ContentTuner.parse_batch_tuning_result(tool_result)
+        return SubagentGenerationResult(
+            agent_name=agent_name,
+            content=f"{frontmatter}\n{tuning_result.content}",
+            tuned=True,
+            changes=tuning_result.changes,
+        )
 
     def generate(self) -> dict[str, Any]:
         """Generate subagents synchronously (not supported).

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -24,9 +24,11 @@ from start_green_stay_green.ai.batch import BatchSubmission
 from start_green_stay_green.ai.batch import ToolUseBatchRequest
 from start_green_stay_green.ai.batch_dispatch import BATCH_TARGET_SUBAGENTS
 from start_green_stay_green.ai.batch_dispatch import BatchSubmitOutcome
+from start_green_stay_green.ai.batch_dispatch import BatchWaitConfig
 from start_green_stay_green.ai.batch_dispatch import ResumeStatus
 from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
 from start_green_stay_green.ai.batch_dispatch import submit_subagent_batch
+from start_green_stay_green.ai.types import GenerationError
 from start_green_stay_green.ai.types import TokenUsage
 from start_green_stay_green.ai.types import ToolUseResult
 from start_green_stay_green.generators.subagents import SubagentBatchEntry
@@ -394,9 +396,11 @@ class TestResumeSubagentBatchWaitMode:
             generator=_fake_generator(),
             state=state,
             project_path=tmp_path,
-            wait=True,
-            poll_interval=0.0,  # tight loop for test speed
-            wait_timeout_seconds=10.0,
+            wait_config=BatchWaitConfig(
+                wait=True,
+                poll_interval=0.0,  # tight loop for test speed
+                wait_timeout_seconds=10.0,
+            ),
         )
 
         assert outcome.status == ResumeStatus.ENDED
@@ -430,12 +434,77 @@ class TestResumeSubagentBatchWaitMode:
             generator=_fake_generator(),
             state=state,
             project_path=tmp_path,
-            wait=True,
-            poll_interval=0.0,
-            wait_timeout_seconds=-1.0,  # already past deadline → exit after one poll
+            wait_config=BatchWaitConfig(
+                wait=True,
+                poll_interval=0.0,
+                wait_timeout_seconds=-1.0,  # already past → exit after one poll
+            ),
         )
 
         assert outcome.status == ResumeStatus.TIMED_OUT
         orchestrator.fetch_batch_results.assert_not_awaited()
         # State retains the in-flight batch so a future run can resume.
         assert state.has_batch()
+
+
+class TestResumeSubagentBatchErrorPropagation:
+    """Resume path: SDK errors mid-wait must preserve in-flight state."""
+
+    @pytest.mark.asyncio
+    async def test_poll_raises_mid_wait_loop_preserves_state(
+        self, tmp_path: Path
+    ) -> None:
+        """Round-2 review observation: an SDK error mid-wait must NOT
+        clear the in-flight batch — a re-run needs the ``batch_id``.
+
+        Pins the contract that ``state.clear_batch`` only fires after
+        a successful ``ENDED`` reconciliation, never before.
+        """
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+        orchestrator = MagicMock()
+        # First poll succeeds (in-progress); second raises.
+        orchestrator.poll_batch = AsyncMock(
+            side_effect=[
+                BatchPoll(
+                    batch_id="msgbatch_42",
+                    status="in_progress",
+                    processing_count=1,
+                    succeeded_count=0,
+                    errored_count=0,
+                ),
+                GenerationError("simulated rate-limit during poll"),
+            ]
+        )
+        orchestrator.fetch_batch_results = AsyncMock()
+
+        with pytest.raises(GenerationError, match="rate-limit"):
+            await resume_subagent_batch(
+                orchestrator=orchestrator,
+                generator=_fake_generator(),
+                state=state,
+                project_path=tmp_path,
+                wait_config=BatchWaitConfig(
+                    wait=True,
+                    poll_interval=0.0,
+                    wait_timeout_seconds=10.0,
+                ),
+            )
+
+        # Critical: in-memory in-flight record survives so a future
+        # call (after the user fixes their API issue and re-runs) can
+        # resume. We do NOT assert on-disk state here — the contract
+        # is that ``save_state`` only fires on a *successful* status
+        # transition (EXPIRED clear, or ENDED reconciliation), so the
+        # raised path leaves the disk untouched. That's the desired
+        # behaviour: the original submit path's persisted state is
+        # still on disk from when the batch was first submitted.
+        assert state.has_batch()
+        assert state.batch is not None
+        assert state.batch.batch_id == "msgbatch_42"
+        # Did NOT fetch — the second poll never returned ``ended``.
+        orchestrator.fetch_batch_results.assert_not_awaited()

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -80,11 +80,9 @@ def _fake_generator() -> MagicMock:
     ]
     # The dispatch re-reads frontmatter at fetch time via the
     # private helpers (see ``_frontmatter_for``).
-    gen._load_agent_content.side_effect = lambda name: (f"---\nname: {name}\n---\nbody")
-    gen._parse_frontmatter.side_effect = lambda content: (
-        content.split("\n---\n", 1)[0] + "\n---",
-        "body",
-    )
+    # Phase 5b post-feedback: dispatch reads frontmatter through the
+    # public ``get_agent_frontmatter`` (no more SLF001 suppressions).
+    gen.get_agent_frontmatter.side_effect = lambda name: f"---\nname: {name}\n---"
     return gen
 
 

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -1,0 +1,443 @@
+"""Unit tests for the Phase 5b batch dispatch orchestration.
+
+These tests exercise the submit / resume orchestration in
+``ai/batch_dispatch.py`` against mocked
+:class:`AIOrchestrator` and :class:`SubagentsGenerator` doubles —
+no network, no filesystem (apart from ``tmp_path``). Real CLI
+plumbing (typer flags, console rendering) is covered separately in
+``tests/test_cli_mocked.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from start_green_stay_green.ai.batch import BatchError
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.batch_dispatch import BATCH_TARGET_SUBAGENTS
+from start_green_stay_green.ai.batch_dispatch import BatchSubmitOutcome
+from start_green_stay_green.ai.batch_dispatch import ResumeStatus
+from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
+from start_green_stay_green.ai.batch_dispatch import submit_subagent_batch
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
+from start_green_stay_green.generators.subagents import SubagentBatchEntry
+from start_green_stay_green.generators.subagents import SubagentsGenerator
+from start_green_stay_green.utils.enhance_state import BatchProgress
+from start_green_stay_green.utils.enhance_state import EnhanceState
+from start_green_stay_green.utils.enhance_state import load_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _entry(agent_name: str, custom_id: str | None = None) -> SubagentBatchEntry:
+    """Tiny factory — keeps each test's setup short and readable."""
+    return SubagentBatchEntry(
+        agent_name=agent_name,
+        custom_id=custom_id or f"subagent:{agent_name}",
+        frontmatter=f"---\nname: {agent_name}\n---",
+        request=ToolUseBatchRequest(
+            custom_id=custom_id or f"subagent:{agent_name}",
+            prompt="body",
+            system_blocks=[{"type": "text", "text": "S"}],
+            tool_schema={"name": "report_tuning", "input_schema": {}},
+        ),
+    )
+
+
+def _success(_agent_name: str, content: str = "tuned body") -> ToolUseResult:
+    """SDK-shaped tool-use payload for one successful agent tune.
+
+    ``_agent_name`` is unused at the moment but kept on the signature
+    so call sites read like the production code (``_success("alpha")``)
+    rather than positional ``content``-only — easier to update if the
+    factory grows agent-specific fields later.
+    """
+    return ToolUseResult(
+        tool_name="report_tuning",
+        tool_input={"tuned_content": content, "changes": ["adapted"]},
+        token_usage=TokenUsage(input_tokens=100, output_tokens=50),
+        model="claude",
+        message_id="msg_abc",
+    )
+
+
+def _fake_generator() -> MagicMock:
+    """A ``SubagentsGenerator`` double with the methods the dispatch needs."""
+    gen = MagicMock(spec=SubagentsGenerator)
+    gen.build_batch_plan.return_value = [
+        _entry("alpha"),
+        _entry("beta"),
+    ]
+    # The dispatch re-reads frontmatter at fetch time via the
+    # private helpers (see ``_frontmatter_for``).
+    gen._load_agent_content.side_effect = lambda name: (f"---\nname: {name}\n---\nbody")
+    gen._parse_frontmatter.side_effect = lambda content: (
+        content.split("\n---\n", 1)[0] + "\n---",
+        "body",
+    )
+    return gen
+
+
+class TestSubmitSubagentBatch:
+    """Submit path: build plan → submit → persist state."""
+
+    @pytest.mark.asyncio
+    async def test_submits_one_request_per_planned_agent(self, tmp_path: Path) -> None:
+        orchestrator = MagicMock()
+        orchestrator.submit_tool_use_batch = AsyncMock(
+            return_value=BatchSubmission(
+                batch_id="msgbatch_42",
+                custom_ids=["subagent:alpha", "subagent:beta"],
+                submitted_at="2026-05-09T22:00:00+00:00",
+            )
+        )
+        generator = _fake_generator()
+        state = EnhanceState()
+
+        outcome = await submit_subagent_batch(
+            orchestrator=orchestrator,
+            generator=generator,
+            target_context="Test project",
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert isinstance(outcome, BatchSubmitOutcome)
+        assert outcome.agent_count == 2
+        assert outcome.submission.batch_id == "msgbatch_42"
+        # The orchestrator received the entry's request payload, in order.
+        sent = orchestrator.submit_tool_use_batch.await_args.args[0]
+        assert [r.custom_id for r in sent] == [
+            "subagent:alpha",
+            "subagent:beta",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_persists_state_with_custom_id_map_pointing_at_subagents(
+        self, tmp_path: Path
+    ) -> None:
+        """Phase 5a contract: ``custom_id_map[custom_id] == "subagents"``."""
+        orchestrator = MagicMock()
+        orchestrator.submit_tool_use_batch = AsyncMock(
+            return_value=BatchSubmission(
+                batch_id="msgbatch_42",
+                custom_ids=["subagent:alpha", "subagent:beta"],
+                submitted_at="2026-05-09T22:00:00+00:00",
+            )
+        )
+        state = EnhanceState()
+
+        await submit_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            target_context="Test project",
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert state.has_batch()
+        assert state.batch is not None
+        assert state.batch.batch_id == "msgbatch_42"
+        assert state.batch.custom_id_map == {
+            "subagent:alpha": BATCH_TARGET_SUBAGENTS,
+            "subagent:beta": BATCH_TARGET_SUBAGENTS,
+        }
+
+        # The state file was actually written so a re-run can resume.
+        on_disk = load_state(tmp_path)
+        assert on_disk.has_batch()
+        assert on_disk.batch is not None
+        assert on_disk.batch.batch_id == "msgbatch_42"
+
+
+class TestResumeSubagentBatchNoOp:
+    """Resume path: degenerate cases — no batch, expired batch."""
+
+    @pytest.mark.asyncio
+    async def test_returns_no_batch_when_state_is_empty(self, tmp_path: Path) -> None:
+        orchestrator = MagicMock()
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=EnhanceState(),
+            project_path=tmp_path,
+        )
+        assert outcome.status == ResumeStatus.NO_BATCH
+        # Did NOT call the SDK — no in-flight batch to poll.
+        assert not orchestrator.method_calls
+
+    @pytest.mark.asyncio
+    async def test_clears_expired_batch_and_persists(self, tmp_path: Path) -> None:
+        """A 25 h-old batch is cleared without touching the API."""
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_old",
+            submitted_at="2026-05-08T00:00:00+00:00",  # ~24 h ago
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+
+        # Force ``is_potentially_expired`` to return True by patching
+        # the BatchProgress instance method.
+        with patch.object(BatchProgress, "is_potentially_expired", return_value=True):
+            orchestrator = MagicMock()
+            outcome = await resume_subagent_batch(
+                orchestrator=orchestrator,
+                generator=_fake_generator(),
+                state=state,
+                project_path=tmp_path,
+            )
+
+        assert outcome.status == ResumeStatus.EXPIRED
+        assert state.batch is None  # cleared
+        assert not load_state(tmp_path).has_batch()
+        # No SDK calls — expiry check beats the poll.
+        assert not orchestrator.method_calls
+
+
+class TestResumeSubagentBatchInProgress:
+    """Resume path: batch still running."""
+
+    @pytest.mark.asyncio
+    async def test_returns_in_progress_without_fetching(self, tmp_path: Path) -> None:
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="in_progress",
+                processing_count=1,
+                succeeded_count=0,
+                errored_count=0,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock()
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert outcome.status == ResumeStatus.IN_PROGRESS
+        assert outcome.poll is not None
+        assert outcome.poll.processing_count == 1
+        # Did NOT fetch — fetch only fires on ``ended``.
+        orchestrator.fetch_batch_results.assert_not_awaited()
+        # State retains the in-flight batch so a later run can resume.
+        assert state.has_batch()
+
+
+class TestResumeSubagentBatchEnded:
+    """Resume path: batch ``ended`` → fetch + write + clear."""
+
+    @pytest.mark.asyncio
+    async def test_writes_per_agent_files_and_clears_state(
+        self, tmp_path: Path
+    ) -> None:
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={
+                "subagent:alpha": BATCH_TARGET_SUBAGENTS,
+                "subagent:beta": BATCH_TARGET_SUBAGENTS,
+            },
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="ended",
+                processing_count=0,
+                succeeded_count=2,
+                errored_count=0,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock(
+            return_value=BatchResultsBundle(
+                successes={
+                    "subagent:alpha": _success("alpha", "alpha tuned"),
+                    "subagent:beta": _success("beta", "beta tuned"),
+                },
+                failures={},
+            )
+        )
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert outcome.status == ResumeStatus.ENDED
+        assert outcome.succeeded_agents == ("alpha", "beta")
+        assert outcome.failed_agents == ()
+        # Files written.
+        agents_dir = tmp_path / ".claude" / "agents"
+        assert (agents_dir / "alpha.md").read_text(encoding="utf-8")
+        assert "alpha tuned" in (agents_dir / "alpha.md").read_text(encoding="utf-8")
+        # Batch cleared from state and from disk.
+        assert not state.has_batch()
+        assert not load_state(tmp_path).has_batch()
+
+    @pytest.mark.asyncio
+    async def test_partitions_failures_separately(self, tmp_path: Path) -> None:
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={
+                "subagent:alpha": BATCH_TARGET_SUBAGENTS,
+                "subagent:beta": BATCH_TARGET_SUBAGENTS,
+            },
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="ended",
+                processing_count=0,
+                succeeded_count=1,
+                errored_count=1,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock(
+            return_value=BatchResultsBundle(
+                successes={"subagent:alpha": _success("alpha")},
+                failures={
+                    "subagent:beta": BatchError(
+                        custom_id="subagent:beta",
+                        result_type="errored",
+                        message="upstream",
+                    )
+                },
+            )
+        )
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert outcome.succeeded_agents == ("alpha",)
+        assert outcome.failed_agents == ("beta",)
+        # Only the succeeded agent's file is written.
+        agents_dir = tmp_path / ".claude" / "agents"
+        assert (agents_dir / "alpha.md").exists()
+        assert not (agents_dir / "beta.md").exists()
+
+
+class TestResumeSubagentBatchWaitMode:
+    """Resume path: ``--wait`` polls in-process until ended or timeout."""
+
+    @pytest.mark.asyncio
+    async def test_wait_polls_until_ended(self, tmp_path: Path) -> None:
+        """Two ``in_progress`` polls then ``ended`` → fetch fires."""
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            side_effect=[
+                BatchPoll(
+                    batch_id="msgbatch_42",
+                    status="in_progress",
+                    processing_count=1,
+                    succeeded_count=0,
+                    errored_count=0,
+                ),
+                BatchPoll(
+                    batch_id="msgbatch_42",
+                    status="in_progress",
+                    processing_count=1,
+                    succeeded_count=0,
+                    errored_count=0,
+                ),
+                BatchPoll(
+                    batch_id="msgbatch_42",
+                    status="ended",
+                    processing_count=0,
+                    succeeded_count=1,
+                    errored_count=0,
+                ),
+            ]
+        )
+        orchestrator.fetch_batch_results = AsyncMock(
+            return_value=BatchResultsBundle(
+                successes={"subagent:alpha": _success("alpha")},
+                failures={},
+            )
+        )
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+            wait=True,
+            poll_interval=0.0,  # tight loop for test speed
+            wait_timeout_seconds=10.0,
+        )
+
+        assert outcome.status == ResumeStatus.ENDED
+        # Three polls (two in-progress + one ended), one fetch.
+        assert orchestrator.poll_batch.await_count == 3
+        orchestrator.fetch_batch_results.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out_when_batch_never_ends(self, tmp_path: Path) -> None:
+        """Wait deadline exceeded → ``TIMED_OUT`` without fetching."""
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="in_progress",
+                processing_count=1,
+                succeeded_count=0,
+                errored_count=0,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock()
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+            wait=True,
+            poll_interval=0.0,
+            wait_timeout_seconds=-1.0,  # already past deadline → exit after one poll
+        )
+
+        assert outcome.status == ResumeStatus.TIMED_OUT
+        orchestrator.fetch_batch_results.assert_not_awaited()
+        # State retains the in-flight batch so a future run can resume.
+        assert state.has_batch()

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -508,3 +508,123 @@ class TestResumeSubagentBatchErrorPropagation:
         assert state.batch.batch_id == "msgbatch_42"
         # Did NOT fetch — the second poll never returned ``ended``.
         orchestrator.fetch_batch_results.assert_not_awaited()
+
+
+class TestResumeSubagentBatchPartialFailureIsolation:
+    """Round-3 review: per-agent isolation for local write failures.
+
+    The PR documents per-agent failure isolation in the README. The
+    round-3 reviewer flagged two paths where that contract leaked:
+    a missing source file would abort the whole loop, and an
+    unresolvable ``custom_id`` would silently vanish from both
+    ``succeeded`` and ``failed_agents``. Both now route through the
+    ``locally_failed`` partition.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_source_file_does_not_abort_other_agents(
+        self, tmp_path: Path
+    ) -> None:
+        """Source file deleted between submit and fetch → only that
+        agent fails; siblings still land on disk."""
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            custom_id_map={
+                "subagent:alpha": BATCH_TARGET_SUBAGENTS,
+                "subagent:beta": BATCH_TARGET_SUBAGENTS,
+            },
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="ended",
+                processing_count=0,
+                succeeded_count=2,
+                errored_count=0,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock(
+            return_value=BatchResultsBundle(
+                successes={
+                    "subagent:alpha": _success("alpha"),
+                    "subagent:beta": _success("beta"),
+                },
+                failures={},
+            )
+        )
+        # Simulate beta's source file having been deleted between
+        # submit and fetch by making get_agent_frontmatter raise.
+        gen = _fake_generator()
+
+        def selective_frontmatter(name: str) -> str:
+            if name == "beta":
+                msg = "source file vanished between submit and fetch"
+                raise FileNotFoundError(msg)
+            return f"---\nname: {name}\n---"
+
+        gen.get_agent_frontmatter.side_effect = selective_frontmatter
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=gen,
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert outcome.status == ResumeStatus.ENDED
+        # Alpha landed; beta is in failed_agents — isolation held.
+        assert outcome.succeeded_agents == ("alpha",)
+        assert outcome.failed_agents == ("beta",)
+        agents_dir = tmp_path / ".claude" / "agents"
+        assert (agents_dir / "alpha.md").exists()
+        assert not (agents_dir / "beta.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_unresolved_custom_id_surfaces_in_failed_agents(
+        self, tmp_path: Path
+    ) -> None:
+        """A custom_id with no known schema lands in ``failed_agents``
+        with an ``unresolved:`` prefix — never silently dropped."""
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_42",
+            submitted_at="2026-05-09T21:00:00+00:00",
+            # Recorded mapping covers only alpha; the rogue custom_id
+            # below isn't in the map and uses a schema we don't know.
+            custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
+        )
+        orchestrator = MagicMock()
+        orchestrator.poll_batch = AsyncMock(
+            return_value=BatchPoll(
+                batch_id="msgbatch_42",
+                status="ended",
+                processing_count=0,
+                succeeded_count=2,
+                errored_count=0,
+            )
+        )
+        orchestrator.fetch_batch_results = AsyncMock(
+            return_value=BatchResultsBundle(
+                successes={
+                    "subagent:alpha": _success("alpha"),
+                    "rogue:unknown-shape": _success("rogue"),
+                },
+                failures={},
+            )
+        )
+
+        outcome = await resume_subagent_batch(
+            orchestrator=orchestrator,
+            generator=_fake_generator(),
+            state=state,
+            project_path=tmp_path,
+        )
+
+        assert outcome.status == ResumeStatus.ENDED
+        assert outcome.succeeded_agents == ("alpha",)
+        # The rogue custom_id is surfaced rather than silently
+        # dropped — synthetic prefix flags the schema-drift bug.
+        assert outcome.failed_agents == ("unresolved:rogue:unknown-shape",)

--- a/tests/unit/generators/test_subagents.py
+++ b/tests/unit/generators/test_subagents.py
@@ -17,8 +17,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
 from start_green_stay_green.generators.subagents import REFERENCE_AGENTS_DIR
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
+from start_green_stay_green.generators.subagents import SubagentBatchEntry
 from start_green_stay_green.generators.subagents import SubagentGenerationResult
 from start_green_stay_green.generators.subagents import SubagentsGenerator
 
@@ -680,3 +683,98 @@ class TestSubagentsParallelism:
 
         await generator.generate_all_agents("ctx")
         assert peak <= 2
+
+
+class TestSubagentsBatchPlan:
+    """Phase 5b: ``build_batch_plan`` + ``apply_batch_result``."""
+
+    def test_build_batch_plan_yields_one_entry_per_required_agent(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """One :class:`SubagentBatchEntry` per file in REQUIRED_AGENTS."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        for source_file in REQUIRED_AGENTS.values():
+            (agents_dir / source_file).write_text(SAMPLE_AGENT_CONTENT)
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+            dry_run=False,
+        )
+
+        plan = generator.build_batch_plan("Test target context")
+
+        assert len(plan) == len(REQUIRED_AGENTS)
+        assert all(isinstance(e, SubagentBatchEntry) for e in plan)
+
+    def test_build_batch_plan_custom_id_convention(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Custom IDs use the ``subagent:<name>`` shape Phase 5a expects."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        for source_file in REQUIRED_AGENTS.values():
+            (agents_dir / source_file).write_text(SAMPLE_AGENT_CONTENT)
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+        )
+
+        plan = generator.build_batch_plan("ctx")
+        custom_ids = [entry.custom_id for entry in plan]
+
+        # Each custom_id is unique and prefixed with ``subagent:``.
+        assert len(set(custom_ids)) == len(custom_ids)
+        for cid in custom_ids:
+            assert cid.startswith("subagent:")
+
+    def test_build_batch_plan_captures_frontmatter_per_entry(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Each entry carries its agent's frontmatter for later re-attach."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        for source_file in REQUIRED_AGENTS.values():
+            (agents_dir / source_file).write_text(SAMPLE_AGENT_CONTENT)
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+        )
+
+        plan = generator.build_batch_plan("ctx")
+
+        # SAMPLE_AGENT_CONTENT starts with ``---`` and contains ``name:``.
+        for entry in plan:
+            assert entry.frontmatter.startswith("---")
+            assert "name:" in entry.frontmatter
+
+    def test_apply_batch_result_reattaches_frontmatter(self) -> None:
+        """``apply_batch_result`` rebuilds ``frontmatter\\nbody``."""
+        tool_result = ToolUseResult(
+            tool_name="report_tuning",
+            tool_input={
+                "tuned_content": "# Adapted body\n",
+                "changes": ["renamed FastAPI to Django"],
+            },
+            token_usage=TokenUsage(input_tokens=10, output_tokens=5),
+            model="claude",
+            message_id="msg_x",
+        )
+
+        result = SubagentsGenerator.apply_batch_result(
+            agent_name="chief-architect",
+            frontmatter="---\nname: chief-architect\n---",
+            tool_result=tool_result,
+        )
+
+        assert result.agent_name == "chief-architect"
+        assert result.tuned
+        assert result.content.startswith("---\n")
+        assert "# Adapted body" in result.content
+        assert "renamed FastAPI to Django" in result.changes

--- a/tests/unit/generators/test_subagents.py
+++ b/tests/unit/generators/test_subagents.py
@@ -778,3 +778,73 @@ class TestSubagentsBatchPlan:
         assert result.content.startswith("---\n")
         assert "# Adapted body" in result.content
         assert "renamed FastAPI to Django" in result.changes
+
+    def test_get_agent_frontmatter_returns_yaml_block_unmodified(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Public sibling of ``apply_batch_result`` for the resume path.
+
+        Replaces two ``noqa: SLF001`` suppressions in
+        ``batch_dispatch.py`` (review feedback on PR #315). The
+        method must return the YAML frontmatter block byte-equivalent
+        to what ``_parse_frontmatter`` would have produced — same
+        leading ``---``, same closing delimiter, no body content.
+        """
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "chief-architect.md").write_text(
+            SAMPLE_AGENT_CONTENT, encoding="utf-8"
+        )
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+        )
+
+        frontmatter = generator.get_agent_frontmatter("chief-architect")
+
+        assert frontmatter.startswith("---")
+        assert "name: test-agent" in frontmatter
+        # Closing delimiter present, body NOT included.
+        assert frontmatter.rstrip().endswith("---")
+        assert "# Test Agent" not in frontmatter
+
+    def test_get_agent_frontmatter_picks_up_local_edits_between_calls(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Re-read semantics: edit on disk → fresh return value.
+
+        ``_frontmatter_for`` (now folded into this method) was
+        documented to re-read at fetch time so a frontmatter edit
+        between submit and fetch is picked up automatically. This
+        test exercises that contract directly — review feedback
+        flagged that the docstring claimed this guarantee but no
+        test backed it up.
+        """
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        agent_file = agents_dir / "chief-architect.md"
+        agent_file.write_text(SAMPLE_AGENT_CONTENT, encoding="utf-8")
+
+        mocker.patch.object(SubagentsGenerator, "_validate_reference_dir")
+        generator = SubagentsGenerator(
+            mocker.Mock(),
+            reference_dir=agents_dir,
+        )
+
+        first = generator.get_agent_frontmatter("chief-architect")
+
+        # Edit the source file's frontmatter in place.
+        agent_file.write_text(
+            SAMPLE_AGENT_CONTENT.replace(
+                "name: test-agent", "name: edited-after-submit"
+            ),
+            encoding="utf-8",
+        )
+
+        second = generator.get_agent_frontmatter("chief-architect")
+
+        assert "name: test-agent" in first
+        assert "name: edited-after-submit" in second
+        assert first != second

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -40,9 +40,13 @@ from typer.testing import CliRunner
 
 from start_green_stay_green import cli
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
+from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
+from start_green_stay_green.utils.enhance_state import BatchProgress
+from start_green_stay_green.utils.enhance_state import EnhanceState
 from start_green_stay_green.utils.enhance_state import load_state
+from start_green_stay_green.utils.enhance_state import save_state
 
 
 def _make_orch_mock(mock_init: Mock) -> MagicMock:
@@ -2471,3 +2475,80 @@ class TestEnhanceBatchCLI:
         assert "--dry-run with --batch" in self._flat(result.stdout)
         submit.assert_not_called()
         resume.assert_not_called()
+
+    def test_batch_submit_api_error_exits_cleanly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``AIGenerationError`` from submit → exit 1 + clear message.
+
+        Review feedback (PR #315): the docstring of
+        :func:`submit_subagent_batch` lists ``GenerationError`` as a
+        documented raise, but the CLI lacked a handler so a real
+        SDK-side failure produced an uncaught traceback. This test
+        pins the post-feedback behaviour: human-readable error, exit
+        code 1, no stack trace bleeding to stdout.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+
+        # ``submit_subagent_batch`` raises before any state is written
+        # so there's no in-flight batch on disk after the run.
+        with mock.patch(
+            "start_green_stay_green.cli.submit_subagent_batch",
+            side_effect=AIGenerationError("Anthropic API rejected the batch (mocked)"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                ],
+            )
+
+        assert result.exit_code == 1
+        flat = self._flat(result.stdout)
+        assert "Batch API call failed" in flat
+        # Original error message survives so the user sees what went wrong.
+        assert "Anthropic API rejected the batch (mocked)" in flat
+        # No raw traceback in user-facing output.
+        assert "Traceback" not in result.stdout
+
+    def test_batch_resume_api_error_exits_cleanly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``AIGenerationError`` from resume → exit 1 + clear message."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+        # Pre-seed an in-flight batch so the resume branch is taken.
+        state = EnhanceState()
+        state.batch = BatchProgress(
+            batch_id="msgbatch_pre_seeded",
+            submitted_at="2026-05-09T22:00:00+00:00",
+            custom_id_map={"subagent:alpha": "subagents"},
+        )
+        save_state(project, state)
+
+        with mock.patch(
+            "start_green_stay_green.cli.resume_subagent_batch",
+            side_effect=AIGenerationError("poll failed (mocked)"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                ],
+            )
+
+        assert result.exit_code == 1
+        flat = self._flat(result.stdout)
+        assert "Batch API call failed" in flat
+        assert "poll failed (mocked)" in flat

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -39,6 +39,7 @@ import typer
 from typer.testing import CliRunner
 
 from start_green_stay_green import cli
+from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
@@ -2552,3 +2553,17 @@ class TestEnhanceBatchCLI:
         flat = self._flat(result.stdout)
         assert "Batch API call failed" in flat
         assert "poll failed (mocked)" in flat
+
+    def test_render_unknown_status_raises_value_error(self) -> None:
+        """Round-2 review #3: an unrecognised ``ResumeStatus`` constant
+        must fail loudly rather than silently rendering as ``ENDED``.
+
+        Phase 6 might add new statuses. Without this guard, a forgotten
+        update to ``_render_batch_resume_outcome`` would print a
+        misleading "0 agent(s) written, 0 failed" line for any
+        unhandled value.
+        """
+        bad = ResumeOutcome(status="bogus-status")
+
+        with pytest.raises(ValueError, match="Unhandled batch resume status"):
+            cli._render_batch_resume_outcome(bad)

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -29,6 +29,7 @@ def test_something(mock_path: Mock) -> None:
 import asyncio
 import json
 from pathlib import Path
+from unittest import mock
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -2375,3 +2376,98 @@ class TestEnhanceDispatchAssertion:
             pytest.raises(RuntimeError, match="undefined helper"),
         ):
             cli._assert_enhance_dispatch_intact()
+
+
+class TestEnhanceBatchCLI:
+    """Phase 5b: ``green enhance --batch`` flag wiring."""
+
+    @staticmethod
+    def _flat(text: str) -> str:
+        return " ".join(text.split())
+
+    @staticmethod
+    def _make_project(tmp_path: Path, *, name: str = "proj") -> Path:
+        project = tmp_path / name
+        project.mkdir()
+        (project / "CLAUDE.md").write_text(
+            f"# Claude Code Project Context: {name}\n\nbaseline.\n",
+            encoding="utf-8",
+        )
+        (project / "pyproject.toml").write_text("[project]\nname='x'\n")
+        (project / ".claude" / "agents").mkdir(parents=True)
+        return project
+
+    def test_batch_with_claude_md_target_exits_with_clear_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--batch --targets claude-md`` is rejected before any API call.
+
+        Phase 5a primitives only handle ``tool_use`` requests; the
+        sync claude-md path uses free-text generation. Failing fast
+        keeps the user model honest.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli.app,
+            [
+                "enhance",
+                str(project),
+                "--batch",
+                "--targets",
+                "claude-md",
+            ],
+        )
+
+        assert result.exit_code == 1
+        flat = self._flat(result.stdout)
+        assert "--batch does not support targets claude-md" in flat
+        # Suggests the working invocation rather than just erroring.
+        assert "--targets subagents" in flat
+
+    def test_wait_without_batch_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--wait`` only makes sense paired with ``--batch``."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--wait"],
+        )
+
+        assert result.exit_code == 1
+        assert "--wait only applies in --batch mode" in self._flat(result.stdout)
+
+    def test_batch_dry_run_short_circuits_without_calling_api(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--batch --dry-run`` prints a notice and does NOT submit."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+        # Patch the dispatch helpers so a slip would be loud.
+        with (
+            mock.patch("start_green_stay_green.cli.submit_subagent_batch") as submit,
+            mock.patch("start_green_stay_green.cli.resume_subagent_batch") as resume,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "--dry-run with --batch" in self._flat(result.stdout)
+        submit.assert_not_called()
+        resume.assert_not_called()


### PR DESCRIPTION
## Summary

Phase 5b ships the user-facing `--batch` flag on top of the Phase 5a primitives (PR #313 → commit `d43e697`). All five gates green; 1775 tests pass (+16 new).

## User-visible flow

```bash
# Submit:
green enhance --batch --targets subagents
# → "Submitted batch msgbatch_42 covering 8 subagent(s).
#    Re-run `green enhance --batch` to fetch results."

# (later) Resume:
green enhance --batch --targets subagents
# → "✓ Batch reconciled: 8 agent(s) written, 0 failed."

# CI-friendly single-call variant:
green enhance --batch --wait --targets subagents
# Polls every 30 s until the batch ends or 1h timeout.
```

## What's new

### `ai/batch_dispatch.py` (new module, 483 lines)

CLI-agnostic orchestration glue. Two entry points:

- **`submit_subagent_batch(...)`** — calls `SubagentsGenerator.build_batch_plan` for per-agent payloads, hands them to `AIOrchestrator.submit_tool_use_batch`, persists via `EnhanceState.start_batch`. Returns `BatchSubmitOutcome`.
- **`resume_subagent_batch(...)`** — pre-poll guard short-circuits on `NO_BATCH` and `EXPIRED` (the latter clears the stale record so the next CLI run falls through to submit). For in-flight batches: polls, optionally waits, fetches, writes per-agent files, clears state. Returns a `ResumeOutcome` discriminated by one of five `ResumeStatus` constants.

Per-request failures (`errored` / `canceled` / `expired`) do **not** abort batch reconciliation — successes land on disk, failures land in `failed_agents` so the user can re-run to retry.

### `SubagentsGenerator` additions

| Method | Purpose |
|---|---|
| `build_batch_plan(target_context)` | One `SubagentBatchEntry` per `REQUIRED_AGENTS` slot. Reuses existing `_load_agent_content` + `_parse_frontmatter` helpers so the byte-shape matches the sync path. |
| `apply_batch_result(name, frontmatter, tool_result)` | Lifts a fetched `ToolUseResult` back into a `SubagentGenerationResult` with the original frontmatter re-attached. |

### CLI: `--batch` + `--wait` flags

Two new flags on `green enhance`. Validation guards before any API call:

- `--batch --targets claude-md` rejected with a clear message naming the working invocation (`--targets subagents`). Phase 5a primitives only handle `tool_use` requests; `claude-md` uses a free-text path.
- `--wait` without `--batch` rejected (it's a no-op flag in sync mode).
- `--batch --dry-run` short-circuits before any state-file or API touch.

### Documentation

- **ADR-001** Phase 5 Scope section updated with 5a → merged, 5b → this PR, plus implementation notes (subagents-only, `--wait` semantics, expiry guard, per-agent failure isolation).
- **README** gains a new `### green enhance` section with a `#### Batch mode (Phase 5)` subsection covering the two-call flow, `--wait` variant, subagents-only limit, expiry handling, and per-request failure isolation. Cross-links to ADR-001.
- **Roadmap** updated.

## Tests (16 new)

| File | Count | Coverage |
|---|---|---|
| `tests/unit/ai/test_batch_dispatch.py` | 9 | Submit-path payload + state persistence; resume no-op (no batch, expired); resume in-progress (no fetch); resume ended (writes, clears, partitions failures); `--wait` mode (polls until ended; times out cleanly). |
| `tests/unit/generators/test_subagents.py` (added) | 4 | Plan = one entry per `REQUIRED_AGENTS`; `subagent:<name>` custom-id convention; frontmatter captured per entry; `apply_batch_result` re-attaches frontmatter. |
| `tests/unit/test_cli_mocked.py` (added) | 3 | `--batch --targets claude-md` rejected; `--wait` without `--batch` rejected; `--batch --dry-run` short-circuits. |

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck, security, complexity — every function grade A).
- **1775 unit + integration/e2e tests pass** (1759 → +16 new).
- Bandit B101 clean — the type-narrowing `assert`s the dispatch initially used were replaced with explicit `if state.batch is None: return …` guards.

## Test plan

- [ ] CI green on this PR.
- [ ] Smoke against a real API key: `green enhance --batch --targets subagents` against a project with 8 reference subagents — verify all 8 land in `.claude/agents/` after the resume call.
- [ ] Smoke the expiry path: corrupt `submitted_at` to 25 h ago, re-run `green enhance --batch` and confirm the "submit a fresh batch" message + cleared state.

## Roadmap status

- ✅ Phase 0–4 + 2c + 5a — merged
- ⏳ **Phase 5b (this PR)**
- 🔜 Phase 6 (UX/docs/release)

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_