### PR TITLE
chore(precommit): restore pre-commit-green baseline (#376)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,6 +149,13 @@
         "hashed_secret": "ef3e11d2d069697256586c90466ab203e528b84e",
         "is_verified": false,
         "line_number": 231
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/ai/test_orchestrator_integration.py",
+        "hashed_secret": "3ce915a1bc54e373d86dda99bf31e9f95221a4f3",
+        "is_verified": false,
+        "line_number": 324
       }
     ],
     "tests/unit/ai/test_orchestrator.py": [
@@ -157,23 +164,41 @@
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 177
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "01c92a77244f5e8e3b1e566c4a9266e724de6d98",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 401
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 468
+        "line_number": 474
+      }
+    ],
+    "tests/unit/ai/test_orchestrator_batch.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/ai/test_orchestrator_batch.py",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "tests/unit/test_cli_mocked.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_cli_mocked.py",
+        "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
+        "is_verified": false,
+        "line_number": 1464
       }
     ]
   },
-  "generated_at": "2026-03-10T23:18:26Z"
+  "generated_at": "2026-05-30T02:06:58Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,7 +350,10 @@ min_confidence = 80
 paths = ["start_green_stay_green"]
 exclude = ["tests/", "reference/", "templates/"]
 ignore_decorators = ["@app.command", "@router.get", "@router.post"]
-ignore_names = []
+# BatchCreateRequest is used only inside a string-literal cast annotation
+# (cast("Iterable[BatchCreateRequest]", payload) in ai/orchestrator.py), which
+# vulture cannot resolve, so it is flagged as an unused import false positive.
+ignore_names = ["BatchCreateRequest"]
 
 # Radon complexity
 [tool.radon]

--- a/start_green_stay_green/ai/batch.py
+++ b/start_green_stay_green/ai/batch.py
@@ -231,7 +231,7 @@ def _tool_use_result_from_message(message: object) -> ToolUseResult:
     usage = _extract_attr(message, "usage")
     return ToolUseResult(
         tool_name=str(_extract_attr(tool_block, "name") or ""),
-        tool_input=dict(tool_input),
+        tool_input=tool_input.copy(),
         token_usage=TokenUsage(
             input_tokens=_int_attr(usage, "input_tokens"),
             output_tokens=_int_attr(usage, "output_tokens"),

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -760,7 +760,7 @@ class AIOrchestrator:
         batch = await self._create_batch(payload)
         return BatchSubmission(
             batch_id=str(getattr(batch, "id", "") or ""),
-            custom_ids=list(custom_ids),
+            custom_ids=custom_ids.copy(),
             submitted_at=datetime.now(UTC).isoformat(),
         )
 
@@ -978,7 +978,7 @@ class AIOrchestrator:
         return {
             "model": self.model,
             "max_tokens": _MAX_TOKENS,
-            "system": list(system_blocks),
+            "system": system_blocks.copy(),
             "tools": [tool_schema],
             "tool_choice": {"type": "tool", "name": raw_name},
             "messages": [

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -2035,8 +2035,7 @@ def _hash_subagents_inputs(project_name: str, language: str) -> str:
     for agent_name, source_file in REQUIRED_AGENTS.items():
         source_path = REFERENCE_AGENTS_DIR / source_file
         body = _read_reference_or_warn(source_path, f"subagent '{agent_name}'")
-        parts.append(f"agent={agent_name}\x00")
-        parts.append(body)
+        parts.extend((f"agent={agent_name}\x00", body))
     return hash_inputs(parts)
 
 

--- a/start_green_stay_green/utils/enhance_state.py
+++ b/start_green_stay_green/utils/enhance_state.py
@@ -236,7 +236,7 @@ class EnhanceState:
         self.batch = BatchProgress(
             batch_id=batch_id,
             submitted_at=submitted_at,
-            custom_id_map=dict(custom_id_map),
+            custom_id_map=custom_id_map.copy(),
         )
         self.last_run = submitted_at
 

--- a/tests/unit/ai/test_batch.py
+++ b/tests/unit/ai/test_batch.py
@@ -53,7 +53,7 @@ def _success_entry(
                         "input": tool_input or {"tuned_content": "X", "changes": ["c"]},
                     },
                 ],
-                "usage": usage if usage is not None else dict(_DEFAULT_USAGE),
+                "usage": usage if usage is not None else _DEFAULT_USAGE.copy(),
             },
         },
     }
@@ -259,8 +259,8 @@ class TestBatchResultsBundle:
 
     def test_default_constructor_yields_empty_maps(self) -> None:
         bundle = BatchResultsBundle()
-        assert bundle.successes == {}
-        assert bundle.failures == {}
+        assert not bundle.successes
+        assert not bundle.failures
         assert bundle.total == 0
 
 

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -315,7 +315,7 @@ class TestResumeSubagentBatchEnded:
 
         assert outcome.status == ResumeStatus.ENDED
         assert outcome.succeeded_agents == ("alpha", "beta")
-        assert outcome.failed_agents == ()
+        assert not outcome.failed_agents
         # Files written.
         agents_dir = tmp_path / ".claude" / "agents"
         assert (agents_dir / "alpha.md").read_text(encoding="utf-8")

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -239,7 +239,7 @@ class TestFetchBatchResults:
 
         assert isinstance(bundle, BatchResultsBundle)
         assert set(bundle.successes) == {"subagent:a", "subagent:b"}
