### PR TITLE
refactor: Phase 6c — ResumeStatus → StrEnum + drop two PLR0913 noqas

### DIFF
--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -29,6 +29,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from start_green_stay_green.generators.subagents import SubagentsGenerator
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BATCH_TARGET_SUBAGENTS",
+    "BatchPersistenceContext",
     "BatchSubmitOutcome",
     "ResumeOutcome",
     "ResumeStatus",
@@ -84,19 +86,22 @@ class BatchSubmitOutcome:
     agent_count: int
 
 
-class ResumeStatus:
+class ResumeStatus(StrEnum):
     """Symbolic outcomes from :func:`resume_subagent_batch`.
 
-    Defined as a plain class with class attributes (rather than
-    :class:`enum.Enum`) so callers can compare against bare strings
-    in CLI rendering without importing the enum.
+    :class:`enum.StrEnum` (Python 3.11+) keeps the bare-string
+    ergonomics — members compare equal to their underlying string,
+    so existing tests asserting ``outcome.status == "ended"`` keep
+    passing — while giving mypy the static membership it needs to
+    drive ``assert_never`` exhaustiveness checks at the CLI render
+    site (see :func:`cli._render_batch_resume_outcome`).
     """
 
-    NO_BATCH: str = "no-batch"
-    EXPIRED: str = "expired"
-    IN_PROGRESS: str = "in-progress"
-    ENDED: str = "ended"
-    TIMED_OUT: str = "timed-out"
+    NO_BATCH = "no-batch"
+    EXPIRED = "expired"
+    IN_PROGRESS = "in-progress"
+    ENDED = "ended"
+    TIMED_OUT = "timed-out"
 
 
 @dataclass(frozen=True)
@@ -128,6 +133,37 @@ class BatchWaitConfig:
 
 
 @dataclass(frozen=True)
+class BatchPersistenceContext:
+    """Persistence-side dependencies shared across resume/reconcile.
+
+    Bundles the three parameters that always travel together when a
+    batch ends and needs to land on disk: the state record (cleared
+    after a successful write), the project root (resolves the agent
+    target dir), and the optional file writer (production code uses
+    ``None`` to write directly; the init pipeline overrides with a
+    buffered writer that defers writes). Grouping them drops
+    :func:`resume_subagent_batch` and :func:`_reconcile_ended_batch`
+    below the ``PLR0913`` threshold without splitting concerns. See
+    issue #316.
+
+    Attributes:
+        state: The :class:`EnhanceState` record. Cleared on
+            successful reconciliation; left intact on
+            :data:`ResumeStatus.IN_PROGRESS` / ``TIMED_OUT``.
+        project_path: Project root. The agent target dir is
+            ``project_path / ".claude" / "agents"``.
+        file_writer: ``None`` writes directly via
+            :meth:`pathlib.Path.write_text`; the init pipeline
+            passes a :class:`FileWriter` that buffers writes for
+            transactional rollback.
+    """
+
+    state: EnhanceState
+    project_path: Path
+    file_writer: FileWriter | None = None
+
+
+@dataclass(frozen=True)
 class ResumeOutcome:
     """What :func:`resume_subagent_batch` reports back to the CLI.
 
@@ -145,7 +181,7 @@ class ResumeOutcome:
             non-``ENDED`` statuses.
     """
 
-    status: str
+    status: ResumeStatus
     poll: BatchPoll | None = None
     bundle: BatchResultsBundle | None = None
     succeeded_agents: tuple[str, ...] = ()
