### PR TITLE
refactor(timing): migrate _active_report to contextvars.ContextVar (#307)

### DIFF
--- a/start_green_stay_green/utils/timing.py
+++ b/start_green_stay_green/utils/timing.py
@@ -12,6 +12,7 @@ Phase 0 of the optimization roadmap relies on this module to baseline
 from __future__ import annotations
 
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from dataclasses import field
 import json
@@ -203,33 +204,33 @@ class TimingReport:
         )
 
 
-# Process-global active report. Correct for both sequential ``green init``
-# and the Phase 2 ``asyncio.gather`` fan-out (every concurrent subagent
-# task should accumulate into the same report). Issue #307 tracks
-# migrating this to ``contextvars.ContextVar`` before Phase 3 / Phase 5
-# introduce per-task timing scopes that need independent reports.
-_active_report: TimingReport | None = None
-_active_lock = threading.Lock()
+# Active report held in a ``ContextVar`` rather than a process-global. A
+# ``ContextVar`` copies its value into each task's context at spawn time,
+# so the Phase 2 ``asyncio.gather`` fan-out still attributes every child
+# task's API calls to the parent's report, while concurrent tasks that
+# install their own report (Phase 3 / Phase 5 per-task timing scopes)
+# stay isolated from one another.
+_active_report: ContextVar[TimingReport | None] = ContextVar(
+    "_active_report", default=None
+)
 
 
 def get_active_report() -> TimingReport | None:
     """Return the currently active ``TimingReport``, if any."""
-    with _active_lock:
-        return _active_report
+    return _active_report.get()
 
 
 def set_active_report(report: TimingReport | None) -> None:
-    """Install ``report`` as the active collector for this process.
+    """Install ``report`` as the active collector for the current context.
 
-    Pass ``None`` to disable collection. Calling this from concurrent
-    threads is safe; the most recent caller wins.
+    Pass ``None`` to disable collection. The value is scoped to the
+    current ``contextvars`` context: tasks spawned afterwards inherit it,
+    but sibling tasks (and other threads) are unaffected.
 
     Args:
         report: The report to install, or ``None`` to clear.
     """
-    global _active_report  # noqa: PLW0603 — module-level singleton by design
-    with _active_lock:
-        _active_report = report
+    _active_report.set(report)
 
 
 @contextmanager

--- a/tests/unit/utils/test_timing.py
+++ b/tests/unit/utils/test_timing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import TYPE_CHECKING
@@ -178,6 +179,63 @@ class TestStepTimerContext:
 
         assert report.steps[0].name == "explodes"
         assert report.steps[0].duration_s >= 0
+
+
+class TestActiveReportContextIsolation:
+    """The active report is a ``ContextVar`` with per-task isolation."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_see_their_own_active_report(self) -> None:
+        """Two concurrent tasks each install and observe a distinct report.
+
+        Because ``set_active_report`` mutates a ``ContextVar``, a value set
+        inside one task is invisible to a sibling task running in the same
+        event loop. A process-global singleton would let the last writer
+        clobber the other task's report, so this fails on the old impl.
+        """
+        report_a = TimingReport()
+        report_b = TimingReport()
+        # Barriers force both tasks to interleave: each sets its report,
+        # then waits until the other has also set its own before reading.
+        both_set = asyncio.Event()
+        set_count = 0
+
+        async def _run(report: TimingReport) -> TimingReport | None:
+            nonlocal set_count
+            set_active_report(report)
+            set_count += 1
+            if set_count == 2:  # both tasks have written
+                both_set.set()
+            await both_set.wait()
+            # If the report leaked across tasks, we would observe the
+            # sibling's report (or whichever wrote last).
+            return get_active_report()
+
+        seen_a, seen_b = await asyncio.gather(_run(report_a), _run(report_b))
+
+        assert seen_a is report_a
+        assert seen_b is report_b
+
+    @pytest.mark.asyncio
+    async def test_spawned_task_inherits_parent_active_report(self) -> None:
+        """A task spawned inside an active report inherits it at spawn time.
+
+        This guarantees the Phase 2 ``asyncio.gather`` fan-out still
+        attributes API calls dispatched by child tasks to the parent's
+        report, because ``ContextVar`` copies the context at task creation.
+        """
+        parent_report = TimingReport()
+        set_active_report(parent_report)
+
+        async def _child() -> TimingReport | None:
+            # No explicit set here: the child must inherit the parent's
+            # report from the copied context.
+            return get_active_report()
+
+        first, second = await asyncio.gather(_child(), _child())
+
+        assert first is parent_report
+        assert second is parent_report
 
 
 class TestMaybeCollectTimingExceptionPath:


### PR DESCRIPTION
## Summary
- Replaces the process-global `_active_report` + `threading.Lock` in `utils/timing.py` with `ContextVar("_active_report", default=None)`; `get_active_report`/`set_active_report` become one-liners.
- Retains `TimingReport._lock` (guards the report's own step-stack — orthogonal to the removed singleton lock).
- Drops the now-unneeded `# noqa: PLW0603` and the stale inline "#307 planned" comment.

## Test plan
- New `test_concurrent_tasks_see_their_own_active_report` (per-task isolation; verified RED against the old singleton) and `test_spawned_task_inherits_parent_active_report` (proves Phase-2 gather attribution survives).
- Existing `test_timing.py` passes unchanged; orchestrator gather/attribution tests pass.
- `pre-commit run --all-files` 29/29; timing.py coverage 97.94%; total ≥90%.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