-        assert bundle.failures == {}
+        assert not bundle.failures
         assert isinstance(bundle.successes["subagent:a"], ToolUseResult)
 
     @pytest.mark.asyncio

--- a/tests/unit/ai/test_tuner.py
+++ b/tests/unit/ai/test_tuner.py
@@ -285,7 +285,7 @@ class TestContentTunerToolUseParsing:
             {"tuned_content": "Unchanged", "changes": []}
         )
         assert content == "Unchanged"
-        assert changes == []
+        assert not changes
 
     def test_drops_blank_change_strings(self) -> None:
         """Blank/non-string entries in ``changes`` are silently dropped."""
@@ -303,7 +303,7 @@ class TestContentTunerToolUseParsing:
         _content, changes = ContentTuner._parse_tool_use_input(
             {"tuned_content": "Body"}
         )
-        assert changes == []
+        assert not changes
 
     def test_non_string_content_raises_generation_error(self) -> None:
         """A bogus ``tuned_content`` type is a hard error, not a silent fallback.

--- a/tests/unit/utils/test_enhance_state.py
+++ b/tests/unit/utils/test_enhance_state.py
@@ -71,7 +71,7 @@ class TestEnhanceState:
         state = EnhanceState()
         assert state.version == STATE_FILE_VERSION
         assert state.last_run == ""
-        assert state.completed == {}
+        assert not state.completed
 
     def test_is_unchanged_returns_false_for_unknown_target(self) -> None:
         """A target that has never been tuned can never be "unchanged"."""
@@ -141,7 +141,7 @@ class TestEnhanceState:
     def test_from_dict_handles_missing_completed(self) -> None:
         """``completed`` absent from payload → empty dict, no crash."""
         loaded = EnhanceState.from_dict({"version": 1})
-        assert loaded.completed == {}
+        assert not loaded.completed
 
 
 class TestStateRoundTripOnDisk:
@@ -159,7 +159,7 @@ class TestStateRoundTripOnDisk:
     def test_load_state_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
         """No state file → empty state (so first runs aren't flagged as changes)."""
         loaded = load_state(tmp_path)
-        assert loaded.completed == {}
+        assert not loaded.completed
 
     def test_load_state_returns_empty_on_invalid_json(self, tmp_path: Path) -> None:
         """Garbage in the state file degrades to empty state, not a crash."""
@@ -168,7 +168,7 @@ class TestStateRoundTripOnDisk:
         path.write_text("not valid json {", encoding="utf-8")
 
         loaded = load_state(tmp_path)
-        assert loaded.completed == {}
+        assert not loaded.completed
 
     def test_load_state_returns_empty_when_payload_is_not_dict(
         self, tmp_path: Path
@@ -179,7 +179,7 @@ class TestStateRoundTripOnDisk:
         path.write_text("[1, 2, 3]", encoding="utf-8")
 
         loaded = load_state(tmp_path)
-        assert loaded.completed == {}
+        assert not loaded.completed
 
     def test_save_state_creates_parent_directory(self, tmp_path: Path) -> None:
         """``.claude/`` is created on first save (no init step required)."""

--- a/tests/unit/utils/test_timing.py
+++ b/tests/unit/utils/test_timing.py
@@ -66,7 +66,7 @@ class TestTimingReport:
         report.record_api_call(APICallRecord(latency_s=0.5))
 
         assert len(report.api_calls) == 1
-        assert report.steps == []
+        assert not report.steps
 
     def test_aggregate_token_totals(self) -> None:
         report = TimingReport()
@@ -224,5 +224,5 @@ class TestMaybeCollectTimingExceptionPath:
         with pytest.raises(ValueError, match="bare"):
             self._explode_bare()
 
-        assert list(tmp_path.iterdir()) == []
+        assert not list(tmp_path.iterdir())
         assert get_active_report() is None


### PR DESCRIPTION
## Summary

Restores `pre-commit run --all-files` to **fully green** on `main`. The baseline had silently drifted red on three hooks that aren't in the required CI checks, blocking Gate 1 for every new PR.

Closes #376.

## Changes (zero behavior change)

1. **refurb (19 findings)** — semantics-preserving FURB113/115/123 rewrites (`dict(x)`/`list(x)` → `.copy()` where the type is confirmed; `== {}`/`== []`/`== ()` → `not x` in test asserts; append/append → `extend`).
2. **vulture (false positive)** — `BatchCreateRequest` is used only inside the string-literal `cast("Iterable[BatchCreateRequest]", ...)` at `orchestrator.py:799`, which vulture can't resolve. Added to `[tool.vulture] ignore_names` with an explanatory comment; import kept intact (removing it would break the cast).
3. **detect-secrets** — regenerated the stale `.secrets.baseline` (line-number/`generated_at` drift since 2026-03-10, plus three audited fake test fixtures that were missing from the baseline). All verified as non-secrets; no real secret introduced. Hook is now stable across runs.

## Verification

- `pre-commit run --all-files`: **29 hooks passed, 0 failed** (only the no-applicable-files symlink skip).
- `./scripts/check-all.sh`: 7/7, coverage 92.91%, 1663 tests pass.
- No `--no-verify`, no `SKIP`, no unjustified `noqa`/`type: ignore`.

## Why foundational

Unblocks the entire open-backlog drive — #341, #351, #307 and all language tracks branch off `main` and must pass Gate 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