@@ -200,13 +236,11 @@ async def submit_subagent_batch(
     return BatchSubmitOutcome(submission=submission, agent_count=len(plan))
 
 
-async def resume_subagent_batch(  # noqa: PLR0913 - see #316
+async def resume_subagent_batch(
     *,
     orchestrator: AIOrchestrator,
     generator: SubagentsGenerator,
-    state: EnhanceState,
-    project_path: Path,
-    file_writer: FileWriter | None = None,
+    persistence: BatchPersistenceContext,
     wait_config: BatchWaitConfig | None = None,
 ) -> ResumeOutcome:
     """Resume an in-flight batch: poll, optionally wait, fetch, write.
@@ -228,12 +262,8 @@ async def resume_subagent_batch(  # noqa: PLR0913 - see #316
         orchestrator: Configured :class:`AIOrchestrator`.
         generator: :class:`SubagentsGenerator` (used to rebuild
             per-agent files via :meth:`apply_batch_result`).
-        state: Loaded :class:`EnhanceState` with an in-flight
-            batch record.
-        project_path: Project root — the state file is updated
-            here on every meaningful state transition.
-        file_writer: Optional dry-run-aware writer. ``None`` in
-            production; tests inject one.
+        persistence: :class:`BatchPersistenceContext` bundling the
+            state record, project root, and optional file writer.
         wait_config: Wait-mode tuning. ``None`` defaults to a
             single-poll non-blocking check.
 
@@ -241,18 +271,18 @@ async def resume_subagent_batch(  # noqa: PLR0913 - see #316
         :class:`ResumeOutcome` describing what happened.
     """
     config = wait_config or BatchWaitConfig()
-    pre_poll = _check_pre_poll(state, project_path)
+    pre_poll = _check_pre_poll(persistence.state, persistence.project_path)
     if pre_poll is not None:
         return pre_poll
     # ``_check_pre_poll`` returns ``None`` only when ``state.batch``
     # exists; the second guard re-narrows the union for mypy without
     # an ``assert`` (which Bandit B101 flags).
-    if state.batch is None:
+    if persistence.state.batch is None:
         return ResumeOutcome(status=ResumeStatus.NO_BATCH)
 
     poll = await _poll_until_terminal(
         orchestrator=orchestrator,
-        batch_id=state.batch.batch_id,
+        batch_id=persistence.state.batch.batch_id,
         config=config,
     )
     if not poll.is_ended:
@@ -261,9 +291,7 @@ async def resume_subagent_batch(  # noqa: PLR0913 - see #316
     return await _reconcile_ended_batch(
         orchestrator=orchestrator,
         generator=generator,
-        state=state,
-        project_path=project_path,
-        file_writer=file_writer,
+        persistence=persistence,
         poll=poll,
     )
 
@@ -300,24 +328,23 @@ def _check_pre_poll(
     return None
 
 
-async def _reconcile_ended_batch(  # noqa: PLR0913 - dispatch glue, see #316
+async def _reconcile_ended_batch(
     *,
     orchestrator: AIOrchestrator,
     generator: SubagentsGenerator,
-    state: EnhanceState,
-    project_path: Path,
-    file_writer: FileWriter | None,
+    persistence: BatchPersistenceContext,
     poll: BatchPoll,
 ) -> ResumeOutcome:
     """Fetch results, write per-agent files, clear batch, build outcome.
 
-    ``state.batch`` is non-``None`` by caller contract (the resume
-    flow only reaches here after the pre-poll guard returned). The
-    runtime check below is a typed re-narrowing for mypy, not a
-    defensive assertion — calling this with no batch is a
-    programming error, but raising rather than asserting keeps
+    ``persistence.state.batch`` is non-``None`` by caller contract
+    (the resume flow only reaches here after the pre-poll guard
+    returned). The runtime check below is a typed re-narrowing for
+    mypy, not a defensive assertion — calling this with no batch is
+    a programming error, but raising rather than asserting keeps
     Bandit B101 quiet.
     """
+    state = persistence.state
     if state.batch is None:
         msg = "_reconcile_ended_batch called without an in-flight batch"
         raise RuntimeError(msg)
@@ -326,11 +353,11 @@ async def _reconcile_ended_batch(  # noqa: PLR0913 - dispatch glue, see #316
         generator=generator,
         bundle=bundle,
         plan_lookup=_lookup_from_state(state),
-        target_dir=project_path / ".claude" / "agents",
-        file_writer=file_writer,
+        target_dir=persistence.project_path / ".claude" / "agents",
+        file_writer=persistence.file_writer,
     )
     state.clear_batch()
-    save_state(project_path, state)
+    save_state(persistence.project_path, state)
     return ResumeOutcome(
         status=ResumeStatus.ENDED,
         poll=poll,

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -20,6 +20,7 @@ from typing import Annotated
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import TypeVar
+from typing import assert_never
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -33,6 +34,7 @@ from rich.console import Console
 from rich.panel import Panel
 import typer
 
+from start_green_stay_green.ai.batch_dispatch import BatchPersistenceContext
 from start_green_stay_green.ai.batch_dispatch import BatchWaitConfig
 from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
 from start_green_stay_green.ai.batch_dispatch import ResumeStatus
@@ -2436,11 +2438,26 @@ def _validate_batch_targets(selected_targets: tuple[str, ...]) -> None:
     raise typer.Exit(code=1)
 
 
-def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
+@dataclass(frozen=True)
+class _EnhanceProjectContext:
+    """Project metadata threaded through the enhance dispatchers.
+
+    Bundles the three identifiers that every enhance helper needs to
+    know about the project under tune: where it lives, what it's
+    called, and what language preset to use. Grouping them drops
+    :func:`_run_enhance_batch` and :func:`_submit_subagent_batch_cli`
+    below the ``PLR0913`` threshold without splitting concerns. See
+    issue #316.
+    """
+
+    project_path: Path
+    project_name: str
+    language: str
+
+
+def _run_enhance_batch(
     *,
-    project_path: Path,
-    project_name: str,
-    language: str,
+    project: _EnhanceProjectContext,
     orchestrator: AIOrchestrator,
     file_writer: FileWriter,
     dry_run: bool,
@@ -2460,11 +2477,11 @@ def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
         )
         return
 
-    state = load_state(project_path)
+    state = load_state(project.project_path)
     try:
         if state.has_batch():
             _resume_subagent_batch_cli(
-                project_path=project_path,
+                project_path=project.project_path,
                 orchestrator=orchestrator,
                 state=state,
                 file_writer=file_writer,
@@ -2483,9 +2500,7 @@ def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
                 "results land.[/dim]"
             )
         _submit_subagent_batch_cli(
-            project_path=project_path,
-            project_name=project_name,
-            language=language,
+            project=project,
             orchestrator=orchestrator,
             state=state,
         )
@@ -2501,16 +2516,14 @@ def _run_enhance_batch(  # noqa: PLR0913 — orchestration glue, see #316
 
 def _submit_subagent_batch_cli(
     *,
-    project_path: Path,
-    project_name: str,
-    language: str,
+    project: _EnhanceProjectContext,
     orchestrator: AIOrchestrator,
     state: EnhanceState,
 ) -> None:
     """Build the subagent batch plan, submit, and persist."""
     target_context = (
-        f"Project: {project_name}, "
-        f"Language: {language}, "
+        f"Project: {project.project_name}, "
+        f"Language: {project.language}, "
         f"Type: existing project being re-tuned via `green enhance --batch`"
     )
     generator = SubagentsGenerator(orchestrator)
@@ -2522,7 +2535,7 @@ def _submit_subagent_batch_cli(
                 generator=generator,
                 target_context=target_context,
                 state=state,
-                project_path=project_path,
+                project_path=project.project_path,
             ),
         )
     )
@@ -2551,9 +2564,11 @@ def _resume_subagent_batch_cli(
             resume_subagent_batch(
                 orchestrator=orchestrator,
                 generator=generator,
-                state=state,
-                project_path=project_path,
-                file_writer=file_writer,
+                persistence=BatchPersistenceContext(
+                    state=state,
+                    project_path=project_path,
+                    file_writer=file_writer,
+                ),
                 wait_config=BatchWaitConfig(wait=wait),
             ),
         )
@@ -2567,7 +2582,7 @@ def _resume_subagent_batch_cli(
 # message, so they branch into ``_render_batch_in_progress`` /
 # ``_render_batch_ended`` instead. Adding them to this dict would
 # silently drop their dynamic data.
-_BATCH_OUTCOME_STATIC: dict[str, str] = {
+_BATCH_OUTCOME_STATIC: dict[ResumeStatus, str] = {
     ResumeStatus.NO_BATCH: (
         "[yellow]No batch is in flight; nothing to resume.[/yellow]"
     ),
@@ -2588,26 +2603,22 @@ def _render_batch_resume_outcome(outcome: ResumeOutcome) -> None:
     Static-message statuses (``NO_BATCH``, ``EXPIRED``, ``TIMED_OUT``)
     are rendered from the lookup table above. ``IN_PROGRESS`` and
     ``ENDED`` need ``outcome.poll`` / ``outcome.bundle`` data woven
-    in, so they branch into dedicated helpers. Splitting on these
-    lines keeps the dispatcher itself grade-A under xenon.
+    in, so they branch into dedicated helpers. The ``case _`` is
+    unreachable today — :data:`ResumeStatus` is a closed
+    :class:`enum.StrEnum` and every member has a branch above — but
+    the :func:`typing.assert_never` keeps mypy honest: adding a new
+    member without updating this dispatcher fails type checking
+    instead of silently falling through.
     """
-    static = _BATCH_OUTCOME_STATIC.get(outcome.status)
-    if static is not None:
-        console.print(static)
-        return
-    if outcome.status == ResumeStatus.IN_PROGRESS:
-        _render_batch_in_progress(outcome)
-        return
-    if outcome.status == ResumeStatus.ENDED:
-        _render_batch_ended(outcome)
-        return
-    # Defensive guard: a future ``ResumeStatus`` constant added
-    # without updating this dispatcher would otherwise silently
-    # render the ENDED message — which prints "0 written, 0 failed"
-    # for a status that means something else entirely. Fail loudly
-    # at the source instead.
-    msg = f"Unhandled batch resume status: {outcome.status!r}"
-    raise ValueError(msg)
+    match outcome.status:
+        case ResumeStatus.NO_BATCH | ResumeStatus.EXPIRED | ResumeStatus.TIMED_OUT:
+            console.print(_BATCH_OUTCOME_STATIC[outcome.status])
+        case ResumeStatus.IN_PROGRESS:
+            _render_batch_in_progress(outcome)
+        case ResumeStatus.ENDED:
+            _render_batch_ended(outcome)
+        case _:
+            assert_never(outcome.status)
 
 
 def _render_batch_in_progress(outcome: ResumeOutcome) -> None:
@@ -2819,9 +2830,11 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
 
     if batch:
         _run_enhance_batch(
-            project_path=project_path,
-            project_name=resolved_name,
-            language=resolved_language,
+            project=_EnhanceProjectContext(
+                project_path=project_path,
+                project_name=resolved_name,
+                language=resolved_language,
+            ),
             orchestrator=orchestrator,
             file_writer=file_writer,
             dry_run=dry_run,

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -10,6 +10,8 @@ plumbing (typer flags, console rendering) is covered separately in
 
 from __future__ import annotations
 
+from datetime import UTC
+from datetime import datetime
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -23,6 +25,7 @@ from start_green_stay_green.ai.batch import BatchResultsBundle
 from start_green_stay_green.ai.batch import BatchSubmission
 from start_green_stay_green.ai.batch import ToolUseBatchRequest
 from start_green_stay_green.ai.batch_dispatch import BATCH_TARGET_SUBAGENTS
+from start_green_stay_green.ai.batch_dispatch import BatchPersistenceContext
 from start_green_stay_green.ai.batch_dispatch import BatchSubmitOutcome
 from start_green_stay_green.ai.batch_dispatch import BatchWaitConfig
 from start_green_stay_green.ai.batch_dispatch import ResumeStatus
@@ -40,6 +43,21 @@ from start_green_stay_green.utils.enhance_state import load_state
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _recent_submitted_at() -> str:
+    """Return a non-expired ISO-8601 UTC timestamp for batch fixtures.
+
+    Hard-coding ``2026-05-09T21:00:00+00:00`` was a time-bomb: as soon
+    as wall-clock crossed the 24 h SLA window relative to it,
+    :meth:`BatchProgress.is_potentially_expired` flipped to ``True``
+    and tests that exercise the live batch path started flapping into
+    the EXPIRED branch unintentionally. Re-anchoring on
+    :func:`datetime.now` per-test makes the expiry guard test only
+    when explicitly asserted (via ``patch.object`` of
+    ``is_potentially_expired`` itself).
+    """
+    return datetime.now(UTC).isoformat()
 
 
 def _entry(agent_name: str, custom_id: str | None = None) -> SubagentBatchEntry:
@@ -170,8 +188,10 @@ class TestResumeSubagentBatchNoOp:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=EnhanceState(),
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=EnhanceState(),
+                project_path=tmp_path,
+            ),
         )
         assert outcome.status == ResumeStatus.NO_BATCH
         # Did NOT call the SDK — no in-flight batch to poll.
@@ -194,8 +214,10 @@ class TestResumeSubagentBatchNoOp:
             outcome = await resume_subagent_batch(
                 orchestrator=orchestrator,
                 generator=_fake_generator(),
-                state=state,
-                project_path=tmp_path,
+                persistence=BatchPersistenceContext(
+                    state=state,
+                    project_path=tmp_path,
+                ),
             )
 
         assert outcome.status == ResumeStatus.EXPIRED
@@ -213,7 +235,7 @@ class TestResumeSubagentBatchInProgress:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
         )
         orchestrator = MagicMock()
@@ -231,8 +253,10 @@ class TestResumeSubagentBatchInProgress:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
         )
 
         assert outcome.status == ResumeStatus.IN_PROGRESS
@@ -254,7 +278,7 @@ class TestResumeSubagentBatchEnded:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={
                 "subagent:alpha": BATCH_TARGET_SUBAGENTS,
                 "subagent:beta": BATCH_TARGET_SUBAGENTS,
@@ -283,8 +307,10 @@ class TestResumeSubagentBatchEnded:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
         )
 
         assert outcome.status == ResumeStatus.ENDED
@@ -303,7 +329,7 @@ class TestResumeSubagentBatchEnded:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={
                 "subagent:alpha": BATCH_TARGET_SUBAGENTS,
                 "subagent:beta": BATCH_TARGET_SUBAGENTS,
@@ -335,8 +361,10 @@ class TestResumeSubagentBatchEnded:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
         )
 
         assert outcome.succeeded_agents == ("alpha",)
@@ -356,7 +384,7 @@ class TestResumeSubagentBatchWaitMode:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
         )
         orchestrator = MagicMock()
@@ -395,8 +423,10 @@ class TestResumeSubagentBatchWaitMode:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
             wait_config=BatchWaitConfig(
                 wait=True,
                 poll_interval=0.0,  # tight loop for test speed
@@ -415,7 +445,7 @@ class TestResumeSubagentBatchWaitMode:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
         )
         orchestrator = MagicMock()
@@ -433,8 +463,10 @@ class TestResumeSubagentBatchWaitMode:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
             wait_config=BatchWaitConfig(
                 wait=True,
                 poll_interval=0.0,
@@ -464,7 +496,7 @@ class TestResumeSubagentBatchErrorPropagation:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
         )
         orchestrator = MagicMock()
@@ -487,8 +519,10 @@ class TestResumeSubagentBatchErrorPropagation:
             await resume_subagent_batch(
                 orchestrator=orchestrator,
                 generator=_fake_generator(),
-                state=state,
-                project_path=tmp_path,
+                persistence=BatchPersistenceContext(
+                    state=state,
+                    project_path=tmp_path,
+                ),
                 wait_config=BatchWaitConfig(
                     wait=True,
                     poll_interval=0.0,
@@ -531,7 +565,7 @@ class TestResumeSubagentBatchPartialFailureIsolation:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             custom_id_map={
                 "subagent:alpha": BATCH_TARGET_SUBAGENTS,
                 "subagent:beta": BATCH_TARGET_SUBAGENTS,
@@ -571,8 +605,10 @@ class TestResumeSubagentBatchPartialFailureIsolation:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=gen,
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
         )
 
         assert outcome.status == ResumeStatus.ENDED
@@ -592,7 +628,7 @@ class TestResumeSubagentBatchPartialFailureIsolation:
         state = EnhanceState()
         state.batch = BatchProgress(
             batch_id="msgbatch_42",
-            submitted_at="2026-05-09T21:00:00+00:00",
+            submitted_at=_recent_submitted_at(),
             # Recorded mapping covers only alpha; the rogue custom_id
             # below isn't in the map and uses a schema we don't know.
             custom_id_map={"subagent:alpha": BATCH_TARGET_SUBAGENTS},
@@ -620,8 +656,10 @@ class TestResumeSubagentBatchPartialFailureIsolation:
         outcome = await resume_subagent_batch(
             orchestrator=orchestrator,
             generator=_fake_generator(),
-            state=state,
-            project_path=tmp_path,
+            persistence=BatchPersistenceContext(
+                state=state,
+                project_path=tmp_path,
+            ),
         )
 
         assert outcome.status == ResumeStatus.ENDED

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -2609,16 +2609,25 @@ class TestEnhanceBatchCLI:
         assert "Batch API call failed" in flat
         assert "poll failed (mocked)" in flat
 
-    def test_render_unknown_status_raises_value_error(self) -> None:
-        """Round-2 review #3: an unrecognised ``ResumeStatus`` constant
-        must fail loudly rather than silently rendering as ``ENDED``.
+    def test_render_unknown_status_fails_loudly(self) -> None:
+        """An out-of-enum status must fail loudly rather than silently
+        rendering as ``ENDED``.
 
-        Phase 6 might add new statuses. Without this guard, a forgotten
-        update to ``_render_batch_resume_outcome`` would print a
-        misleading "0 agent(s) written, 0 failed" line for any
-        unhandled value.
+        Phase 6c migrated :class:`ResumeStatus` to :class:`enum.StrEnum`
+        and the dispatcher to a ``match`` statement with
+        :func:`typing.assert_never` — so a future member added without
+        updating ``_render_batch_resume_outcome`` is caught at mypy
+        time, not just at runtime. The runtime guard remains as
+        defense-in-depth: type checkers can be silenced or skipped, so
+        an out-of-enum value reaching the dispatcher still raises
+        ``AssertionError`` from ``assert_never`` rather than producing
+        a misleading "0 written, 0 failed" line.
         """
-        bad = ResumeOutcome(status="bogus-status")
+        # ``# type: ignore[arg-type]`` is exactly how a future
+        # forgotten-case bug would manifest — a developer might silence
+        # mypy here without realising the dispatcher hasn't been
+        # extended. The runtime guard catches it anyway.
+        bad = ResumeOutcome(status="bogus-status")  # type: ignore[arg-type]
 
-        with pytest.raises(ValueError, match="Unhandled batch resume status"):
+        with pytest.raises(AssertionError, match="unreachable"):
             cli._render_batch_resume_outcome(bad)


### PR DESCRIPTION
Final phase of the optimization roadmap, addressing issues #318 and
#316. Pure refactor + typing tightening; no behaviour change to
production code paths. Also fixes a pre-existing flaky-timestamp
time-bomb in the batch dispatch test fixtures.

Issue #318: ResumeStatus → StrEnum + assert_never exhaustiveness
================================================================

``ResumeStatus`` was a plain class with class attributes — string
ergonomics at the cost of mypy losing exhaustiveness. A new constant
added without updating ``cli._render_batch_resume_outcome`` would
have surfaced only at runtime via a defensive ``ValueError``, not
at type-check time.

* Migrate ``class ResumeStatus`` to ``class ResumeStatus(StrEnum)``
  (``enum.StrEnum`` is Python 3.11+; pyproject pins ``python_version
  = "3.11"``). Members compare equal to their underlying strings, so
  existing tests asserting ``outcome.status == "ended"`` keep
  passing untouched.
* Tighten ``ResumeOutcome.status: str`` → ``ResumeStatus`` so the
  field carries enum-typed values through the pipeline.
* Replace ``_render_batch_resume_outcome``'s ``if/elif`` chain with
  a ``match`` statement and ``case _: assert_never(outcome.status)``.
  mypy now flags any new ``ResumeStatus`` member that doesn't have
  a ``case`` branch as a type error — the ``assert_never`` runtime
  guard remains as defense-in-depth for ``# type: ignore`` paths.
* ``_BATCH_OUTCOME_STATIC: dict[str, str]`` → ``dict[ResumeStatus,
  str]`` for consistent typing.

Renamed ``test_render_unknown_status_raises_value_error`` →
``test_render_unknown_status_fails_loudly`` and updated to expect
``AssertionError`` from ``assert_never`` (the new contract). The
test purposely uses ``# type: ignore[arg-type]`` to simulate the
forgotten-case scenario the type system is supposed to catch and
verifies the runtime guard catches it anyway.

Issue #316: drop both PLR0913 noqas via context dataclasses
============================================================

Two new frozen dataclasses, each bundling parameters that already
travel together in production:

* ``BatchPersistenceContext(state, project_path, file_writer)`` —
  added next to ``BatchWaitConfig`` in ``ai/batch_dispatch.py``.
  Used by ``resume_subagent_batch`` (was 6 args + noqa, now 4) and
  ``_reconcile_ended_batch`` (was 6 args + noqa, now 4). Exposed in
  ``__all__``.
* ``_EnhanceProjectContext(project_path, project_name, language)``
  — module-private dataclass in ``cli.py``. Used by
  ``_run_enhance_batch`` (was 7 args + noqa, now 5) and
  ``_submit_subagent_batch_cli`` (was 5 args, now 3 — would have
  crossed the threshold once #319 threaded ``wait`` through, which
  PR #323 worked around by moving the warning upstream).

Net: three ``# noqa: PLR0913`` directives deleted
(``resume_subagent_batch``, ``_reconcile_ended_batch``,
``_run_enhance_batch``). Six remain in ``cli.py``
(``init``, ``_enhance_claude_md``, ``_enhance_subagents``,
``_dispatch_enhance_targets``, ``_run_enhance_pipeline``,
``enhance``) — all explicitly out of scope per #316. Issue #316
suggests the same ``_EnhanceProjectContext`` could clean up
``_dispatch_enhance_targets`` and ``_run_enhance_pipeline`` in a
future pass.

Test plumbing
=============

10 ``resume_subagent_batch`` test call sites refactored to construct
``BatchPersistenceContext`` inline. ``submit_subagent_batch`` callers
intentionally NOT refactored — that function is at 5 args (under the
threshold) and out of scope for #316.

Pre-existing time-bomb fix
==========================

8 batch dispatch tests had a hard-coded ``submitted_at=
"2026-05-09T21:00:00+00:00"`` fixture. As of wall-clock
``2026-05-10T21:00:00+00:00`` (the 24 h SLA boundary), the fixtures
flipped from "in-flight" to "expired", so every test that exercises
the live-batch path started flapping into the EXPIRED branch
unintentionally. Confirmed independently broken on ``main`` HEAD
before this PR.

* New helper ``_recent_submitted_at()`` in
  ``tests/unit/ai/test_batch_dispatch.py`` returns
  ``datetime.now(UTC).isoformat()``, so each fixture is anchored to
  test-run time and the expiry guard only activates when explicitly
  asserted (via ``patch.object`` on ``is_potentially_expired``).
* All 8 hard-coded sites replaced. Tests previously testing the
  EXPIRED branch (which patch ``is_potentially_expired``) continue
  to assert that path correctly.

Verification
============

* All five CI gate scripts pass locally.
* **1788 unit + integration/e2e tests pass** — same count as PR
  #323 (one test renamed; no net add/remove).
* No noqa directives added; three removed.

Closes #316
Closes #318

https://claude.ai/code/session_01FJofNMfuZcb7vcWoLfj37U