### PR TITLE
feat(go): add architecture-enforcement parity (#341)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,9 +196,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1464
+        "line_number": 1494
       }
     ]
   },
-  "generated_at": "2026-05-30T02:06:58Z"
+  "generated_at": "2026-05-31T03:24:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1464
+        "line_number": 1494
       }
     ]
   },
-  "generated_at": "2026-05-31T03:55:46Z"
+  "generated_at": "2026-05-31T15:55:28Z"
 }

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1022,18 +1022,18 @@ def _generate_architecture_step(
     """Generate architecture rules.
 
     Architecture configuration is fully deterministic (import-linter for
-    Python, dependency-cruiser for TypeScript). Runs regardless of API
-    key availability; only Python and TypeScript projects produce output.
-    The previous ``orchestrator`` argument was unused and has been
-    removed from this private helper.
+    Python, dependency-cruiser for TypeScript, go-arch-lint for Go). Runs
+    regardless of API key availability; only Python, TypeScript, and Go
+    projects produce output. The previous ``orchestrator`` argument was
+    unused and has been removed from this private helper.
     """
-    if language not in {"python", "typescript"}:
-        # The generator only supports these two; surface a dim info line
-        # so users understand why no architecture rules were generated
-        # for, e.g., a Go or Rust project rather than seeing silence.
+    if language not in {"python", "typescript", "go"}:
+        # The generator only supports these languages; surface a dim info
+        # line so users understand why no architecture rules were generated
+        # for, e.g., a Rust project rather than seeing silence.
         console.print(
             f"[dim]Architecture rules unavailable for {language} "
-            "(supported: python, typescript)[/dim]"
+            "(supported: python, typescript, go)[/dim]"
         )
         return
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -1,7 +1,7 @@
 """Architecture enforcement generator.
 
-Generates architecture validation configuration for import-linter (Python)
-and dependency-cruiser (TypeScript).
+Generates architecture validation configuration for import-linter (Python),
+dependency-cruiser (TypeScript), and go-arch-lint (Go).
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ class ArchitectureResult:
     Attributes:
         output_dir: Directory containing generated files.
         files_created: List of files created.
-        language: Target language (python, typescript).
+        language: Target language (python, typescript, go).
     """
 
     output_dir: Path
@@ -30,12 +30,59 @@ class ArchitectureResult:
     language: str
 
 
+@dataclass(frozen=True)
+class _LanguageTooling:
+    """Per-language architecture tooling metadata.
+
+    Attributes:
+        tool: Human-readable name of the enforcement tool.
+        config_file: Name of the generated configuration file.
+        install_cmd: Shell command to install the tool.
+        run_cmd: Shell command to run the architecture check directly.
+        docs_url: URL to the tool's documentation.
+    """
+
+    tool: str
+    config_file: str
+    install_cmd: str
+    run_cmd: str
+    docs_url: str
+
+
+# Maps each supported language to its architecture-enforcement tooling.
+# Keeping the metadata in one place lets the README and run-script
+# generators stay tool-agnostic and avoids per-language branching.
+_LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
+    "python": _LanguageTooling(
+        tool="import-linter",
+        config_file=".importlinter",
+        install_cmd="pip install import-linter",
+        run_cmd="lint-imports --config .importlinter",
+        docs_url="https://import-linter.readthedocs.io/",
+    ),
+    "typescript": _LanguageTooling(
+        tool="dependency-cruiser",
+        config_file=".dependency-cruiser.js",
+        install_cmd="npm install -g dependency-cruiser",
+        run_cmd="depcruise --config .dependency-cruiser.js src",
+        docs_url="https://github.com/sverweij/dependency-cruiser",
+    ),
+    "go": _LanguageTooling(
+        tool="go-arch-lint",
+        config_file=".go-arch-lint.yml",
+        install_cmd=("go install github.com/fe3dback/go-arch-lint@latest"),
+        run_cmd="go-arch-lint check --arch-file .go-arch-lint.yml",
+        docs_url="https://github.com/fe3dback/go-arch-lint",
+    ),
+}
+
+
 class ArchitectureEnforcementGenerator:
     """Generates architecture enforcement configuration.
 
-    Generates import-linter config for Python and dependency-cruiser
-    config for TypeScript to enforce layer separation and prevent
-    circular dependencies.
+    Generates import-linter config for Python, dependency-cruiser
+    config for TypeScript, and go-arch-lint config for Go to enforce
+    layer separation and prevent circular dependencies.
 
     Attributes:
         orchestrator: AI orchestrator for content generation.
@@ -82,7 +129,7 @@ class ArchitectureEnforcementGenerator:
         """Generate architecture enforcement configuration.
 
         Args:
