### PR TITLE
docs(review): Phase-6a round-2 follow-ups — collapse docstrings, fix CHANGELOG anchors, generalize model literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ roadmap (Phases 0 → 5b).
 - **Language-specific setup instructions** in `green init` output
   (#279).
 - **`await-claude-review`, `address-feedback`, and Phase-5 skills**
-  imported from `well-worn-tools` (#303, #314).
+  imported from `well-worn-tools` ([#303], [#314]).
 
 ### Changed
 
@@ -117,12 +117,14 @@ for the methodology.
 - All five CI gate scripts (lint, format, typecheck, security,
   complexity) pass; every function grade A under xenon.
 
+[#303]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/303
 [#308]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/308
 [#309]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/309
 [#310]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/310
 [#311]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/311
 [#312]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/312
 [#313]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/313
+[#314]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/314
 [#315]: https://github.com/Geoffe-Ga/start_green_stay_green/pull/315
 [Unreleased]: https://github.com/Geoffe-Ga/start_green_stay_green/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/Geoffe-Ga/start_green_stay_green/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -278,10 +278,10 @@ constraints:
 | `green enhance --batch` | minutes – hours | ≤3 | Same outputs as `green enhance` at 50 % cost via the Anthropic Batches API. Two-call submit-then-resume; pair with `--wait` for a single blocking command. Subagents only. |
 
 Numbers are rough order-of-magnitude on a Mac M-series with the
-default model (`claude-sonnet-4-6`); your mileage varies with
-network and rate-limit conditions. The scaffold half is
-deterministic and offline; only the polish half varies with the
-API.
+default Sonnet model (see `green --help` for the current pin); your
+mileage varies with network and rate-limit conditions. The scaffold
+half is deterministic and offline; only the polish half varies with
+the API.
 
 ### What "Pass 2 polish" actually does
 

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -683,25 +683,14 @@ class TestLanguageValidation:
             assert lang in help_text, f"Language '{lang}' missing from help text"
 
     def test_api_key_flag_hidden_from_init_help(self) -> None:
-        """Deprecated --api-key must not appear in ``green init --help``.
-
-        The flag remains functional (with a runtime ``[DEPRECATED]`` warning)
-        but advertising it in --help would invite users to keep passing
-        secrets via argv where they leak into shell history and ps listings.
-        Locks in ``hidden=True`` on the typer.Option so silent removal
-        regresses this test instead of exposing the flag again.
-        """
+        """Lock in hidden=True on init's --api-key (regresses if re-exposed)."""
         runner = CliRunner()
         result = runner.invoke(cli.app, ["init", "--help"])
         assert result.exit_code == 0
         assert "--api-key" not in result.output
 
     def test_api_key_flag_hidden_from_enhance_help(self) -> None:
-        """Deprecated --api-key must not appear in ``green enhance --help``.
-
-        Same rationale as ``init``: the flag is kept only as a backwards-
-        compatible execution path, not a discoverable surface.
-        """
+        """Lock in hidden=True on enhance's --api-key (regresses if re-exposed)."""
         runner = CliRunner()
         result = runner.invoke(cli.app, ["enhance", "--help"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Follow-up to merged PR #321 — addresses the three non-blocking polish items the round-2 reviewer flagged ([COMMENTS verdict](https://github.com/Geoffe-Ga/start_green_stay_green/pull/321#issuecomment-4414613771)). Pure docs + test-text; **no logic change**, **no new tests**, **same 1785 test count** as #321.

## What landed

| # | Item | Fix |
|---|---|---|
| 1 | Test docstrings violated CLAUDE.md "one-line max" | Both `test_api_key_flag_hidden_from_*_help` docstrings collapsed to single lines. Rationale moved to PR #321's commit body + CHANGELOG (where it already lives). |
| 2 | CHANGELOG mixed link-anchored `[#308]` with plain `(#303, #314)` | Edited body to `([#303], [#314])` and added the two missing anchor defs in numerical order at the link-defs block. All PR refs are now clickable. |
| 3 | README hard-coded `claude-sonnet-4-6` | Replaced with "the default Sonnet model (see `green --help` for the current pin)" — same density, won't go stale on the next default-model bump. |

## Out of scope (process note)

Reviewer also noted the `[Unreleased]` / `[1.0.0]` anchors at the bottom of CHANGELOG.md 404 until the `v1.0.0` git tag is pushed. That's standard Keep-a-Changelog convention (write the links before tagging) — the action is "push the tag", which lives in the release operator's checklist, not this PR.

## Verification

- All five CI gate scripts pass locally (lint, format, typecheck, security, complexity).
- **1785 tests pass** — same count as PR #321 (only docstring text + a couple of doc lines changed).
- No `noqa` directives.

## Test plan

- [ ] CI green.
- [ ] Skim CHANGELOG diff: `[#303]` and `[#314]` resolve to the right URLs.
- [ ] Skim README: "the default Sonnet model" reads cleanly.

## Roadmap status

- ✅ Phase 0–5b — merged
- ✅ Phase 6a — merged (#321)
- ⏳ **Phase 6a follow-ups (this PR)** — review polish
- 🔜 Phase 6b — CLI UX + safety (#317 + #319)
- 🔜 Phase 6c — typing + refactor (#318 + #316)

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U)_