### PR TITLE
feat(cli): Phase 6b — path-containment guard + first-run --wait warning

### DIFF
--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -484,13 +484,28 @@ def _write_one_agent(
     so this function returns nothing rather than echoing it back —
     avoids the misleading ``-> str`` annotation flagged by review.
     """
+    agent_file = target_dir / f"{agent_name}.md"
+    # Defense-in-depth: today ``agent_name`` is stripped from a
+    # ``custom_id`` whose source is the code-defined
+    # :data:`REQUIRED_AGENTS` map, so traversal payloads cannot
+    # reach here. The guard protects against a future phase widening
+    # the input to user-supplied custom IDs (e.g. ``skill:<name>``)
+    # — see issue #317. Runs before any content work so a bad name
+    # never reaches ``apply_batch_result``.
+    resolved_target = target_dir.resolve()
+    resolved_file = agent_file.resolve()
+    if not resolved_file.is_relative_to(resolved_target):
+        msg = (
+            f"refusing to write agent {agent_name!r}: path "
+            f"{resolved_file} escapes target dir {resolved_target}"
+        )
+        raise ValueError(msg)
     frontmatter = generator.get_agent_frontmatter(agent_name)
     result = SubagentsGenerator.apply_batch_result(
         agent_name=agent_name,
         frontmatter=frontmatter,
         tool_result=tool_result,
     )
-    agent_file = target_dir / f"{agent_name}.md"
     if file_writer is not None:
         file_writer.write_file(agent_file, result.content)
     else:

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -2471,6 +2471,17 @@ def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
                 wait=wait,
             )
             return
+        # ``wait`` is meaningful for the resume branch above, but the
+        # submit call itself never blocks (see ADR-001's two-call
+        # contract). Warn upfront on first-run so users know to pass
+        # ``--wait`` again on the resume call. See issue #319.
+        if wait:
+            console.print(
+                "[dim]--wait has no effect on the first --batch call "
+                "(submit-only by design — see ADR-001). Re-run with "
+                "--wait once the batch is in flight to block until "
+                "results land.[/dim]"
+            )
         _submit_subagent_batch_cli(
             project_path=project_path,
             project_name=project_name,
@@ -2519,8 +2530,8 @@ def _submit_subagent_batch_cli(
         f"[green]✓[/green] Submitted batch [bold]"
         f"{outcome.submission.batch_id}[/bold] covering "
         f"{outcome.agent_count} subagent(s). Re-run "
-        f"`green enhance --batch` to fetch results, or pass "
-        f"--wait to block in-process."
+        f"`green enhance --batch` to fetch results, or with "
+        f"`--wait` to block in-process."
     )
 
 
@@ -2738,7 +2749,9 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
                 "When used with ``--batch``: block in-process polling "
                 "every 30 s until the batch ends or the timeout is "
                 "reached. Default off (two-call submit-then-resume "
-                "pattern is friendlier for CI)."
+                "pattern is friendlier for CI). Has no effect on the "
+                "first ``--batch`` invocation (submit-only); pass "
+                "``--wait`` on the resume call to block."
             ),
         ),
     ] = False,

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -26,6 +26,7 @@ from start_green_stay_green.ai.batch_dispatch import BATCH_TARGET_SUBAGENTS
 from start_green_stay_green.ai.batch_dispatch import BatchSubmitOutcome
 from start_green_stay_green.ai.batch_dispatch import BatchWaitConfig
 from start_green_stay_green.ai.batch_dispatch import ResumeStatus
+from start_green_stay_green.ai.batch_dispatch import _write_one_agent
 from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
 from start_green_stay_green.ai.batch_dispatch import submit_subagent_batch
 from start_green_stay_green.ai.types import GenerationError
@@ -628,3 +629,48 @@ class TestResumeSubagentBatchPartialFailureIsolation:
         # The rogue custom_id is surfaced rather than silently
         # dropped — synthetic prefix flags the schema-drift bug.
         assert outcome.failed_agents == ("unresolved:rogue:unknown-shape",)
+
+
+class TestWriteOneAgentPathContainment:
+    """Defense-in-depth: ``_write_one_agent`` rejects path-traversal names (#317)."""
+
+    def test_rejects_dotdot_traversal_outside_target_dir(self, tmp_path: Path) -> None:
+        """An ``agent_name`` containing ``..`` separators must raise rather
+        than write outside ``target_dir``. The guard is defense-in-depth:
+        today the name comes from a code-defined ``REQUIRED_AGENTS`` map,
+        but a future phase widening the input to user-supplied custom IDs
+        (e.g. ``skill:<name>``) could otherwise allow filesystem escape.
+        See issue #317.
+        """
+        target_dir = tmp_path / "agents"
+        target_dir.mkdir()
+        sentinel = tmp_path / "escape.md"
+        assert not sentinel.exists()
+
+        with pytest.raises(ValueError, match="escapes target dir"):
+            _write_one_agent(
+                generator=_fake_generator(),
+                agent_name="../escape",
+                tool_result=_success("..."),
+                target_dir=target_dir,
+                file_writer=None,
+            )
+        # The guard is the only thing standing between the malicious
+        # name and the filesystem, so prove the file was not written.
+        assert not sentinel.exists()
+
+    def test_accepts_normal_agent_name(self, tmp_path: Path) -> None:
+        """Sanity check: a plain alphanumeric agent name still writes
+        through the guard without raising."""
+        target_dir = tmp_path / "agents"
+        target_dir.mkdir()
+
+        _write_one_agent(
+            generator=_fake_generator(),
+            agent_name="implementation-engineer",
+            tool_result=_success("body"),
+            target_dir=target_dir,
+            file_writer=None,
+        )
+
+        assert (target_dir / "implementation-engineer.md").exists()

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -2491,6 +2491,47 @@ class TestEnhanceBatchCLI:
         submit.assert_not_called()
         resume.assert_not_called()
 
+    def test_first_run_batch_with_wait_warns_no_op(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``green enhance --batch --wait`` on first-run prints a no-op warning.
+
+        Issue #319: the submit branch silently ignored ``--wait``
+        because the submit call itself never blocks (ADR-001 two-call
+        contract). The user is told upfront so they know to pass
+        ``--wait`` again on the resume call.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+
+        fake_outcome = mock.MagicMock()
+        fake_outcome.submission.batch_id = "msgbatch_first_run"
+        fake_outcome.agent_count = 7
+
+        with mock.patch(
+            "start_green_stay_green.cli.submit_subagent_batch",
+            new=mock.AsyncMock(return_value=fake_outcome),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                    "--wait",
+                ],
+            )
+
+        assert result.exit_code == 0, result.stdout
+        flat = self._flat(result.stdout)
+        assert "--wait has no effect on the first --batch call" in flat
+        # The success message still surfaces — warning is additive.
+        assert "Submitted batch" in flat
+        assert "msgbatch_first_run" in flat
+
     def test_batch_submit_api_error_exits_cleanly(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Two follow-ups from the Phase-5b round-4 review (#315 review notes
documented as issues #317 and #319). Both are small, surgical, and
contained to one helper each.

Issue #317: defense-in-depth path-containment guard in _write_one_agent
=======================================================================

Today ``agent_name`` reaches ``ai/batch_dispatch.py:_write_one_agent``
only via ``_lookup_from_state``, which strips it from a ``custom_id``
whose source is the code-defined ``REQUIRED_AGENTS`` map — so a
traversal payload like ``../../etc/passwd`` cannot get there from
production input. The guard is purely defensive against a future
phase widening the input surface to user-supplied custom IDs (e.g.
``--include skill:<name>``).

* Compute ``resolved_file`` and ``resolved_target`` after building
  ``agent_file = target_dir / f"{agent_name}.md"``.
* Reject with a clear ``ValueError`` if the resolved path is not
  relative to the resolved target dir. Path-containment via
  ``Path.is_relative_to`` (Python 3.9+) is the more robust of the
  two options the reviewer suggested — name-format regexes go
  stale when name conventions change; the path check tracks the
  actual security property.
* Runs *before* ``apply_batch_result`` so a bad name never reaches
  the content-tuning code, not just the write call.

Two new tests in ``TestWriteOneAgentPathContainment`` (in
``tests/unit/ai/test_batch_dispatch.py``):

* ``test_rejects_dotdot_traversal_outside_target_dir`` —
  constructs an ``agent_name="../escape"`` payload, asserts the
  raise carries "escapes target dir", and proves the sentinel file
  is not on disk.
* ``test_accepts_normal_agent_name`` — sanity check that a plain
  alphanumeric name (the production case) still writes through.

Issue #319: first-run --wait is no longer a silent no-op
========================================================

``green enhance --batch --wait --targets subagents`` on the *first*
invocation takes the submit branch, which by ADR-001 design never
blocks. The flag was previously ignored without comment and the
success message even told the user to "pass --wait to block" — but
the user *had* passed --wait. Confusing.

Conservative fix per option (1) in the issue (option (2) requires
an ADR-001 amendment):

* In ``_run_enhance_batch`` (the function that knows the submit-vs-
  resume branch), print a one-line ``[dim]`` note before submit
  whenever ``wait=True``: "--wait has no effect on the first
  --batch call (submit-only by design — see ADR-001). Re-run with
  --wait once the batch is in flight to block until results
  land."
* The success message now reads "...or with `--wait` to block
  in-process" — corrects the misleading "pass" wording for the
  user who already passed.
* ``--wait`` typer help string updated with a one-line note about
  the no-op-on-submit behaviour.

The warning lives in ``_run_enhance_batch`` rather than
``_submit_subagent_batch_cli`` because:

1. ``_run_enhance_batch`` is the function that owns the
   submit-vs-resume branch decision and already has ``wait`` in
   scope.
2. ``_submit_subagent_batch_cli`` is at the 5-arg PLR0913 limit;
   threading a 6th param would have introduced a new noqa
   directive (the opposite of what issue #316 is trying to clean
   up).

New test ``test_first_run_batch_with_wait_warns_no_op`` in
``TestEnhanceBatchCLI`` mocks ``submit_subagent_batch`` and asserts
the warning string and the (now-corrected) success message both
appear in stdout, exit code 0.

Verification
============

* All five CI gate scripts pass locally.
* **1788 unit + integration/e2e tests pass** — was 1785; +3 new
  tests (1 path-containment rejection, 1 path-containment sanity,
  1 --wait first-run warning).
* No noqa directives added (#316 follow-up still applies to
  pre-existing sites).

Closes #317
Closes #319

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U