-            language: Target language (python, typescript).
+            language: Target language (python, typescript, go).
             project_name: Name of the project.
 
         Returns:
@@ -91,7 +138,7 @@ class ArchitectureEnforcementGenerator:
         Raises:
             ValueError: If language is not supported.
         """
-        supported_languages = {"python", "typescript"}
+        supported_languages = {"python", "typescript", "go"}
         if language not in supported_languages:
             msg = f"Unsupported language: {language}"
             raise ValueError(msg)
@@ -105,6 +152,8 @@ class ArchitectureEnforcementGenerator:
             files_created.extend(self._generate_python_config(project_name))
         elif language == "typescript":
             files_created.extend(self._generate_typescript_config(project_name))
+        elif language == "go":
+            files_created.extend(self._generate_go_config(project_name))
 
         # Generate README and run script
         files_created.extend(
@@ -250,6 +299,66 @@ module.exports = {
         dc_path.write_text(config_content)
         return [dc_path]
 
+    def _generate_go_config(self, project_name: str) -> list[Path]:  # noqa: ARG002
+        """Generate go-arch-lint configuration for Go.
+
+        go-arch-lint enforces a component map and dependency rules over Go
+        packages, providing the same layer-separation and domain-independence
+        guarantees as import-linter (Python) and dependency-cruiser
+        (TypeScript).
+
+        Args:
+            project_name: Name of the project.
+
+        Returns:
+            List of files created.
+        """
+        config_path = self.output_dir / ".go-arch-lint.yml"
+
+        # Generate go-arch-lint configuration. Components map onto package
+        # globs; the deps section forbids the domain layer from importing
+        # the application, presentation, and infrastructure layers, keeping
+        # business logic pure and dependency-free.
+        config_content = """version: 3
+workdir: .
+
+components:
+  presentation:
+    in: presentation/**
+  application:
+    in: application/**
+  domain:
+    in: domain/**
+  infrastructure:
+    in: infrastructure/**
+
+# Enforce layered architecture:
+#   presentation -> application -> domain
+# and keep the domain layer independent of outer layers.
+deps:
+  presentation:
+    mayDependOn:
+      - application
+      - domain
+  application:
+    mayDependOn:
+      - domain
+  domain:
+    # Domain layer must remain pure: no dependency on application,
+    # presentation, or infrastructure concerns.
+    mayDependOn: []
+  infrastructure:
+    mayDependOn:
+      - domain
+
+# Forbid imports that would create circular dependencies between layers.
+commonComponents:
+  - domain
+"""
+
+        config_path.write_text(config_content)
+        return [config_path]
+
     def _generate_readme(self, language: str, project_name: str) -> Path:
         """Generate README with usage instructions.
 
@@ -262,17 +371,10 @@ module.exports = {
         """
         readme_path = self.output_dir / "README.md"
 
-        tool = "import-linter" if language == "python" else "dependency-cruiser"
-        install_cmd = (
-            "pip install import-linter"
-            if language == "python"
-            else "npm install -g dependency-cruiser"
-        )
-        run_cmd = (
-            "lint-imports"
-            if language == "python"
-            else "depcruise --config .dependency-cruiser.js src"
-        )
+        tooling = _LANGUAGE_TOOLING[language]
+        tool = tooling.tool
+        install_cmd = tooling.install_cmd
+        run_cmd = tooling.run_cmd
 
         readme_content = f"""# Architecture Enforcement
 
@@ -337,10 +439,12 @@ The domain layer must remain pure:
 Edit the configuration file:
 - Python: `.importlinter`
 - TypeScript: `.dependency-cruiser.js`
+- Go: `.go-arch-lint.yml`
 
 See documentation:
 - Python: https://import-linter.readthedocs.io/
 - TypeScript: https://github.com/sverweij/dependency-cruiser
+- Go: https://github.com/fe3dback/go-arch-lint
 
 ## Integration
 
@@ -375,37 +479,7 @@ Add to CI pipeline:
         """
         script_path = self.output_dir / "run-check.sh"
 
-        if language == "python":
-            script_content = """#!/usr/bin/env bash
-set -euo pipefail
-
-echo "🏛️  Checking Python architecture with import-linter..."
-
-if ! command -v lint-imports &> /dev/null; then
-    echo "❌ import-linter not found. Install with: pip install import-linter"
-    exit 1
-fi
-
-lint-imports --config plans/architecture/.importlinter
-
-echo "✅ Architecture checks passed!"
-"""
-        else:  # typescript
-            script_content = """#!/usr/bin/env bash
-set -euo pipefail
-
-echo "🏛️  Checking TypeScript architecture with dependency-cruiser..."
-
-if ! command -v depcruise &> /dev/null; then
-    echo "❌ dependency-cruiser not found."
-    echo "Install with: npm install -g dependency-cruiser"
-    exit 1
-fi
-
-depcruise --config plans/architecture/.dependency-cruiser.js src
-
-echo "✅ Architecture checks passed!"
-"""
+        script_content = self._build_run_script(language)
 
         script_path.write_text(script_content)
 
@@ -413,3 +487,46 @@ echo "✅ Architecture checks passed!"
         script_path.chmod(0o755)
 
         return script_path
+
+    @staticmethod
+    def _build_run_script(language: str) -> str:
+        """Build the run-check.sh contents for a language.
+
+        Derives the command and the binary-availability guard from the
+        shared :data:`_LANGUAGE_TOOLING` metadata so adding a language
+        requires no changes here.
+
+        Args:
+            language: Target language.
+
+        Returns:
+            The shell script source for run-check.sh.
+        """
+        tooling = _LANGUAGE_TOOLING[language]
+        display = {
+            "python": "Python",
+            "typescript": "TypeScript",
+            "go": "Go",
+        }[language]
+        # The first token of run_cmd is the binary to probe with command -v.
+        binary = tooling.run_cmd.split()[0]
+        # Prefix the relative config path in run_cmd with plans/architecture/
+        # so the script works when invoked from the project root.
+        full_cmd = tooling.run_cmd.replace(
+            tooling.config_file,
+            f"plans/architecture/{tooling.config_file}",
+        )
+        return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🏛️  Checking {display} architecture with {tooling.tool}..."
+
+if ! command -v {binary} &> /dev/null; then
+    echo "❌ {tooling.tool} not found. Install with: {tooling.install_cmd}"
+    exit 1
+fi
+
+{full_cmd}
+
+echo "✅ Architecture checks passed!"
+"""

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -38,8 +38,13 @@ class _LanguageTooling:
         tool: Human-readable name of the enforcement tool.
         config_file: Name of the generated configuration file.
         install_cmd: Shell command to install the tool.
-        run_cmd: Shell command to run the architecture check directly.
+        run_cmd: Run-command template with a ``{config_file}`` placeholder
+            (e.g. ``"lint-imports --config {config_file}"``). The placeholder
+            is filled with the (optionally path-prefixed) config filename at
+            the call site, avoiding fragile substring replacement.
         docs_url: URL to the tool's documentation.
+        display_name: Capitalized language label for human-readable output
+            (e.g. ``"Python"``, ``"TypeScript"``, ``"Go"``).
     """
 
     tool: str
@@ -47,6 +52,7 @@ class _LanguageTooling:
     install_cmd: str
     run_cmd: str
     docs_url: str
+    display_name: str
 
 
 # Maps each supported language to its architecture-enforcement tooling.
@@ -57,22 +63,25 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         tool="import-linter",
         config_file=".importlinter",
         install_cmd="pip install import-linter",
-        run_cmd="lint-imports --config .importlinter",
+        run_cmd="lint-imports --config {config_file}",
         docs_url="https://import-linter.readthedocs.io/",
+        display_name="Python",
     ),
     "typescript": _LanguageTooling(
         tool="dependency-cruiser",
         config_file=".dependency-cruiser.js",
         install_cmd="npm install -g dependency-cruiser",
-        run_cmd="depcruise --config .dependency-cruiser.js src",
+        run_cmd="depcruise --config {config_file} src",
         docs_url="https://github.com/sverweij/dependency-cruiser",
+        display_name="TypeScript",
     ),
     "go": _LanguageTooling(
         tool="go-arch-lint",
         config_file=".go-arch-lint.yml",
         install_cmd=("go install github.com/fe3dback/go-arch-lint@latest"),
-        run_cmd="go-arch-lint check --arch-file .go-arch-lint.yml",
+        run_cmd="go-arch-lint check --arch-file {config_file}",
         docs_url="https://github.com/fe3dback/go-arch-lint",
+        display_name="Go",
     ),
 }
 
@@ -299,6 +308,9 @@ module.exports = {
         dc_path.write_text(config_content)
         return [dc_path]
 
+    # ARG002: project_name is unused but kept for API parity with
+    # _generate_python_config / _generate_typescript_config so the
+    # generate() dispatch can call every _generate_*_config uniformly.
     def _generate_go_config(self, project_name: str) -> list[Path]:  # noqa: ARG002
         """Generate go-arch-lint configuration for Go.
 
@@ -374,7 +386,9 @@ commonComponents:
         tooling = _LANGUAGE_TOOLING[language]
         tool = tooling.tool
         install_cmd = tooling.install_cmd
-        run_cmd = tooling.run_cmd
+        # Manual invocation runs from the config directory, so the bare
+        # config filename is correct here (no plans/architecture/ prefix).
+        run_cmd = tooling.run_cmd.format(config_file=tooling.config_file)
 
         readme_content = f"""# Architecture Enforcement
 
@@ -503,23 +517,19 @@ Add to CI pipeline:
             The shell script source for run-check.sh.
         """
         tooling = _LANGUAGE_TOOLING[language]
-        display = {
-            "python": "Python",
-            "typescript": "TypeScript",
-            "go": "Go",
-        }[language]
         # The first token of run_cmd is the binary to probe with command -v.
         binary = tooling.run_cmd.split()[0]
-        # Prefix the relative config path in run_cmd with plans/architecture/
-        # so the script works when invoked from the project root.
-        full_cmd = tooling.run_cmd.replace(
-            tooling.config_file,
-            f"plans/architecture/{tooling.config_file}",
+        # Fill the {config_file} placeholder with the path-prefixed config so
+        # the script works when invoked from the project root. Using the
+        # template (rather than substring replacement) keeps the substitution
+        # immune to accidental collisions with other tokens in run_cmd.
+        full_cmd = tooling.run_cmd.format(
+            config_file=f"plans/architecture/{tooling.config_file}",
         )
         return f"""#!/usr/bin/env bash
 set -euo pipefail
 
-echo "🏛️  Checking {display} architecture with {tooling.tool}..."
+echo "🏛️  Checking {tooling.display_name} architecture with {tooling.tool}..."
 
 if ! command -v {binary} &> /dev/null; then
     echo "❌ {tooling.tool} not found. Install with: {tooling.install_cmd}"

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -147,7 +147,7 @@ class ArchitectureEnforcementGenerator:
         Raises:
             ValueError: If language is not supported.
         """
-        supported_languages = {"python", "typescript", "go"}
+        supported_languages = frozenset(_LANGUAGE_TOOLING)
         if language not in supported_languages:
             msg = f"Unsupported language: {language}"
             raise ValueError(msg)
@@ -363,7 +363,7 @@ deps:
     mayDependOn:
       - domain
 
-# Forbid imports that would create circular dependencies between layers.
+# domain is available to all components without an explicit deps entry.
 commonComponents:
   - domain
 """

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -9,6 +9,8 @@ from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.generators.architecture import (
     ArchitectureEnforcementGenerator,
 )
+from start_green_stay_green.generators.architecture import _LANGUAGE_TOOLING
+from start_green_stay_green.generators.architecture import _LanguageTooling
 
 
 class TestArchitectureEnforcementGeneratorInit:
@@ -255,6 +257,35 @@ class TestArchitectureEnforcementGeneratorGo:
 
         assert result.language == "go"
 
+    def test_go_run_script_uses_display_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Go run-check.sh announces the 'Go' display name."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "Checking Go architecture" in script
+
+    def test_go_run_script_prefixes_config_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Go run-check.sh points at the plans/architecture config."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert (
+            "go-arch-lint check --arch-file plans/architecture/.go-arch-lint.yml"
+            in script
+        )
+
 
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
@@ -290,3 +321,68 @@ class TestArchitectureEnforcementGeneratorTypeScript:
 
         # Should check for circular dependencies
         assert "circular" in content.lower() or "cycle" in content.lower()
+
+
+class TestLanguageTooling:
+    """Test the shared _LanguageTooling / _LANGUAGE_TOOLING metadata."""
+
+    @pytest.mark.parametrize(
+        ("language", "expected_display"),
+        [
+            ("python", "Python"),
+            ("typescript", "TypeScript"),
+            ("go", "Go"),
+        ],
+    )
+    def test_each_tooling_carries_a_display_name(
+        self, language: str, expected_display: str
+    ) -> None:
+        """Display name is a single-source-of-truth field on the dataclass."""
+        assert _LANGUAGE_TOOLING[language].display_name == expected_display
+
+    @pytest.mark.parametrize("language", ["python", "typescript", "go"])
+    def test_run_cmd_is_a_config_file_template(self, language: str) -> None:
+        """run_cmd holds a {config_file} placeholder, not a literal path."""
+        tooling = _LANGUAGE_TOOLING[language]
+        assert "{config_file}" in tooling.run_cmd
+        # Filling the template reproduces the bare-config invocation.
+        filled = tooling.run_cmd.format(config_file=tooling.config_file)
+        assert tooling.config_file in filled
+        assert "{config_file}" not in filled
+
+    def test_build_run_script_uses_display_name_not_a_dict(self) -> None:
+        """_build_run_script reads display_name from the dataclass."""
+        for language in _LANGUAGE_TOOLING:
+            script = ArchitectureEnforcementGenerator._build_run_script(language)
+            assert _LANGUAGE_TOOLING[language].display_name in script
+
+    def test_build_run_script_prefixes_config_via_template(self) -> None:
+        """The plans/architecture prefix is inserted via the template."""
+        for language, tooling in _LANGUAGE_TOOLING.items():
+            script = ArchitectureEnforcementGenerator._build_run_script(language)
+            assert f"plans/architecture/{tooling.config_file}" in script
+
+    def test_template_prefix_immune_to_substring_collision(self) -> None:
+        """A config filename that is a prefix of a flag is filled correctly.
+
+        The template approach must not misfire when ``config_file`` happens
+        to be a substring of another token in ``run_cmd`` — something the
+        old ``str.replace`` approach was vulnerable to.
+        """
+        tooling = _LanguageTooling(
+            tool="phony-lint",
+            config_file="arch.yml",
+            install_cmd="install phony-lint",
+            # 'arch.yml' is also a substring of the '--arch.yml-strict' flag.
+            run_cmd="phony-lint --arch.yml-strict check {config_file}",
+            docs_url="https://example.com",
+            display_name="Phony",
+        )
+        full_cmd = tooling.run_cmd.format(
+            config_file=f"plans/architecture/{tooling.config_file}",
+        )
+        # Only the {config_file} placeholder is expanded; the look-alike
+        # flag token is left untouched.
+        assert "--arch.yml-strict" in full_cmd
+        assert "plans/architecture/arch.yml" in full_cmd
+        assert "plans/architecture/--arch.yml-strict" not in full_cmd

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -163,6 +163,99 @@ class TestArchitectureEnforcementGeneratorPython:
         assert "circular" in content.lower() or "cycle" in content.lower()
 
 
+class TestArchitectureEnforcementGeneratorGo:
+    """Test Go-specific architecture rules."""
+
+    def test_generate_go_creates_go_arch_lint_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test generating go-arch-lint config for Go."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="test-project")
+
+        # Should create the go-arch-lint config file
+        config_file = output_dir / ".go-arch-lint.yml"
+        assert config_file.exists()
+
+        # Should create README and run script
+        assert (output_dir / "README.md").exists()
+        assert (output_dir / "run-check.sh").exists()
+
+    def test_go_config_enforces_layer_separation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test Go config enforces layered architecture components."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        config = (output_dir / ".go-arch-lint.yml").read_text()
+
+        # Should define the architecture layers as components
+        assert "components" in config.lower()
+        assert "domain" in config.lower()
+        assert "presentation" in config.lower()
+
+    def test_go_config_enforces_domain_independence(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test Go config keeps the domain layer dependency-free."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        config = (output_dir / ".go-arch-lint.yml").read_text()
+
+        # Domain dependency rules must be present (deps section)
+        assert "deps" in config.lower()
+        assert "infrastructure" in config.lower()
+
+    def test_go_readme_mentions_go_arch_lint(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Go README references the go-arch-lint tooling."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        readme = (output_dir / "README.md").read_text()
+        assert "go-arch-lint" in readme
+
+    def test_go_run_script_invokes_go_arch_lint(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Go run-check.sh script invokes go-arch-lint."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "go-arch-lint" in script
+
+    def test_go_result_reports_go_language(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the result object records the Go language."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        result = generator.generate(language="go", project_name="myapp")
+
+        assert result.language == "go"
+
+
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
 

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -219,6 +219,32 @@ class TestArchitectureEnforcementGeneratorGo:
         assert "deps" in config.lower()
         assert "infrastructure" in config.lower()
 
+    def test_go_config_common_components_comment_is_accurate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """commonComponents is documented as a whitelist, not a cycle guard.
+
+        ``commonComponents`` in go-arch-lint v3 is a whitelist: every
+        component may import the listed components without an explicit
+        ``deps`` entry. It does not detect circular dependencies, so the
+        config must not claim that it does.
+        """
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        generator.generate(language="go", project_name="myapp")
+
+        config = (output_dir / ".go-arch-lint.yml").read_text()
+
+        # The misleading cycle-detection claim must be gone.
+        assert "circular dependencies between layers" not in config
+        # An accurate whitelist description must precede commonComponents.
+        assert (
+            "# domain is available to all components without an explicit "
+            "deps entry." in config
+        )
+
     def test_go_readme_mentions_go_arch_lint(
         self,
         tmp_path: Path,
@@ -386,3 +412,26 @@ class TestLanguageTooling:
         assert "--arch.yml-strict" in full_cmd
         assert "plans/architecture/arch.yml" in full_cmd
         assert "plans/architecture/--arch.yml-strict" not in full_cmd
+
+    def test_supported_languages_match_tooling_keys(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """generate() accepts exactly the languages with tooling metadata.
+
+        ``supported_languages`` is derived from ``_LANGUAGE_TOOLING`` so the
+        accepted-language set and the tooling map cannot drift apart. Every
+        tooling key must generate without raising, and a key-less language
+        must be rejected.
+        """
+        generator = ArchitectureEnforcementGenerator(
+            output_dir=tmp_path / "plans" / "architecture"
+        )
+
+        for language in _LANGUAGE_TOOLING:
+            result = generator.generate(language=language, project_name="myapp")
+            assert result.language == language
+
+        assert "rust" not in _LANGUAGE_TOOLING
+        with pytest.raises(ValueError, match="Unsupported language"):
+            generator.generate(language="rust", project_name="myapp")

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1247,6 +1247,36 @@ class TestGenerateSteps:
 
         mock_generator.generate.assert_called()
 
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_go(self, mock_generator_class: Mock) -> None:
+        """Test _generate_architecture_step generates rules for Go."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "go")
+
+        # Go now has architecture parity: the generator must be invoked.
+        mock_generator.generate.assert_called_once()
+        assert mock_generator.generate.call_args.kwargs["language"] == "go"
+
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_skips_unsupported(
+        self, mock_generator_class: Mock
+    ) -> None:
+        """Test unsupported languages skip architecture generation."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "ruby")
+
+        mock_generator.generate.assert_not_called()
+
     @patch("start_green_stay_green.cli.run_async")
     @patch("start_green_stay_green.cli.SubagentsGenerator")
     def test_generate_subagents_step(

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -160,6 +160,29 @@ class TestMultiLanguageGeneration:
             assert calls[1][0][2] == "go"
 
 
+class TestMultiLanguageArchitectureParity:
+    """Test that Go has architecture-enforcement parity (#341)."""
+
+    def test_go_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
+        """Go must emit an architecture-enforcement config like py/ts."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "go")
+
+        config = tmp_path / "plans" / "architecture" / ".go-arch-lint.yml"
+        assert config.exists(), "Go init must emit a go-arch-lint config"
+
+    @pytest.mark.parametrize("language", ["python", "typescript", "go"])
+    def test_supported_languages_emit_architecture_config(
+        self, tmp_path: Path, language: str
+    ) -> None:
+        """Every supported language produces architecture rules."""
+        project = tmp_path / language
+        cli_mod._generate_architecture_step(project, "my-project", language)
+
+        arch_dir = project / "plans" / "architecture"
+        assert (arch_dir / "README.md").exists()
+        assert (arch_dir / "run-check.sh").exists()
+
+
 class TestMultiLanguageScriptsDir:
     """Test multi-language scripts use subdirectories (#262)."""
 


### PR DESCRIPTION
## Summary
- Adds Go to `architecture.py` `supported_languages` with a new `_generate_go_config()` emitting a go-arch-lint v3 component map (layered `presentation→application→domain` + domain independence), parallel to the Python (import-linter) / TypeScript (dependency-cruiser) branches.
- Refactors README + run-script generation behind a `_LANGUAGE_TOOLING` mapping (`_LanguageTooling` dataclass) + `_build_run_script()` helper to keep complexity ≤10 while adding Go.
- CLI `_generate_architecture_step` gate now includes `go`.

## Test plan
- New `TestArchitectureEnforcementGeneratorGo` (6 tests: config emission, layer separation, domain independence, README tooling, run-script, result language); architecture.py module coverage 98.84%.
- `test_generate_architecture_step_go` + `test_generate_architecture_step_skips_unsupported` in test_cli_mocked.py.
- `TestMultiLanguageArchitectureParity` in test_multi_language.py (go end-to-end + parametrized parity python/typescript/go).
- `./scripts/check-all.sh` green; `pre-commit run --all-files` 29/29 pass; full suite 1675 passed.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
