### PR TITLE
refactor(ai): introduce LLMProvider interface and AnthropicProvider (#381)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,35 +127,35 @@
         "filename": "tests/integration/ai/test_orchestrator_integration.py",
         "hashed_secret": "ba18a817848206af37b2cc770cd77b90c6ddbbbe",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 50
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/ai/test_orchestrator_integration.py",
         "hashed_secret": "6ad8b5ee9cc7241169add44832766d8b11102048",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/ai/test_orchestrator_integration.py",
         "hashed_secret": "61f9b84fe105b8ecd43e5ea7239222030b299047",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 141
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/ai/test_orchestrator_integration.py",
         "hashed_secret": "ef3e11d2d069697256586c90466ab203e528b84e",
         "is_verified": false,
-        "line_number": 231
+        "line_number": 236
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/integration/ai/test_orchestrator_integration.py",
         "hashed_secret": "3ce915a1bc54e373d86dda99bf31e9f95221a4f3",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 329
       }
     ],
     "tests/unit/ai/test_orchestrator.py": [
@@ -164,21 +164,21 @@
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
         "is_verified": false,
-        "line_number": 177
+        "line_number": 182
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "01c92a77244f5e8e3b1e566c4a9266e724de6d98",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 406
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/ai/test_orchestrator.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 474
+        "line_number": 479
       }
     ],
     "tests/unit/ai/test_orchestrator_batch.py": [
@@ -187,7 +187,16 @@
         "filename": "tests/unit/ai/test_orchestrator_batch.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 60
+      }
+    ],
+    "tests/unit/ai/test_providers.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/ai/test_providers.py",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 198
       }
     ],
     "tests/unit/test_cli_mocked.py": [
@@ -200,5 +209,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T02:06:58Z"
+  "generated_at": "2026-05-31T03:55:46Z"
 }

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -1,50 +1,38 @@
 """AI generation orchestrator.
 
-Coordinates AI-powered generation tasks using Claude API.
+Coordinates AI-powered generation tasks using a pluggable
+:class:`~start_green_stay_green.ai.providers.base.LLMProvider`.
+
+As of tracer T1 (#381) this module no longer touches the ``anthropic``
+SDK directly: all Anthropic-specific code (client construction, retry
+/ backoff, token accounting, the Message Batches API) lives in
+:class:`~start_green_stay_green.ai.providers.anthropic_provider.AnthropicProvider`.
+``AIOrchestrator`` owns input validation and the public API surface,
+then delegates the actual generation to an injected provider — by
+default an :class:`AnthropicProvider`, so every existing caller is
+unchanged.
 """
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncIterable
-from dataclasses import dataclass
-from datetime import UTC
-from datetime import datetime
-import time
 from typing import Final
 from typing import Literal
 from typing import TYPE_CHECKING
-from typing import cast
 
-from anthropic import Anthropic
-from anthropic import AsyncAnthropic
-from anthropic.types import TextBlock
-from anthropic.types import ToolUseBlock
-
-from start_green_stay_green.ai.batch import BatchError
-from start_green_stay_green.ai.batch import BatchPoll
-from start_green_stay_green.ai.batch import BatchResultsBundle
-from start_green_stay_green.ai.batch import BatchSubmission
-from start_green_stay_green.ai.batch import ToolUseBatchRequest
-from start_green_stay_green.ai.batch import parse_batch_result_entry
+from start_green_stay_green.ai.providers.anthropic_provider import AnthropicProvider
 from start_green_stay_green.ai.types import GenerationError
 from start_green_stay_green.ai.types import GenerationResult
 from start_green_stay_green.ai.types import TokenUsage
 from start_green_stay_green.ai.types import ToolUseResult
-from start_green_stay_green.utils.timing import APICallRecord
-from start_green_stay_green.utils.timing import get_active_report
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-    from collections.abc import Iterable
-    from collections.abc import Iterator
     from collections.abc import Sequence
 
-    from anthropic.types.messages.batch_create_params import (
-        Request as BatchCreateRequest,
-    )
-
-    from start_green_stay_green.utils.timing import TimingReport
+    from start_green_stay_green.ai.batch import BatchPoll
+    from start_green_stay_green.ai.batch import BatchResultsBundle
+    from start_green_stay_green.ai.batch import BatchSubmission
+    from start_green_stay_green.ai.batch import ToolUseBatchRequest
+    from start_green_stay_green.ai.providers.base import LLMProvider
 
 # Re-export shared types from ``ai.types`` so existing
 # ``from start_green_stay_green.ai.orchestrator import ToolUseResult``
@@ -66,37 +54,6 @@ __all__ = [
 ]
 
 
-def _count(obj: object, name: str) -> int:
-    """Read a count attribute off ``obj``, defaulting to ``0``.
-
-    SDK response objects expose ``request_counts.processing`` etc. as
-    plain ``int`` attributes; tests pass ``MagicMock`` doubles. Keeps
-    ``poll_batch``'s body short enough to stay grade-A complex.
-    """
-    return int(getattr(obj, name, 0) or 0)
-
-
-async def _aiter(
-    stream: AsyncIterable[object] | Iterable[object],
-) -> AsyncIterator[object]:
-    """Yield from an async iterable OR a sync iterable.
-
-    The Anthropic SDK's ``messages.batches.results`` returns an
-    async iterator at runtime, but unit tests construct fakes that
-    are easier to write as plain lists. Accept both shapes so the
-    test seam is wide.
-
-    ``isinstance(stream, AsyncIterable)`` narrows the union for
-    mypy on both branches, so neither path needs a ``type: ignore``.
-    """
-    if isinstance(stream, AsyncIterable):
-        async for item in stream:
-            yield item
-        return
-    for item in stream:
-        yield item
-
-
 class PromptTemplateError(Exception):
     """Raised when prompt template is invalid or malformed."""
 
@@ -112,33 +69,15 @@ class ModelConfig:
     SONNET: Final[str] = "claude-sonnet-4-5-20250929"
 
 
-# Per-call max_tokens for every Claude request the orchestrator
-# issues — sync, async, tool-use, and batch alike. Single source of
-# truth so a future limit change is one edit instead of four.
-_MAX_TOKENS: Final[int] = 4096
-
-
-@dataclass(frozen=True)
-class _AttemptOutcome:
-    """Internal helper: success result or captured retryable error."""
-
-    result: GenerationResult | None
-    error: Exception | None
-
-
-@dataclass(frozen=True)
-class _ToolAttemptOutcome:
-    """Internal helper: ``tool_use`` success or captured retryable error."""
-
-    result: ToolUseResult | None
-    error: Exception | None
-
-
 class AIOrchestrator:
-    """Orchestrates AI generation requests using Claude API.
+    """Orchestrates AI generation requests via an :class:`LLMProvider`.
 
-    This class manages API communication, retry logic, and response
-    parsing for AI-powered generation tasks.
+    This class owns input validation and the stable public API; the
+    actual API communication, retry logic, and response parsing are
+    delegated to the injected provider. By default it constructs an
+    :class:`AnthropicProvider`, so existing callers that pass only an
+    ``api_key`` keep the original Anthropic-backed behavior with no
+    changes.
 
     Attributes:
         api_key: Claude API key for authentication.
@@ -154,6 +93,7 @@ class AIOrchestrator:
         model: str = ModelConfig.SONNET,
         max_retries: int = 3,
         retry_delay: float = 1.0,
+        provider: LLMProvider | None = None,
     ) -> None:
         """Initialize AIOrchestrator with configuration.
 
@@ -162,6 +102,13 @@ class AIOrchestrator:
             model: Claude model identifier. Defaults to SONNET.
             max_retries: Maximum retry attempts. Defaults to 3.
             retry_delay: Initial retry delay in seconds. Defaults to 1.0.
+            provider: Optional pre-built :class:`LLMProvider`. When
+                omitted (the default), an :class:`AnthropicProvider` is
+                constructed from ``api_key``, ``model``, ``max_retries``,
+                and ``retry_delay`` so existing callers are unchanged.
+                Injecting a provider lets later tracers and tests
+                substitute a different backend without touching this
+                class.
 
         Raises:
             ValueError: If api_key is empty or parameters are invalid.
@@ -173,10 +120,12 @@ class AIOrchestrator:
         self.model = model
         self.max_retries = max_retries
         self.retry_delay = retry_delay
-        # Lazily-created long-lived async client. Reusing one client across
-        # all calls in an init run lets us share the underlying httpx pool,
-        # which matters once Phase 2 fans out subagent tunings concurrently.
-        self._async_client: AsyncAnthropic | None = None
+        self._provider: LLMProvider = provider or AnthropicProvider(
+            api_key,
+            model=model,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+        )
 
     @staticmethod
     def _validate_api_key(api_key: str) -> None:
@@ -241,186 +190,12 @@ class AIOrchestrator:
             msg = f"Unsupported output format: {output_format}"
             raise ValueError(msg)
 
-    @staticmethod
-    def _cache_tokens(usage: object) -> tuple[int, int]:
-        """Extract ``(cache_read, cache_creation)`` token counts from ``usage``.
-
-        The Anthropic SDK exposes ``cache_read_input_tokens`` and
-        ``cache_creation_input_tokens`` only when prompt caching is
-        active *and* the SDK version supports them; both fields can be
-        ``None``. Coerce to ``int`` so downstream telemetry never has
-        to defend against ``None``.
-        """
-        return (
-            int(getattr(usage, "cache_read_input_tokens", 0) or 0),
-            int(getattr(usage, "cache_creation_input_tokens", 0) or 0),
-        )
-
-    def _call_api(
-        self,
-        client: Anthropic,
-        prompt: str,
-        output_format: str,
-    ) -> GenerationResult:
-        """Call Claude API and build result.
-
-        Args:
-            client: Anthropic API client.
-            prompt: Generation prompt.
-            output_format: Desired output format.
-
-        Returns:
-            GenerationResult with content and metadata.
-
-        Raises:
-            GenerationError: If response is invalid.
-        """
-        response = client.messages.create(
-            model=self.model,
-            max_tokens=_MAX_TOKENS,
-            system=(
-                f"Generate {output_format} output. "
-                "Follow the instructions precisely."
-            ),
-            messages=[
-                {
-                    "role": "user",
-                    "content": prompt,
-                },
-            ],
-        )
-
-        # Extract content from response
-        first_block = response.content[0]
-        if not isinstance(first_block, TextBlock):
-            msg = "Expected TextBlock in response"
-            raise GenerationError(msg)
-
-        cache_read, cache_creation = self._cache_tokens(response.usage)
-        return GenerationResult(
-            content=first_block.text,
-            format=output_format,
-            token_usage=TokenUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-            ),
-            model=response.model,
-            message_id=response.id,
-            cache_read_tokens=cache_read,
-            cache_creation_tokens=cache_creation,
-        )
-
-    def _retry_with_backoff(
-        self,
-        client: Anthropic,
-        prompt: str,
-        output_format: str,
-    ) -> GenerationResult:
-        """Retry API call with exponential backoff (sync).
-
-        Telemetry is recorded by the call site once after the loop
-        terminates (success or exhaustion). Failure paths never miss a
-        recording because both branches end with ``_record_call``.
-        """
-        report = get_active_report()
-        call_started = time.perf_counter()
-
-        for attempt, sleep_s in self._retry_schedule():
-            outcome = self._attempt_sync(client, prompt, output_format)
-            if outcome.result is not None:
-                self._record_call(report, call_started, attempt, outcome.result)
-                return outcome.result
-            if sleep_s is None:
-                self._record_call(report, call_started, attempt, None)
-                msg = "Failed to generate content"
-                raise GenerationError(msg, cause=outcome.error) from outcome.error
-            time.sleep(sleep_s)
-
-        # ``_retry_schedule`` always yields at least one entry, so this
-        # is unreachable; keep mypy/coverage happy.
-        msg = "Failed to generate content"
-        raise GenerationError(msg)
-
-    def _retry_schedule(self) -> Iterator[tuple[int, float | None]]:
-        """Yield ``(attempt_index, sleep_before_next_or_None)`` pairs."""
-        for attempt in range(self.max_retries + 1):
-            is_last = attempt == self.max_retries
-            yield attempt, None if is_last else self.retry_delay * (2**attempt)
-
-    def _attempt_sync(
-        self,
-        client: Anthropic,
-        prompt: str,
-        output_format: str,
-    ) -> _AttemptOutcome:
-        """Run one sync attempt; return the result or capture the error."""
-        try:
-            return _AttemptOutcome(
-                result=self._call_api(client, prompt, output_format),
-                error=None,
-            )
-        except GenerationError:
-            raise
-        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
-            return _AttemptOutcome(result=None, error=e)
-
-    @staticmethod
-    def _build_api_call_record(
-        latency_s: float,
-        attempt: int,
-        result: GenerationResult | ToolUseResult | None,
-    ) -> APICallRecord:
-        """Build an ``APICallRecord`` from a result, or zeros for failures.
-
-        Extracted from :meth:`_record_call` to keep the recorder at
-        cyclomatic grade A: the four-way ``result and X`` branch chain
-        was tipping it into grade B.
-        """
-        if result is None:
-            return APICallRecord(latency_s=latency_s, retries=attempt)
-        return APICallRecord(
-            latency_s=latency_s,
-            retries=attempt,
-            input_tokens=result.token_usage.input_tokens,
-            output_tokens=result.token_usage.output_tokens,
-            cache_read_tokens=result.cache_read_tokens,
-            cache_creation_tokens=result.cache_creation_tokens,
-        )
-
-    @classmethod
-    def _record_call(
-        cls,
-        report: TimingReport | None,
-        start: float,
-        attempt: int,
-        result: GenerationResult | ToolUseResult | None,
-    ) -> None:
-        """Record a completed call (success or failure) on the active report.
-
-        Args:
-            report: Active timing collector, or ``None`` when telemetry is off.
-            start: ``perf_counter`` value captured before the first attempt.
-            attempt: Zero-indexed attempt number from
-                :meth:`_retry_schedule`. ``attempt=0`` means the first
-                try succeeded with no retries; ``attempt=N`` means
-                ``N`` retries were used. Stored as ``retries`` on the
-                resulting :class:`APICallRecord` because that's the
-                telemetry consumer's preferred naming.
-            result: Successful :class:`GenerationResult` or
-                :class:`ToolUseResult`, or ``None`` when the call
-                failed (so token counts default to 0).
-        """
-        if report is None:
-            return
-        latency_s = time.perf_counter() - start
-        report.record_api_call(cls._build_api_call_record(latency_s, attempt, result))
-
     def generate(
         self,
         prompt: str,
         output_format: Literal["yaml", "toml", "markdown", "bash"],
     ) -> GenerationResult:
-        """Generate content using Claude API (synchronous).
+        """Generate content using the provider (synchronous).
 
         Args:
             prompt: Prompt describing what to generate.
@@ -431,111 +206,11 @@ class AIOrchestrator:
 
         Raises:
             ValueError: If prompt is empty or format unsupported.
-            GenerationError: If API call fails or response invalid.
+            GenerationError: If generation fails or response invalid.
         """
         self._validate_prompt(prompt)
         self._validate_output_format(output_format)
-
-        # Use context manager to ensure httpx client is properly closed
-        with Anthropic(api_key=self._api_key) as client:
-            return self._retry_with_backoff(client, prompt, output_format)
-
-    def _get_async_client(self) -> AsyncAnthropic:
-        """Return the cached ``AsyncAnthropic`` client, creating it once.
-
-        The check-then-set pattern is *not* thread-safe in the abstract,
-        but it is safe under asyncio: there is no ``await`` between the
-        ``is None`` check and the assignment, so no other coroutine can
-        run between them on the same event loop. This method is only
-        ever called from coroutines on a single event loop, never from
-        a thread pool, so adding a lock would be over-engineering. Do
-        *not* call this from ``ThreadPoolExecutor``.
-        """
-        if self._async_client is None:
-            self._async_client = AsyncAnthropic(api_key=self._api_key)
-        return self._async_client
-
-    async def _call_api_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        output_format: str,
-    ) -> GenerationResult:
-        """Async counterpart of :meth:`_call_api`."""
-        response = await client.messages.create(
-            model=self.model,
-            max_tokens=_MAX_TOKENS,
-            system=(
-                f"Generate {output_format} output. "
-                "Follow the instructions precisely."
-            ),
-            messages=[
-                {
-                    "role": "user",
-                    "content": prompt,
-                },
-            ],
-        )
-
-        first_block = response.content[0]
-        if not isinstance(first_block, TextBlock):
-            msg = "Expected TextBlock in response"
-            raise GenerationError(msg)
-
-        cache_read, cache_creation = self._cache_tokens(response.usage)
-        return GenerationResult(
-            content=first_block.text,
-            format=output_format,
-            token_usage=TokenUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-            ),
-            model=response.model,
-            message_id=response.id,
-            cache_read_tokens=cache_read,
-            cache_creation_tokens=cache_creation,
-        )
-
-    async def _retry_with_backoff_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        output_format: str,
-    ) -> GenerationResult:
-        """Async retry loop matching the sync semantics of ``_retry_with_backoff``."""
-        report = get_active_report()
-        call_started = time.perf_counter()
-
-        for attempt, sleep_s in self._retry_schedule():
-            outcome = await self._attempt_async(client, prompt, output_format)
-            if outcome.result is not None:
-                self._record_call(report, call_started, attempt, outcome.result)
-                return outcome.result
-            if sleep_s is None:
-                self._record_call(report, call_started, attempt, None)
-                msg = "Failed to generate content"
-                raise GenerationError(msg, cause=outcome.error) from outcome.error
-            await asyncio.sleep(sleep_s)
-
-        msg = "Failed to generate content"
-        raise GenerationError(msg)
-
-    async def _attempt_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        output_format: str,
-    ) -> _AttemptOutcome:
-        """Run one async attempt; return the result or capture the error."""
-        try:
-            return _AttemptOutcome(
-                result=await self._call_api_async(client, prompt, output_format),
-                error=None,
-            )
-        except GenerationError:
-            raise
-        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
-            return _AttemptOutcome(result=None, error=e)
+        return self._provider.generate(prompt, output_format)
 
     async def generate_async(
         self,
@@ -544,126 +219,14 @@ class AIOrchestrator:
     ) -> GenerationResult:
         """Async equivalent of :meth:`generate`.
 
-        Reuses a single long-lived ``AsyncAnthropic`` client per
-        orchestrator instance so concurrent calls share the httpx
+        Delegates to the provider, which reuses a single long-lived
+        client per orchestrator instance so concurrent calls share the
         connection pool. Callers should ``await`` :meth:`aclose` when
         the orchestrator is no longer needed.
         """
         self._validate_prompt(prompt)
         self._validate_output_format(output_format)
-
-        client = self._get_async_client()
-        return await self._retry_with_backoff_async(client, prompt, output_format)
-
-    async def _call_tool_api_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        *,
-        system_blocks: list[dict[str, object]],
-        tool_schema: dict[str, object],
-    ) -> ToolUseResult:
-        """Make one ``tool_use`` API call and return the parsed result.
-
-        Forces the model into the supplied tool via ``tool_choice``,
-        then extracts the first :class:`ToolUseBlock` from the
-        response. The block's ``input`` (already validated against the
-        tool's ``input_schema`` server-side) is the structured payload
-        the caller wants.
-
-        Delegates the request-envelope construction to
-        :meth:`_tool_request_params` so the sync and batch paths
-        share one source of truth — a future change to ``system``,
-        ``tool_choice``, or ``max_tokens`` shape lands in one place.
-        """
-        params = self._tool_request_params(prompt, system_blocks, tool_schema)
-        # The Anthropic SDK exposes ``system``, ``tools``, and
-        # ``tool_choice`` as deeply-nested TypedDict unions. Threading
-        # those through the generic ``dict[str, object]`` shapes we
-        # accept from callers would mean re-exporting half the SDK's
-        # internal types just to satisfy mypy, with no runtime
-        # benefit. The SDK validates the payload server-side; we
-        # type-ignore the single call site instead.
-        response = await client.messages.create(**params)  # type: ignore[call-overload]
-
-        tool_block = next(
-            (b for b in response.content if isinstance(b, ToolUseBlock)),
-            None,
-        )
-        if tool_block is None:
-            msg = "Expected ToolUseBlock in response"
-            raise GenerationError(msg)
-        if not isinstance(tool_block.input, dict):
-            msg = "Tool input was not a JSON object"
-            raise GenerationError(msg)
-
-        cache_read, cache_creation = self._cache_tokens(response.usage)
-        return ToolUseResult(
-            tool_name=tool_block.name,
-            tool_input=dict(tool_block.input),
-            token_usage=TokenUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-            ),
-            model=response.model,
-            message_id=response.id,
-            cache_read_tokens=cache_read,
-            cache_creation_tokens=cache_creation,
-        )
-
-    async def _attempt_tool_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        *,
-        system_blocks: list[dict[str, object]],
-        tool_schema: dict[str, object],
-    ) -> _ToolAttemptOutcome:
-        """Run one async ``tool_use`` attempt; capture errors for retry."""
-        try:
-            result = await self._call_tool_api_async(
-                client,
-                prompt,
-                system_blocks=system_blocks,
-                tool_schema=tool_schema,
-            )
-        except GenerationError:
-            raise
-        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
-            return _ToolAttemptOutcome(result=None, error=e)
-        else:
-            return _ToolAttemptOutcome(result=result, error=None)
-
-    async def _retry_tool_with_backoff_async(
-        self,
-        client: AsyncAnthropic,
-        prompt: str,
-        *,
-        system_blocks: list[dict[str, object]],
-        tool_schema: dict[str, object],
-    ) -> ToolUseResult:
-        """Async retry loop for the ``tool_use`` path."""
-        report = get_active_report()
-        call_started = time.perf_counter()
-
-        for attempt, sleep_s in self._retry_schedule():
-            outcome = await self._attempt_tool_async(
-                client,
-                prompt,
-                system_blocks=system_blocks,
-                tool_schema=tool_schema,
-            )
-            if outcome.result is not None:
-                self._record_call(report, call_started, attempt, outcome.result)
-                return outcome.result
-            if sleep_s is None:
-                self._record_call(report, call_started, attempt, None)
-                msg = "Failed to generate content"
-                raise GenerationError(msg, cause=outcome.error) from outcome.error
-            await asyncio.sleep(sleep_s)
-
-        msg = "Failed to generate content"
-        raise GenerationError(msg)
+        return await self._provider.generate_async(prompt, output_format)
 
     async def generate_tool_use_async(
         self,
@@ -677,7 +240,7 @@ class AIOrchestrator:
         The model is forced to invoke ``tool_schema`` and the parsed
         ``input`` dict is returned to the caller — no free-form text
         parsing required. ``system_blocks`` is passed verbatim to the
-        Anthropic API, so callers can attach
+        provider, so callers can attach
         ``cache_control={"type": "ephemeral"}`` to whichever blocks
         should participate in prompt caching.
 
@@ -687,10 +250,10 @@ class AIOrchestrator:
                 ``system_blocks``, otherwise cache-key mismatches will
                 defeat the cache).
             system_blocks: Ordered list of system-prompt blocks, each
-                a dict matching the Anthropic SDK's system-block
+                a dict matching the provider's system-block
                 schema (``{"type": "text", "text": "...",
                 "cache_control": {...}}``).
-            tool_schema: Anthropic-SDK-shaped tool definition with
+            tool_schema: Provider-shaped tool definition with
                 ``name``, ``description``, and ``input_schema`` keys.
 
         Returns:
@@ -703,23 +266,19 @@ class AIOrchestrator:
                 the response does not contain a tool-use block.
         """
         self._validate_prompt(prompt)
-        client = self._get_async_client()
-        return await self._retry_tool_with_backoff_async(
-            client,
+        return await self._provider.generate_tool_use_async(
             prompt,
             system_blocks=system_blocks,
             tool_schema=tool_schema,
         )
 
     async def aclose(self) -> None:
-        """Release the cached async client, if any.
+        """Release the provider's cached client, if any.
 
         Idempotent. Safe to call from a finally block even when no async
         calls were made.
         """
-        if self._async_client is not None:
-            await self._async_client.close()
-            self._async_client = None
+        await self._provider.aclose()
 
     async def submit_tool_use_batch(
         self,
@@ -727,24 +286,12 @@ class AIOrchestrator:
     ) -> BatchSubmission:
         """Submit ``requests`` as a single Message Batches API call.
 
-        Each :class:`ToolUseBatchRequest` is translated into the
-        Batches-API request envelope (``custom_id`` + ``params``) and
-        the whole list is passed to
-        ``client.messages.batches.create``. Returns the batch id and
-        an echo of the submitted ``custom_id`` order so callers can
-        persist both for a later resume.
-
-        The forced ``tool_choice`` mirrors :meth:`generate_tool_use_async`
-        — the model is required to invoke the supplied tool, so the
-        result message is guaranteed to contain a
-        ``ToolUseBlock``. This keeps the result parser
-        (:func:`parse_batch_result_entry`) simple.
+        Delegates to the provider. See
+        :meth:`LLMProvider.submit_tool_use_batch` for the contract.
 
         Args:
             requests: One or more :class:`ToolUseBatchRequest`
-                payloads. Empty input is rejected (the SDK would reject
-                it server-side; failing locally keeps the error close
-                to the caller).
+                payloads. Empty input is rejected.
 
         Returns:
             :class:`BatchSubmission` with the new ``batch_id`` and the
@@ -755,60 +302,13 @@ class AIOrchestrator:
                 ``custom_id`` values.
             GenerationError: If the API call fails.
         """
-        custom_ids = self._validate_batch_requests(requests)
-        payload = [self._batch_request_envelope(r) for r in requests]
-        batch = await self._create_batch(payload)
-        return BatchSubmission(
-            batch_id=str(getattr(batch, "id", "") or ""),
-            custom_ids=custom_ids.copy(),
-            submitted_at=datetime.now(UTC).isoformat(),
-        )
-
-    @staticmethod
-    def _validate_batch_requests(
-        requests: Sequence[ToolUseBatchRequest],
-    ) -> list[str]:
-        """Pre-flight validation; returns the ordered ``custom_id`` list."""
-        if not requests:
-            msg = "submit_tool_use_batch requires at least one request"
-            raise ValueError(msg)
-        custom_ids = [r.custom_id for r in requests]
-        if len(set(custom_ids)) != len(custom_ids):
-            msg = "submit_tool_use_batch requests must have unique custom_id values"
-            raise ValueError(msg)
-        return custom_ids
-
-    async def _create_batch(self, payload: list[dict[str, object]]) -> object:
-        """Wrap the SDK call so callers see ``GenerationError`` on failure.
-
-        The SDK signature is
-        ``create(*, requests: Iterable[batch_create_params.Request])``.
-        We construct each envelope as a ``dict[str, object]`` matching
-        the ``Request`` ``TypedDict`` shape (verified by
-        ``test_request_envelope_carries_tool_choice_and_system``).
-        Mypy cannot prove the dict matches the TypedDict's deeply-nested
-        ``MessageCreateParamsNonStreaming`` shape without re-typing the
-        ``ToolUseBatchRequest.system_blocks`` chain end-to-end, so we
-        use one ``cast()`` at the SDK boundary to assert the contract
-        rather than a ``# type: ignore`` to suppress it. ``cast`` is
-        documented narrowing; ``type: ignore`` is suppression.
-        """
-        client = self._get_async_client()
-        try:
-            return await client.messages.batches.create(
-                requests=cast("Iterable[BatchCreateRequest]", payload),
-            )
-        except Exception as exc:
-            msg = "Batch submission failed"
-            raise GenerationError(msg, cause=exc) from exc
+        return await self._provider.submit_tool_use_batch(requests)
 
     async def poll_batch(self, batch_id: str) -> BatchPoll:
         """Return the current state of an in-flight batch.
 
-        Single retrieve call — no internal polling loop. Callers that
-        want a blocking wait drive their own sleep/poll cycle (see the
-        ADR for why the two-call CLI pattern is preferred over a
-        long-running command).
+        Delegates to the provider. See
+        :meth:`LLMProvider.poll_batch` for the contract.
 
         Args:
             batch_id: Identifier returned from
@@ -821,32 +321,13 @@ class AIOrchestrator:
             ValueError: If ``batch_id`` is empty.
             GenerationError: If the API call fails.
         """
-        self._require_batch_id(batch_id, "poll_batch")
-        batch = await self._retrieve_batch(batch_id)
-        return self._batch_poll_from_response(batch_id, batch)
-
-    @staticmethod
-    def _batch_poll_from_response(batch_id: str, batch: object) -> BatchPoll:
-        """Pull the ``BatchPoll`` snapshot fields off a SDK response object."""
-        counts = getattr(batch, "request_counts", None)
-        return BatchPoll(
-            batch_id=batch_id,
-            status=str(getattr(batch, "processing_status", "") or ""),
-            processing_count=_count(counts, "processing"),
-            succeeded_count=_count(counts, "succeeded"),
-            errored_count=_count(counts, "errored"),
-            canceled_count=_count(counts, "canceled"),
-            expired_count=_count(counts, "expired"),
-        )
+        return await self._provider.poll_batch(batch_id)
 
     async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
         """Stream a finished batch's results into ``(successes, failures)``.
 
-        Calls ``client.messages.batches.results(batch_id)`` and folds
-        each entry through :func:`parse_batch_result_entry`. Successes
-        land in :attr:`BatchResultsBundle.successes` keyed by
-        ``custom_id``; non-success entries (errored, canceled,
-        expired) land in :attr:`BatchResultsBundle.failures`.
+        Delegates to the provider. See
+        :meth:`LLMProvider.fetch_batch_results` for the contract.
 
         Args:
             batch_id: Identifier of an ``ended`` batch.
@@ -860,128 +341,4 @@ class AIOrchestrator:
                 shape is unrecoverably malformed (per-request
                 failures do *not* raise — they populate ``failures``).
         """
-        self._require_batch_id(batch_id, "fetch_batch_results")
-        stream = await self._open_results_stream(batch_id)
-        # Collect into local dicts and construct the frozen bundle at
-        # the end. Mutating the bundle's fields in-place after
-        # construction worked (``frozen=True`` doesn't deep-freeze
-        # mutable containers) but read as a contradiction — a reader
-        # seeing ``frozen=True`` reasonably expects the object to be
-        # fully immutable.
-        successes: dict[str, ToolUseResult] = {}
-        failures: dict[str, BatchError] = {}
-        async for entry in _aiter(stream):
-            custom_id, outcome = parse_batch_result_entry(entry)
-            if isinstance(outcome, ToolUseResult):
-                successes[custom_id] = outcome
-            else:
-                failures[custom_id] = outcome
-        return BatchResultsBundle(successes=successes, failures=failures)
-
-    @staticmethod
-    def _require_batch_id(batch_id: str, op: str) -> None:
-        """Reject empty/missing ``batch_id`` close to the caller."""
-        if not batch_id:
-            msg = f"{op} requires a non-empty batch_id"
-            raise ValueError(msg)
-
-    async def _retrieve_batch(self, batch_id: str) -> object:
-        """Wrap the SDK retrieve so callers see ``GenerationError`` on failure."""
-        client = self._get_async_client()
-        try:
-            return await client.messages.batches.retrieve(batch_id)
-        except Exception as exc:
-            msg = f"Batch retrieve failed for {batch_id}"
-            raise GenerationError(msg, cause=exc) from exc
-
-    async def _open_results_stream(
-        self,
-        batch_id: str,
-    ) -> AsyncIterable[object] | Iterable[object]:
-        """Open the batch's result stream as an iterable.
-
-        ``AsyncBatches.results()`` is ``async def`` (a coroutine
-        function — *not* an async-generator function); it returns a
-        coroutine that resolves to an
-        ``AsyncJSONLDecoder[MessageBatchIndividualResponse]``. The
-        decoder is itself an async iterable, hence the
-        ``await`` then ``async for`` pattern in the caller.
-        Verified against ``anthropic`` SDK 0.97.0 by reading
-        ``inspect.iscoroutinefunction(AsyncBatches.results)``.
-
-        Returns the iterable shape ``_aiter`` expects directly, so
-        callers do not have to cast. SDK errors are remapped to
-        :class:`GenerationError` to keep the public surface uniform
-        with the sync path.
-        """
-        client = self._get_async_client()
-        try:
-            stream = await client.messages.batches.results(batch_id)
-        except Exception as exc:
-            msg = f"Batch results stream failed for {batch_id}"
-            raise GenerationError(msg, cause=exc) from exc
-        # The SDK returns an async iterator at runtime; tests pass a
-        # plain list via ``AsyncMock``. Both satisfy the union, so
-        # the cast is a type-check-only narrowing — no isinstance
-        # at runtime.
-        return cast("AsyncIterable[object] | Iterable[object]", stream)
-
-    def _batch_request_envelope(
-        self,
-        request: ToolUseBatchRequest,
-    ) -> dict[str, object]:
-        """Wrap one :class:`ToolUseBatchRequest` in Batches-API shape.
-
-        The Anthropic Batches API expects a list of
-        ``{"custom_id": ..., "params": {...}}`` dicts where ``params``
-        is a normal ``messages.create`` body. ``params`` is built by
-        :meth:`_tool_request_params` — the same helper
-        :meth:`_call_tool_api_async` uses — so sync and batch paths
-        cannot drift apart on envelope shape.
-        """
-        return {
-            "custom_id": request.custom_id,
-            "params": self._tool_request_params(
-                request.prompt,
-                request.system_blocks,
-                request.tool_schema,
-                custom_id=request.custom_id,
-            ),
-        }
-
-    def _tool_request_params(
-        self,
-        prompt: str,
-        system_blocks: list[dict[str, object]],
-        tool_schema: dict[str, object],
-        *,
-        custom_id: str = "",
-    ) -> dict[str, object]:
-        """Build the Anthropic ``messages.create`` body shared by sync + batch.
-
-        Every field here is identical between the two transports —
-        a single source of truth so a future change to ``system``,
-        ``tool_choice``, ``max_tokens``, or ``messages`` shape lands
-        once and applies to both. ``custom_id`` is optional context
-        for the validation error (named in the message when present).
-
-        Validates ``tool_schema["name"]`` is non-empty before
-        construction; the API would otherwise reject a missing name
-        with an opaque HTTP 400 wrapped in a generic
-        ``GenerationError``.
-        """
-        raw_name = tool_schema.get("name")
-        if not isinstance(raw_name, str) or not raw_name:
-            qualifier = f" for custom_id {custom_id!r}" if custom_id else ""
-            msg = f"tool_schema{qualifier} must include a non-empty " "'name' string"
-            raise GenerationError(msg)
-        return {
-            "model": self.model,
-            "max_tokens": _MAX_TOKENS,
-            "system": system_blocks.copy(),
-            "tools": [tool_schema],
-            "tool_choice": {"type": "tool", "name": raw_name},
-            "messages": [
-                {"role": "user", "content": prompt},
-            ],
-        }
+        return await self._provider.fetch_batch_results(batch_id)

--- a/start_green_stay_green/ai/providers/__init__.py
+++ b/start_green_stay_green/ai/providers/__init__.py
@@ -1,0 +1,26 @@
+"""LLM provider abstraction for the AI subsystem.
+
+Introduced in tracer T1 of the multi-agent epic (#381). The
+:class:`~start_green_stay_green.ai.providers.base.LLMProvider`
+interface is the seam every later tracer depends on: it decouples
+:class:`~start_green_stay_green.ai.orchestrator.AIOrchestrator` from
+any single SDK. :class:`AnthropicProvider` is the only concrete
+implementation today and contains *all* Anthropic-specific code
+(client construction, retry/backoff, token accounting, the Message
+Batches API).
+
+The orchestrator depends on the interface, not on the ``anthropic``
+package, so a future provider (a second vendor, a local model, a
+fake for tests) can be slotted in without touching orchestration
+logic.
+"""
+
+from __future__ import annotations
+
+from start_green_stay_green.ai.providers.anthropic_provider import AnthropicProvider
+from start_green_stay_green.ai.providers.base import LLMProvider
+
+__all__ = [
+    "AnthropicProvider",
+    "LLMProvider",
+]

--- a/start_green_stay_green/ai/providers/anthropic_provider.py
+++ b/start_green_stay_green/ai/providers/anthropic_provider.py
@@ -1,0 +1,885 @@
+"""Anthropic-backed :class:`LLMProvider` implementation.
+
+Houses *every* line of Anthropic-specific code for the AI subsystem:
+the ``anthropic`` SDK imports, sync/async client construction and
+caching, the retry/backoff loops, prompt-cache token accounting, and
+the Message Batches API plumbing. Extracted from
+:mod:`start_green_stay_green.ai.orchestrator` in tracer T1 (#381) so
+the orchestrator can depend on the provider-neutral
+:class:`~start_green_stay_green.ai.providers.base.LLMProvider`
+interface instead of on ``anthropic`` directly.
+
+This is a pure relocation: the behavior, model identifiers, retry
+schedule, and telemetry are byte-for-byte the same as before the
+split. ``anthropic`` remains a hard dependency here (made optional in
+a later tracer, not now).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterable
+from datetime import UTC
+from datetime import datetime
+import time
+from typing import Final
+from typing import TYPE_CHECKING
+from typing import cast
+
+from anthropic import Anthropic
+from anthropic import AsyncAnthropic
+from anthropic.types import TextBlock
+from anthropic.types import ToolUseBlock
+
+from start_green_stay_green.ai.batch import BatchError
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import parse_batch_result_entry
+from start_green_stay_green.ai.providers.base import LLMProvider
+from start_green_stay_green.ai.providers.base import OutputFormat
+from start_green_stay_green.ai.providers.outcomes import AttemptOutcome
+from start_green_stay_green.ai.providers.outcomes import ToolAttemptOutcome
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import GenerationResult
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
+from start_green_stay_green.utils.timing import APICallRecord
+from start_green_stay_green.utils.timing import get_active_report
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from collections.abc import Iterable
+    from collections.abc import Iterator
+    from collections.abc import Sequence
+
+    from anthropic.types.messages.batch_create_params import (
+        Request as BatchCreateRequest,
+    )
+
+    from start_green_stay_green.ai.batch import ToolUseBatchRequest
+    from start_green_stay_green.utils.timing import TimingReport
+
+__all__ = ["AnthropicProvider"]
+
+
+# Per-call max_tokens for every Claude request the provider issues —
+# sync, async, tool-use, and batch alike. Single source of truth so a
+# future limit change is one edit instead of four.
+_MAX_TOKENS: Final[int] = 4096
+
+
+def _count(obj: object, name: str) -> int:
+    """Read a count attribute off ``obj``, defaulting to ``0``.
+
+    SDK response objects expose ``request_counts.processing`` etc. as
+    plain ``int`` attributes; tests pass ``MagicMock`` doubles. Keeps
+    ``poll_batch``'s body short enough to stay grade-A complex.
+    """
+    return int(getattr(obj, name, 0) or 0)
+
+
+async def _aiter(
+    stream: AsyncIterable[object] | Iterable[object],
+) -> AsyncIterator[object]:
+    """Yield from an async iterable OR a sync iterable.
+
+    The Anthropic SDK's ``messages.batches.results`` returns an
+    async iterator at runtime, but unit tests construct fakes that
+    are easier to write as plain lists. Accept both shapes so the
+    test seam is wide.
+
+    ``isinstance(stream, AsyncIterable)`` narrows the union for
+    mypy on both branches, so neither path needs a ``type: ignore``.
+    """
+    if isinstance(stream, AsyncIterable):
+        async for item in stream:
+            yield item
+        return
+    for item in stream:
+        yield item
+
+
+class AnthropicProvider(LLMProvider):
+    """Anthropic SDK implementation of :class:`LLMProvider`.
+
+    Wraps the exact request/retry/telemetry logic that previously
+    lived on ``AIOrchestrator``. Construction is cheap and performs no
+    I/O: the sync client is created per-call inside a context manager,
+    and the async client is allocated lazily and cached for reuse
+    across concurrent calls.
+
+    Attributes:
+        model: Claude model identifier used for every request.
+        max_retries: Maximum number of retry attempts for failed
+            requests.
+        retry_delay: Initial delay in seconds between retry attempts
+            (doubled each retry).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> None:
+        """Initialize the provider with credentials and retry policy.
+
+        Args:
+            api_key: Claude API key for authentication. Must be
+                non-empty (validated by the caller; revalidated here is
+                unnecessary because the orchestrator owns auth
+                validation).
+            model: Claude model identifier to generate with.
+            max_retries: Maximum retry attempts. Defaults to 3.
+            retry_delay: Initial retry delay in seconds. Defaults to
+                1.0.
+        """
+        self._api_key = api_key
+        self._model = model
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        # Lazily-created long-lived async client. Reusing one client across
+        # all calls in an init run lets us share the underlying httpx pool,
+        # which matters once later tracers fan out subagent tunings
+        # concurrently.
+        self._async_client: AsyncAnthropic | None = None
+
+    @property
+    def model(self) -> str:
+        """Return the Claude model identifier this provider uses."""
+        return self._model
+
+    @staticmethod
+    def _cache_tokens(usage: object) -> tuple[int, int]:
+        """Extract ``(cache_read, cache_creation)`` token counts from ``usage``.
+
+        The Anthropic SDK exposes ``cache_read_input_tokens`` and
+        ``cache_creation_input_tokens`` only when prompt caching is
+        active *and* the SDK version supports them; both fields can be
+        ``None``. Coerce to ``int`` so downstream telemetry never has
+        to defend against ``None``.
+        """
+        return (
+            int(getattr(usage, "cache_read_input_tokens", 0) or 0),
+            int(getattr(usage, "cache_creation_input_tokens", 0) or 0),
+        )
+
+    def _call_api(
+        self,
+        client: Anthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Call Claude API and build result.
+
+        Args:
+            client: Anthropic API client.
+            prompt: Generation prompt.
+            output_format: Desired output format.
+
+        Returns:
+            GenerationResult with content and metadata.
+
+        Raises:
+            GenerationError: If response is invalid.
+        """
+        response = client.messages.create(
+            model=self._model,
+            max_tokens=_MAX_TOKENS,
+            system=(
+                f"Generate {output_format} output. "
+                "Follow the instructions precisely."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        )
+
+        # Extract content from response
+        first_block = response.content[0]
+        if not isinstance(first_block, TextBlock):
+            msg = "Expected TextBlock in response"
+            raise GenerationError(msg)
+
+        cache_read, cache_creation = self._cache_tokens(response.usage)
+        return GenerationResult(
+            content=first_block.text,
+            format=output_format,
+            token_usage=TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            model=response.model,
+            message_id=response.id,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+        )
+
+    def _retry_with_backoff(
+        self,
+        client: Anthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Retry API call with exponential backoff (sync).
+
+        Telemetry is recorded by the call site once after the loop
+        terminates (success or exhaustion). Failure paths never miss a
+        recording because both branches end with ``_record_call``.
+        """
+        report = get_active_report()
+        call_started = time.perf_counter()
+
+        for attempt, sleep_s in self._retry_schedule():
+            outcome = self._attempt_sync(client, prompt, output_format)
+            if outcome.result is not None:
+                self._record_call(report, call_started, attempt, outcome.result)
+                return outcome.result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=outcome.error) from outcome.error
+            time.sleep(sleep_s)
+
+        # ``_retry_schedule`` always yields at least one entry, so this
+        # is unreachable; keep mypy/coverage happy.
+        msg = "Failed to generate content"
+        raise GenerationError(msg)
+
+    def _retry_schedule(self) -> Iterator[tuple[int, float | None]]:
+        """Yield ``(attempt_index, sleep_before_next_or_None)`` pairs."""
+        for attempt in range(self.max_retries + 1):
+            is_last = attempt == self.max_retries
+            yield attempt, None if is_last else self.retry_delay * (2**attempt)
+
+    def _attempt_sync(
+        self,
+        client: Anthropic,
+        prompt: str,
+        output_format: str,
+    ) -> AttemptOutcome:
+        """Run one sync attempt; return the result or capture the error."""
+        try:
+            return AttemptOutcome(
+                result=self._call_api(client, prompt, output_format),
+                error=None,
+            )
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return AttemptOutcome(result=None, error=e)
+
+    @staticmethod
+    def _build_api_call_record(
+        latency_s: float,
+        attempt: int,
+        result: GenerationResult | ToolUseResult | None,
+    ) -> APICallRecord:
+        """Build an ``APICallRecord`` from a result, or zeros for failures.
+
+        Extracted from :meth:`_record_call` to keep the recorder at
+        cyclomatic grade A: the four-way ``result and X`` branch chain
+        was tipping it into grade B.
+        """
+        if result is None:
+            return APICallRecord(latency_s=latency_s, retries=attempt)
+        return APICallRecord(
+            latency_s=latency_s,
+            retries=attempt,
+            input_tokens=result.token_usage.input_tokens,
+            output_tokens=result.token_usage.output_tokens,
+            cache_read_tokens=result.cache_read_tokens,
+            cache_creation_tokens=result.cache_creation_tokens,
+        )
+
+    @classmethod
+    def _record_call(
+        cls,
+        report: TimingReport | None,
+        start: float,
+        attempt: int,
+        result: GenerationResult | ToolUseResult | None,
+    ) -> None:
+        """Record a completed call (success or failure) on the active report.
+
+        Args:
+            report: Active timing collector, or ``None`` when telemetry is off.
+            start: ``perf_counter`` value captured before the first attempt.
+            attempt: Zero-indexed attempt number from
+                :meth:`_retry_schedule`. ``attempt=0`` means the first
+                try succeeded with no retries; ``attempt=N`` means
+                ``N`` retries were used. Stored as ``retries`` on the
+                resulting :class:`APICallRecord` because that's the
+                telemetry consumer's preferred naming.
+            result: Successful :class:`GenerationResult` or
+                :class:`ToolUseResult`, or ``None`` when the call
+                failed (so token counts default to 0).
+        """
+        if report is None:
+            return
+        latency_s = time.perf_counter() - start
+        report.record_api_call(cls._build_api_call_record(latency_s, attempt, result))
+
+    def generate(self, prompt: str, output_format: OutputFormat) -> GenerationResult:
+        """Generate content using Claude API (synchronous).
+
+        Args:
+            prompt: Prompt describing what to generate.
+            output_format: Desired output format (yaml, toml, markdown, bash).
+
+        Returns:
+            GenerationResult containing generated content and metadata.
+
+        Raises:
+            GenerationError: If API call fails or response invalid.
+        """
+        # Use context manager to ensure httpx client is properly closed
+        with Anthropic(api_key=self._api_key) as client:
+            return self._retry_with_backoff(client, prompt, output_format)
+
+    def _get_async_client(self) -> AsyncAnthropic:
+        """Return the cached ``AsyncAnthropic`` client, creating it once.
+
+        The check-then-set pattern is *not* thread-safe in the abstract,
+        but it is safe under asyncio: there is no ``await`` between the
+        ``is None`` check and the assignment, so no other coroutine can
+        run between them on the same event loop. This method is only
+        ever called from coroutines on a single event loop, never from
+        a thread pool, so adding a lock would be over-engineering. Do
+        *not* call this from ``ThreadPoolExecutor``.
+        """
+        if self._async_client is None:
+            self._async_client = AsyncAnthropic(api_key=self._api_key)
+        return self._async_client
+
+    async def _call_api_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Async counterpart of :meth:`_call_api`."""
+        response = await client.messages.create(
+            model=self._model,
+            max_tokens=_MAX_TOKENS,
+            system=(
+                f"Generate {output_format} output. "
+                "Follow the instructions precisely."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+        )
+
+        first_block = response.content[0]
+        if not isinstance(first_block, TextBlock):
+            msg = "Expected TextBlock in response"
+            raise GenerationError(msg)
+
+        cache_read, cache_creation = self._cache_tokens(response.usage)
+        return GenerationResult(
+            content=first_block.text,
+            format=output_format,
+            token_usage=TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            model=response.model,
+            message_id=response.id,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+        )
+
+    async def _retry_with_backoff_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Async retry loop matching the sync semantics of ``_retry_with_backoff``."""
+        report = get_active_report()
+        call_started = time.perf_counter()
+
+        for attempt, sleep_s in self._retry_schedule():
+            outcome = await self._attempt_async(client, prompt, output_format)
+            if outcome.result is not None:
+                self._record_call(report, call_started, attempt, outcome.result)
+                return outcome.result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=outcome.error) from outcome.error
+            await asyncio.sleep(sleep_s)
+
+        msg = "Failed to generate content"
+        raise GenerationError(msg)
+
+    async def _attempt_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        output_format: str,
+    ) -> AttemptOutcome:
+        """Run one async attempt; return the result or capture the error."""
+        try:
+            return AttemptOutcome(
+                result=await self._call_api_async(client, prompt, output_format),
+                error=None,
+            )
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return AttemptOutcome(result=None, error=e)
+
+    async def generate_async(
+        self,
+        prompt: str,
+        output_format: OutputFormat,
+    ) -> GenerationResult:
+        """Async equivalent of :meth:`generate`.
+
+        Reuses a single long-lived ``AsyncAnthropic`` client per
+        provider instance so concurrent calls share the httpx
+        connection pool. Callers should ``await`` :meth:`aclose` when
+        the provider is no longer needed.
+        """
+        client = self._get_async_client()
+        return await self._retry_with_backoff_async(client, prompt, output_format)
+
+    async def _call_tool_api_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolUseResult:
+        """Make one ``tool_use`` API call and return the parsed result.
+
+        Forces the model into the supplied tool via ``tool_choice``,
+        then extracts the first :class:`ToolUseBlock` from the
+        response. The block's ``input`` (already validated against the
+        tool's ``input_schema`` server-side) is the structured payload
+        the caller wants.
+
+        Delegates the request-envelope construction to
+        :meth:`_tool_request_params` so the sync and batch paths
+        share one source of truth — a future change to ``system``,
+        ``tool_choice``, or ``max_tokens`` shape lands in one place.
+        """
+        params = self._tool_request_params(prompt, system_blocks, tool_schema)
+        # The Anthropic SDK exposes ``system``, ``tools``, and
+        # ``tool_choice`` as deeply-nested TypedDict unions. Threading
+        # those through the generic ``dict[str, object]`` shapes we
+        # accept from callers would mean re-exporting half the SDK's
+        # internal types just to satisfy mypy, with no runtime
+        # benefit. The SDK validates the payload server-side; we
+        # type-ignore the single call site instead.
+        response = await client.messages.create(**params)  # type: ignore[call-overload]
+
+        tool_block = next(
+            (b for b in response.content if isinstance(b, ToolUseBlock)),
+            None,
+        )
+        if tool_block is None:
+            msg = "Expected ToolUseBlock in response"
+            raise GenerationError(msg)
+        if not isinstance(tool_block.input, dict):
+            msg = "Tool input was not a JSON object"
+            raise GenerationError(msg)
+
+        cache_read, cache_creation = self._cache_tokens(response.usage)
+        return ToolUseResult(
+            tool_name=tool_block.name,
+            tool_input=dict(tool_block.input),
+            token_usage=TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            ),
+            model=response.model,
+            message_id=response.id,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+        )
+
+    async def _attempt_tool_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolAttemptOutcome:
+        """Run one async ``tool_use`` attempt; capture errors for retry."""
+        try:
+            result = await self._call_tool_api_async(
+                client,
+                prompt,
+                system_blocks=system_blocks,
+                tool_schema=tool_schema,
+            )
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return ToolAttemptOutcome(result=None, error=e)
+        else:
+            return ToolAttemptOutcome(result=result, error=None)
+
+    async def _retry_tool_with_backoff_async(
+        self,
+        client: AsyncAnthropic,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolUseResult:
+        """Async retry loop for the ``tool_use`` path."""
+        report = get_active_report()
+        call_started = time.perf_counter()
+
+        for attempt, sleep_s in self._retry_schedule():
+            outcome = await self._attempt_tool_async(
+                client,
+                prompt,
+                system_blocks=system_blocks,
+                tool_schema=tool_schema,
+            )
+            if outcome.result is not None:
+                self._record_call(report, call_started, attempt, outcome.result)
+                return outcome.result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=outcome.error) from outcome.error
+            await asyncio.sleep(sleep_s)
+
+        msg = "Failed to generate content"
+        raise GenerationError(msg)
+
+    async def generate_tool_use_async(
+        self,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolUseResult:
+        """Run a structured (``tool_use``) generation.
+
+        The model is forced to invoke ``tool_schema`` and the parsed
+        ``input`` dict is returned to the caller — no free-form text
+        parsing required. ``system_blocks`` is passed verbatim to the
+        Anthropic API, so callers can attach
+        ``cache_control={"type": "ephemeral"}`` to whichever blocks
+        should participate in prompt caching.
+
+        Args:
+            prompt: User-message body (per-call delta — should NOT
+                duplicate content already present in
+                ``system_blocks``, otherwise cache-key mismatches will
+                defeat the cache).
+            system_blocks: Ordered list of system-prompt blocks, each
+                a dict matching the Anthropic SDK's system-block
+                schema (``{"type": "text", "text": "...",
+                "cache_control": {...}}``).
+            tool_schema: Anthropic-SDK-shaped tool definition with
+                ``name``, ``description``, and ``input_schema`` keys.
+
+        Returns:
+            :class:`ToolUseResult` with the parsed ``tool_input`` dict
+            and full token / cache telemetry.
+
+        Raises:
+            GenerationError: If the API call fails after retries or
+                the response does not contain a tool-use block.
+        """
+        client = self._get_async_client()
+        return await self._retry_tool_with_backoff_async(
+            client,
+            prompt,
+            system_blocks=system_blocks,
+            tool_schema=tool_schema,
+        )
+
+    async def aclose(self) -> None:
+        """Release the cached async client, if any.
+
+        Idempotent. Safe to call from a finally block even when no async
+        calls were made.
+        """
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
+
+    async def submit_tool_use_batch(
+        self,
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> BatchSubmission:
+        """Submit ``requests`` as a single Message Batches API call.
+
+        Each :class:`ToolUseBatchRequest` is translated into the
+        Batches-API request envelope (``custom_id`` + ``params``) and
+        the whole list is passed to
+        ``client.messages.batches.create``. Returns the batch id and
+        an echo of the submitted ``custom_id`` order so callers can
+        persist both for a later resume.
+
+        The forced ``tool_choice`` mirrors :meth:`generate_tool_use_async`
+        — the model is required to invoke the supplied tool, so the
+        result message is guaranteed to contain a
+        ``ToolUseBlock``. This keeps the result parser
+        (:func:`parse_batch_result_entry`) simple.
+
+        Args:
+            requests: One or more :class:`ToolUseBatchRequest`
+                payloads. Empty input is rejected (the SDK would reject
+                it server-side; failing locally keeps the error close
+                to the caller).
+
+        Returns:
+            :class:`BatchSubmission` with the new ``batch_id`` and the
+            ``custom_id`` echo list.
+
+        Raises:
+            ValueError: If ``requests`` is empty or contains duplicate
+                ``custom_id`` values.
+            GenerationError: If the API call fails.
+        """
+        custom_ids = self._validate_batch_requests(requests)
+        payload = [self._batch_request_envelope(r) for r in requests]
+        batch = await self._create_batch(payload)
+        return BatchSubmission(
+            batch_id=str(getattr(batch, "id", "") or ""),
+            custom_ids=custom_ids.copy(),
+            submitted_at=datetime.now(UTC).isoformat(),
+        )
+
+    @staticmethod
+    def _validate_batch_requests(
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> list[str]:
+        """Pre-flight validation; returns the ordered ``custom_id`` list."""
+        if not requests:
+            msg = "submit_tool_use_batch requires at least one request"
+            raise ValueError(msg)
+        custom_ids = [r.custom_id for r in requests]
+        if len(set(custom_ids)) != len(custom_ids):
+            msg = "submit_tool_use_batch requests must have unique custom_id values"
+            raise ValueError(msg)
+        return custom_ids
+
+    async def _create_batch(self, payload: list[dict[str, object]]) -> object:
+        """Wrap the SDK call so callers see ``GenerationError`` on failure.
+
+        The SDK signature is
+        ``create(*, requests: Iterable[batch_create_params.Request])``.
+        We construct each envelope as a ``dict[str, object]`` matching
+        the ``Request`` ``TypedDict`` shape (verified by
+        ``test_request_envelope_carries_tool_choice_and_system``).
+        Mypy cannot prove the dict matches the TypedDict's deeply-nested
+        ``MessageCreateParamsNonStreaming`` shape without re-typing the
+        ``ToolUseBatchRequest.system_blocks`` chain end-to-end, so we
+        use one ``cast()`` at the SDK boundary to assert the contract
+        rather than a ``# type: ignore`` to suppress it. ``cast`` is
+        documented narrowing; ``type: ignore`` is suppression.
+        """
+        client = self._get_async_client()
+        try:
+            return await client.messages.batches.create(
+                requests=cast("Iterable[BatchCreateRequest]", payload),
+            )
+        except Exception as exc:
+            msg = "Batch submission failed"
+            raise GenerationError(msg, cause=exc) from exc
+
+    async def poll_batch(self, batch_id: str) -> BatchPoll:
+        """Return the current state of an in-flight batch.
+
+        Single retrieve call — no internal polling loop. Callers that
+        want a blocking wait drive their own sleep/poll cycle (see the
+        ADR for why the two-call CLI pattern is preferred over a
+        long-running command).
+
+        Args:
+            batch_id: Identifier returned from
+                :meth:`submit_tool_use_batch`.
+
+        Returns:
+            :class:`BatchPoll` with status and per-state counts.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the API call fails.
+        """
+        self._require_batch_id(batch_id, "poll_batch")
+        batch = await self._retrieve_batch(batch_id)
+        return self._batch_poll_from_response(batch_id, batch)
+
+    @staticmethod
+    def _batch_poll_from_response(batch_id: str, batch: object) -> BatchPoll:
+        """Pull the ``BatchPoll`` snapshot fields off a SDK response object."""
+        counts = getattr(batch, "request_counts", None)
+        return BatchPoll(
+            batch_id=batch_id,
+            status=str(getattr(batch, "processing_status", "") or ""),
+            processing_count=_count(counts, "processing"),
+            succeeded_count=_count(counts, "succeeded"),
+            errored_count=_count(counts, "errored"),
+            canceled_count=_count(counts, "canceled"),
+            expired_count=_count(counts, "expired"),
+        )
+
+    async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
+        """Stream a finished batch's results into ``(successes, failures)``.
+
+        Calls ``client.messages.batches.results(batch_id)`` and folds
+        each entry through :func:`parse_batch_result_entry`. Successes
+        land in :attr:`BatchResultsBundle.successes` keyed by
+        ``custom_id``; non-success entries (errored, canceled,
+        expired) land in :attr:`BatchResultsBundle.failures`.
+
+        Args:
+            batch_id: Identifier of an ``ended`` batch.
+
+        Returns:
+            :class:`BatchResultsBundle` with per-``custom_id`` results.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the API call fails or any entry's
+                shape is unrecoverably malformed (per-request
+                failures do *not* raise — they populate ``failures``).
+        """
+        self._require_batch_id(batch_id, "fetch_batch_results")
+        stream = await self._open_results_stream(batch_id)
+        # Collect into local dicts and construct the frozen bundle at
+        # the end. Mutating the bundle's fields in-place after
+        # construction worked (``frozen=True`` doesn't deep-freeze
+        # mutable containers) but read as a contradiction — a reader
+        # seeing ``frozen=True`` reasonably expects the object to be
+        # fully immutable.
+        successes: dict[str, ToolUseResult] = {}
+        failures: dict[str, BatchError] = {}
+        async for entry in _aiter(stream):
+            custom_id, outcome = parse_batch_result_entry(entry)
+            if isinstance(outcome, ToolUseResult):
+                successes[custom_id] = outcome
+            else:
+                failures[custom_id] = outcome
+        return BatchResultsBundle(successes=successes, failures=failures)
+
+    @staticmethod
+    def _require_batch_id(batch_id: str, op: str) -> None:
+        """Reject empty/missing ``batch_id`` close to the caller."""
+        if not batch_id:
+            msg = f"{op} requires a non-empty batch_id"
+            raise ValueError(msg)
+
+    async def _retrieve_batch(self, batch_id: str) -> object:
+        """Wrap the SDK retrieve so callers see ``GenerationError`` on failure."""
+        client = self._get_async_client()
+        try:
+            return await client.messages.batches.retrieve(batch_id)
+        except Exception as exc:
+            msg = f"Batch retrieve failed for {batch_id}"
+            raise GenerationError(msg, cause=exc) from exc
+
+    async def _open_results_stream(
+        self,
+        batch_id: str,
+    ) -> AsyncIterable[object] | Iterable[object]:
+        """Open the batch's result stream as an iterable.
+
+        ``AsyncBatches.results()`` is ``async def`` (a coroutine
+        function — *not* an async-generator function); it returns a
+        coroutine that resolves to an
+        ``AsyncJSONLDecoder[MessageBatchIndividualResponse]``. The
+        decoder is itself an async iterable, hence the
+        ``await`` then ``async for`` pattern in the caller.
+        Verified against ``anthropic`` SDK 0.97.0 by reading
+        ``inspect.iscoroutinefunction(AsyncBatches.results)``.
+
+        Returns the iterable shape ``_aiter`` expects directly, so
+        callers do not have to cast. SDK errors are remapped to
+        :class:`GenerationError` to keep the public surface uniform
+        with the sync path.
+        """
+        client = self._get_async_client()
+        try:
+            stream = await client.messages.batches.results(batch_id)
+        except Exception as exc:
+            msg = f"Batch results stream failed for {batch_id}"
+            raise GenerationError(msg, cause=exc) from exc
+        # The SDK returns an async iterator at runtime; tests pass a
+        # plain list via ``AsyncMock``. Both satisfy the union, so
+        # the cast is a type-check-only narrowing — no isinstance
+        # at runtime.
+        return cast("AsyncIterable[object] | Iterable[object]", stream)
+
+    def _batch_request_envelope(
+        self,
+        request: ToolUseBatchRequest,
+    ) -> dict[str, object]:
+        """Wrap one :class:`ToolUseBatchRequest` in Batches-API shape.
+
+        The Anthropic Batches API expects a list of
+        ``{"custom_id": ..., "params": {...}}`` dicts where ``params``
+        is a normal ``messages.create`` body. ``params`` is built by
+        :meth:`_tool_request_params` — the same helper
+        :meth:`_call_tool_api_async` uses — so sync and batch paths
+        cannot drift apart on envelope shape.
+        """
+        return {
+            "custom_id": request.custom_id,
+            "params": self._tool_request_params(
+                request.prompt,
+                request.system_blocks,
+                request.tool_schema,
+                custom_id=request.custom_id,
+            ),
+        }
+
+    def _tool_request_params(
+        self,
+        prompt: str,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+        *,
+        custom_id: str = "",
+    ) -> dict[str, object]:
+        """Build the Anthropic ``messages.create`` body shared by sync + batch.
+
+        Every field here is identical between the two transports —
+        a single source of truth so a future change to ``system``,
+        ``tool_choice``, ``max_tokens``, or ``messages`` shape lands
+        once and applies to both. ``custom_id`` is optional context
+        for the validation error (named in the message when present).
+
+        Validates ``tool_schema["name"]`` is non-empty before
+        construction; the API would otherwise reject a missing name
+        with an opaque HTTP 400 wrapped in a generic
+        ``GenerationError``.
+        """
+        raw_name = tool_schema.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            qualifier = f" for custom_id {custom_id!r}" if custom_id else ""
+            msg = f"tool_schema{qualifier} must include a non-empty " "'name' string"
+            raise GenerationError(msg)
+        return {
+            "model": self._model,
+            "max_tokens": _MAX_TOKENS,
+            "system": system_blocks.copy(),
+            "tools": [tool_schema],
+            "tool_choice": {"type": "tool", "name": raw_name},
+            "messages": [
+                {"role": "user", "content": prompt},
+            ],
+        }

--- a/start_green_stay_green/ai/providers/base.py
+++ b/start_green_stay_green/ai/providers/base.py
@@ -1,0 +1,210 @@
+"""Provider-neutral LLM interface.
+
+Defines :class:`LLMProvider`, the contract every concrete provider
+(Anthropic today; others later) must satisfy. The interface is split
+into five capability groups so callers — and later tracers in the
+multi-agent epic — can reason about exactly what a provider offers:
+
+* **auth / lifecycle** — :meth:`~LLMProvider.aclose`.
+* **model config** — :attr:`~LLMProvider.model`.
+* **sync complete** — :meth:`~LLMProvider.generate`.
+* **async complete** — :meth:`~LLMProvider.generate_async`.
+* **tool-use** — :meth:`~LLMProvider.generate_tool_use_async`.
+* **batch** — :meth:`~LLMProvider.submit_tool_use_batch`,
+  :meth:`~LLMProvider.poll_batch`, :meth:`~LLMProvider.fetch_batch_results`.
+
+Every request and response type referenced here lives in
+:mod:`start_green_stay_green.ai.types` or
+:mod:`start_green_stay_green.ai.batch` and is deliberately
+provider-neutral: no ``anthropic`` types leak across this boundary.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from abc import abstractmethod
+from typing import Literal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from start_green_stay_green.ai.batch import BatchPoll
+    from start_green_stay_green.ai.batch import BatchResultsBundle
+    from start_green_stay_green.ai.batch import BatchSubmission
+    from start_green_stay_green.ai.batch import ToolUseBatchRequest
+    from start_green_stay_green.ai.types import GenerationResult
+    from start_green_stay_green.ai.types import ToolUseResult
+
+__all__ = ["LLMProvider"]
+
+OutputFormat = Literal["yaml", "toml", "markdown", "bash"]
+
+
+class LLMProvider(ABC):
+    """Abstract contract for a large-language-model backend.
+
+    A provider owns its own client lifecycle, retry policy, model
+    selection, and token accounting. Implementations translate the
+    provider-neutral request/response dataclasses into whatever shape
+    their SDK expects and back again, so no vendor type ever crosses
+    this boundary.
+
+    Concrete providers are expected to be cheap to construct and to
+    lazily allocate any network clients, so that constructing one
+    never performs I/O.
+    """
+
+    @property
+    @abstractmethod
+    def model(self) -> str:
+        """Return the model identifier this provider generates with.
+
+        Returns:
+            The provider-specific model id (for example an Anthropic
+            ``claude-...`` string). Stable for the provider's
+            lifetime.
+        """
+
+    @abstractmethod
+    def generate(self, prompt: str, output_format: OutputFormat) -> GenerationResult:
+        """Generate free-form content synchronously.
+
+        Args:
+            prompt: Prompt describing what to generate. Must be
+                non-empty.
+            output_format: Desired output format (``yaml``, ``toml``,
+                ``markdown``, or ``bash``).
+
+        Returns:
+            A :class:`~start_green_stay_green.ai.types.GenerationResult`
+            with the generated content and token telemetry.
+
+        Raises:
+            ValueError: If ``prompt`` is empty or ``output_format`` is
+                unsupported.
+            GenerationError: If generation fails after the provider's
+                configured retries, or the response is malformed.
+        """
+
+    @abstractmethod
+    async def generate_async(
+        self,
+        prompt: str,
+        output_format: OutputFormat,
+    ) -> GenerationResult:
+        """Async counterpart of :meth:`generate`.
+
+        Implementations should reuse a single long-lived client across
+        calls so concurrent requests share a connection pool. Callers
+        must ``await`` :meth:`aclose` when finished.
+
+        Args:
+            prompt: Prompt describing what to generate. Must be
+                non-empty.
+            output_format: Desired output format.
+
+        Returns:
+            A populated
+            :class:`~start_green_stay_green.ai.types.GenerationResult`.
+
+        Raises:
+            ValueError: If ``prompt`` is empty or ``output_format`` is
+                unsupported.
+            GenerationError: If generation fails after retries.
+        """
+
+    @abstractmethod
+    async def generate_tool_use_async(
+        self,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolUseResult:
+        """Run a structured (forced tool-use) generation.
+
+        The model is forced to invoke ``tool_schema`` and the parsed
+        ``input`` dict is returned, replacing free-form text parsing.
+
+        Args:
+            prompt: User-message body (per-call delta). Must be
+                non-empty.
+            system_blocks: Ordered system-prompt blocks, each a dict in
+                the provider's system-block schema. Passed verbatim so
+                callers may attach cache-control markers.
+            tool_schema: Provider-shaped tool definition with at least
+                a non-empty ``name``.
+
+        Returns:
+            A :class:`~start_green_stay_green.ai.types.ToolUseResult`
+            carrying the parsed ``tool_input`` and token telemetry.
+
+        Raises:
+            ValueError: If ``prompt`` is empty.
+            GenerationError: If the call fails after retries or the
+                response contains no tool-use block.
+        """
+
+    @abstractmethod
+    async def submit_tool_use_batch(
+        self,
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> BatchSubmission:
+        """Submit many tool-use requests as one batch.
+
+        Args:
+            requests: One or more batch requests with unique
+                ``custom_id`` values.
+
+        Returns:
+            A :class:`~start_green_stay_green.ai.batch.BatchSubmission`
+            echoing the new batch id and submitted ``custom_id`` order.
+
+        Raises:
+            ValueError: If ``requests`` is empty or has duplicate
+                ``custom_id`` values.
+            GenerationError: If the submission call fails.
+        """
+
+    @abstractmethod
+    async def poll_batch(self, batch_id: str) -> BatchPoll:
+        """Return the current state of an in-flight batch.
+
+        Args:
+            batch_id: Identifier returned from
+                :meth:`submit_tool_use_batch`.
+
+        Returns:
+            A :class:`~start_green_stay_green.ai.batch.BatchPoll`
+            snapshot with status and per-state counts.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the poll call fails.
+        """
+
+    @abstractmethod
+    async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
+        """Stream a finished batch's results into successes and failures.
+
+        Args:
+            batch_id: Identifier of an ended batch.
+
+        Returns:
+            A :class:`~start_green_stay_green.ai.batch.BatchResultsBundle`
+            partitioned by ``custom_id``.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty.
+            GenerationError: If the call fails or an entry is so
+                malformed no ``custom_id`` can be recovered.
+        """
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Release any cached network client.
+
+        Must be idempotent: safe to call from a ``finally`` block even
+        when no async work was performed.
+        """

--- a/start_green_stay_green/ai/providers/outcomes.py
+++ b/start_green_stay_green/ai/providers/outcomes.py
@@ -1,0 +1,36 @@
+"""Internal retry-attempt outcome helpers for LLM providers.
+
+A provider's retry loop runs one attempt, then either returns the
+result or remembers the error to retry. These two frozen dataclasses
+carry that "success result OR captured retryable error" pair for the
+free-form and tool-use paths respectively. They are provider-neutral
+(no ``anthropic`` types) so any future provider can reuse the same
+retry plumbing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from start_green_stay_green.ai.types import GenerationResult
+    from start_green_stay_green.ai.types import ToolUseResult
+
+__all__ = ["AttemptOutcome", "ToolAttemptOutcome"]
+
+
+@dataclass(frozen=True)
+class AttemptOutcome:
+    """One free-form attempt: a success result or a captured error."""
+
+    result: GenerationResult | None
+    error: Exception | None
+
+
+@dataclass(frozen=True)
+class ToolAttemptOutcome:
+    """One ``tool_use`` attempt: a success result or a captured error."""
+
+    result: ToolUseResult | None
+    error: Exception | None

--- a/tests/integration/ai/test_orchestrator_integration.py
+++ b/tests/integration/ai/test_orchestrator_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for AI Orchestrator end-to-end workflows."""
 
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import create_autospec
 from unittest.mock import patch
@@ -13,12 +15,15 @@ from start_green_stay_green.ai.orchestrator import GenerationResult
 from start_green_stay_green.ai.orchestrator import ModelConfig
 from start_green_stay_green.ai.orchestrator import TokenUsage
 
+if TYPE_CHECKING:
+    from start_green_stay_green.ai.providers import AnthropicProvider
+
 
 @pytest.mark.integration
 class TestOrchestratorEndToEndWorkflows:
     """Test complete orchestrator workflows from initialization to generation."""
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_full_workflow_with_yaml_generation(
         self,
         mock_anthropic: MagicMock,
@@ -70,8 +75,8 @@ class TestOrchestratorEndToEndWorkflows:
         assert call_kwargs["model"] == ModelConfig.OPUS
         assert call_kwargs["max_tokens"] == 4096
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_resilience_workflow_with_retry_recovery(
         self,
         mock_anthropic: MagicMock,
@@ -116,8 +121,8 @@ class TestOrchestratorEndToEndWorkflows:
         assert mock_client.messages.create.call_count == 2
         assert mock_sleep.call_count == 1
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_failure_workflow_max_retries_exhausted(
         self,
         mock_anthropic: MagicMock,
@@ -152,7 +157,7 @@ class TestOrchestratorEndToEndWorkflows:
         assert mock_client.messages.create.call_count == 3  # 1 + 2 retries
         assert mock_sleep.call_count == 2
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_multiple_format_workflow(
         self,
         mock_anthropic: MagicMock,
@@ -205,7 +210,7 @@ class TestOrchestratorEndToEndWorkflows:
         # Verify all formats were generated
         assert mock_client.messages.create.call_count == 4
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_configuration_workflow_with_custom_settings(
         self,
         mock_anthropic: MagicMock,
@@ -273,7 +278,7 @@ class TestOrchestratorAsyncWorkflows:
     """Coverage for the AsyncAnthropic-backed generate_async path."""
 
     @pytest.mark.asyncio
-    @patch("start_green_stay_green.ai.orchestrator.AsyncAnthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.AsyncAnthropic")
     async def test_generate_async_returns_generation_result(
         self,
         mock_async_anthropic: MagicMock,
@@ -324,7 +329,7 @@ class TestOrchestratorAsyncWorkflows:
         mock_async_anthropic.assert_called_once_with(api_key="async-smoke")
 
     @pytest.mark.asyncio
-    @patch("start_green_stay_green.ai.orchestrator.AsyncAnthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.AsyncAnthropic")
     async def test_aclose_is_idempotent(
         self,
         mock_async_anthropic: MagicMock,
@@ -347,7 +352,7 @@ class TestOrchestratorAsyncWorkflows:
 
         # Now allocate the client by calling ``_get_async_client`` and
         # close it twice.
-        orchestrator._get_async_client()
+        cast("AnthropicProvider", orchestrator._provider)._get_async_client()
         await orchestrator.aclose()
         await orchestrator.aclose()
         mock_client.close.assert_called_once()

--- a/tests/unit/ai/test_orchestrator.py
+++ b/tests/unit/ai/test_orchestrator.py
@@ -1,6 +1,8 @@
 """Unit tests for AI Orchestrator data classes and core functionality."""
 
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -21,6 +23,9 @@ from start_green_stay_green.ai.orchestrator import TokenUsage
 from start_green_stay_green.ai.orchestrator import ToolUseResult
 from start_green_stay_green.utils.timing import TimingReport
 from start_green_stay_green.utils.timing import set_active_report
+
+if TYPE_CHECKING:
+    from start_green_stay_green.ai.providers import AnthropicProvider
 
 
 class TestTokenUsage:
@@ -266,7 +271,7 @@ class TestAIOrchestrator:
         # Verify it's a float, not accidentally converted to int
         assert isinstance(orchestrator.retry_delay, float)
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_with_valid_prompt_returns_result(
         self,
         mock_anthropic: Mock,
@@ -322,7 +327,7 @@ class TestAIOrchestrator:
                 output_format="invalid_format",  # type: ignore[arg-type]
             )
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_supports_all_output_formats(
         self,
         mock_anthropic: Mock,
@@ -354,7 +359,7 @@ class TestAIOrchestrator:
             )
             assert result.format == fmt
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_api_error_raises_generation_error(
         self,
         mock_anthropic: Mock,
@@ -372,7 +377,7 @@ class TestAIOrchestrator:
         with pytest.raises(GenerationError, match="Failed to generate content"):
             orchestrator.generate(prompt="Generate config", output_format="yaml")
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_creates_client_with_api_key(
         self,
         mock_anthropic: Mock,
@@ -401,8 +406,8 @@ class TestAIOrchestrator:
         mock_anthropic.assert_called_once_with(api_key="my-secret-key")
 
     @pytest.mark.flaky_in_ci
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_retries_on_failure(
         self,
         mock_anthropic: Mock,
@@ -442,8 +447,8 @@ class TestAIOrchestrator:
         # Should have slept twice (after each failure)
         assert mock_sleep.call_count == 2
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_exponential_backoff(
         self,
         mock_anthropic: Mock,
@@ -480,8 +485,8 @@ class TestAIOrchestrator:
         # Verify exponential backoff: 1.0, 2.0 seconds
         mock_sleep.assert_has_calls([call(1.0), call(2.0)])
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_max_retries_exceeded(
         self,
         mock_anthropic: Mock,
@@ -504,7 +509,7 @@ class TestAIOrchestrator:
         # Should have slept 2 times (after first 2 failures)
         assert mock_sleep.call_count == 2
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_no_retry_on_success(
         self,
         mock_anthropic: Mock,
@@ -625,8 +630,8 @@ class TestMutationKillers:
         with pytest.raises(ValueError, match="API key cannot be empty"):
             AIOrchestrator(api_key="\t\n  ")
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_retry_delay_exact_exponential_backoff(
         self,
         mock_anthropic: Mock,
@@ -684,8 +689,8 @@ class TestMutationKillers:
         # Verify these are NOT linear backoff (would be [1.0, 2.0, 3.0])
         assert sleep_calls != [1.0, 2.0, 3.0]
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_retry_count_exact(
         self,
         mock_anthropic: Mock,
@@ -717,8 +722,8 @@ class TestMutationKillers:
         # Should sleep exactly max_retries times (after each failure except last)
         assert mock_sleep.call_count == 2
 
-    @patch("start_green_stay_green.ai.orchestrator.time.sleep")
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.time.sleep")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_with_max_retries_zero(
         self,
         mock_anthropic: Mock,
@@ -747,7 +752,7 @@ class TestMutationKillers:
         # Should never sleep (no retries)
         mock_sleep.assert_not_called()
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_with_non_text_block_raises(
         self,
         mock_anthropic: Mock,
@@ -777,7 +782,7 @@ class TestMutationKillers:
         ):
             orchestrator.generate(prompt="Test", output_format="yaml")
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generation_result_fields_exact_values(
         self,
         mock_anthropic: Mock,
@@ -851,7 +856,7 @@ class TestMutationKillers:
         assert "claude-opus" in ModelConfig.OPUS
         assert "claude-sonnet" in ModelConfig.SONNET
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_prompt_format_in_api_call(
         self,
         mock_anthropic: Mock,
@@ -954,7 +959,7 @@ class TestMutationKillers:
         Location: orchestrator.py:186
         """
         with patch(
-            "start_green_stay_green.ai.orchestrator.Anthropic"
+            "start_green_stay_green.ai.providers.anthropic_provider.Anthropic"
         ) as mock_anthropic:
             mock_client = MagicMock()
             mock_anthropic.return_value = mock_client
@@ -977,7 +982,7 @@ class TestMutationKillers:
             assert "TextBlock" in str(exc_info.value)
             assert "response" in str(exc_info.value)
 
-    @patch("start_green_stay_green.ai.orchestrator.Anthropic")
+    @patch("start_green_stay_green.ai.providers.anthropic_provider.Anthropic")
     def test_generate_last_error_initialized_to_none_not_empty_string(
         self,
         mock_anthropic: Mock,
@@ -1074,7 +1079,7 @@ class TestGenerateToolUseAsync:
                 tool_input={"tuned_content": "hello", "changes": ["one"]},
             )
         )
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         try:
             result = await orchestrator.generate_tool_use_async(
@@ -1105,7 +1110,7 @@ class TestGenerateToolUseAsync:
                 tool_input={"tuned_content": "x", "changes": []},
             )
         )
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         system_blocks: list[dict[str, object]] = [
             {"type": "text", "text": "instructions"},
@@ -1150,7 +1155,7 @@ class TestGenerateToolUseAsync:
         text_block.text = "wrong shape"
         text_response.content = [text_block]
         mock_client = _make_async_client(text_response)
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         try:
             with pytest.raises(GenerationError, match="ToolUseBlock"):
@@ -1180,7 +1185,7 @@ class TestGenerateToolUseAsync:
                 cache_creation=80,
             )
         )
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         try:
             await orchestrator.generate_tool_use_async(
@@ -1205,7 +1210,7 @@ class TestGenerateToolUseAsync:
                 cache_creation=7,
             )
         )
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         try:
             result = await orchestrator.generate_tool_use_async(
@@ -1258,7 +1263,7 @@ class TestCacheTelemetryOnTextPath:
         text_block.text = "hi"
         text_response.content = [text_block]
         mock_client = _make_async_client(text_response)
-        orchestrator._async_client = mock_client
+        cast("AnthropicProvider", orchestrator._provider)._async_client = mock_client
 
         try:
             result = await orchestrator.generate_async("hello", "markdown")

--- a/tests/unit/ai/test_orchestrator_batch.py
+++ b/tests/unit/ai/test_orchestrator_batch.py
@@ -9,6 +9,8 @@ parser side is covered separately in ``test_batch.py``.
 from __future__ import annotations
 
 from typing import Any
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
@@ -22,6 +24,9 @@ from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError
 from start_green_stay_green.ai.orchestrator import ToolUseResult
 
+if TYPE_CHECKING:
+    from start_green_stay_green.ai.providers import AnthropicProvider
+
 
 def _wire_batches(orchestrator: AIOrchestrator) -> MagicMock:
     """Replace the cached async client with a mock exposing ``messages.batches``.
@@ -32,7 +37,7 @@ def _wire_batches(orchestrator: AIOrchestrator) -> MagicMock:
     instance is created.
     """
     client = MagicMock()
-    orchestrator._async_client = client
+    cast("AnthropicProvider", orchestrator._provider)._async_client = client
     batches: MagicMock = client.messages.batches
     return batches
 

--- a/tests/unit/ai/test_providers.py
+++ b/tests/unit/ai/test_providers.py
@@ -1,0 +1,573 @@
+"""Unit tests for the LLMProvider seam introduced in tracer T1 (#381).
+
+Two contracts are pinned here:
+
+* :class:`AnthropicProvider` *is* an :class:`LLMProvider` and is
+  instantiable without performing any I/O.
+* :class:`AIOrchestrator` delegates every generation call to the
+  injected provider verbatim — it adds input validation, nothing
+  else — and defaults to an :class:`AnthropicProvider` when none is
+  supplied.
+
+The delegation tests use a fully fake provider so they assert the
+wiring (which method, which arguments) without any Anthropic SDK or
+network involvement.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from anthropic.types import TextBlock
+from anthropic.types import ToolUseBlock
+import pytest
+
+from start_green_stay_green.ai.batch import BatchPoll
+from start_green_stay_green.ai.batch import BatchResultsBundle
+from start_green_stay_green.ai.batch import BatchSubmission
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.orchestrator import AIOrchestrator
+from start_green_stay_green.ai.orchestrator import ModelConfig
+from start_green_stay_green.ai.providers import AnthropicProvider
+from start_green_stay_green.ai.providers import LLMProvider
+from start_green_stay_green.ai.providers.outcomes import AttemptOutcome
+from start_green_stay_green.ai.providers.outcomes import ToolAttemptOutcome
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import GenerationResult
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
+from start_green_stay_green.utils.timing import TimingReport
+from start_green_stay_green.utils.timing import set_active_report
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from collections.abc import Iterator
+    from collections.abc import Sequence
+
+
+def _generation_result() -> GenerationResult:
+    return GenerationResult(
+        content="content",
+        format="yaml",
+        token_usage=TokenUsage(input_tokens=1, output_tokens=2),
+        model="model-x",
+        message_id="msg_1",
+    )
+
+
+def _tool_use_result() -> ToolUseResult:
+    return ToolUseResult(
+        tool_name="report_tuning",
+        tool_input={"k": "v"},
+        token_usage=TokenUsage(input_tokens=1, output_tokens=2),
+        model="model-x",
+        message_id="msg_1",
+    )
+
+
+def _spy_provider() -> MagicMock:
+    """Return a fake provider whose every method is a recording mock.
+
+    ``spec=LLMProvider`` keeps the fake honest: a typo'd method name on
+    the orchestrator would raise instead of silently passing.
+    """
+    provider = MagicMock(spec=LLMProvider)
+    provider.model = "model-x"
+    provider.generate = MagicMock(return_value=_generation_result())
+    provider.generate_async = AsyncMock(return_value=_generation_result())
+    provider.generate_tool_use_async = AsyncMock(return_value=_tool_use_result())
+    provider.submit_tool_use_batch = AsyncMock(
+        return_value=BatchSubmission(batch_id="b1", custom_ids=["a"], submitted_at="t")
+    )
+    provider.poll_batch = AsyncMock(
+        return_value=BatchPoll(
+            batch_id="b1",
+            status="ended",
+            processing_count=0,
+            succeeded_count=1,
+            errored_count=0,
+        )
+    )
+    provider.fetch_batch_results = AsyncMock(return_value=BatchResultsBundle())
+    provider.aclose = AsyncMock()
+    return provider
+
+
+class TestAnthropicProviderSatisfiesInterface:
+    """``AnthropicProvider`` must be a concrete, no-I/O ``LLMProvider``."""
+
+    def test_is_subclass_of_llm_provider(self) -> None:
+        """The concrete provider declares the interface as its base."""
+        assert issubclass(AnthropicProvider, LLMProvider)
+
+    def test_instance_is_an_llm_provider(self) -> None:
+        """An instance satisfies ``isinstance`` against the interface."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        assert isinstance(provider, LLMProvider)
+
+    def test_construction_performs_no_io(self) -> None:
+        """Constructing the provider allocates no network client.
+
+        The async client is lazy; the sync client is per-call. So a
+        freshly-built provider holds ``None`` for its cached client.
+        """
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        assert provider._async_client is None
+
+    def test_model_property_returns_configured_id(self) -> None:
+        """``model`` echoes the id passed at construction, exactly."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.OPUS)
+        assert provider.model == ModelConfig.OPUS
+        assert provider.model != ModelConfig.SONNET
+
+    def test_implements_every_abstract_method(self) -> None:
+        """No abstract method is left unimplemented (kills stub mutants)."""
+        assert not getattr(AnthropicProvider, "__abstractmethods__", frozenset())
+
+    def test_default_retry_policy_matches_orchestrator_defaults(self) -> None:
+        """Default retry knobs match the historical orchestrator values."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        assert provider.max_retries == 3
+        assert provider.retry_delay == 1.0
+
+    def test_retry_schedule_is_exponential_and_last_has_no_sleep(self) -> None:
+        """``_retry_schedule`` yields exact exponential delays, None last.
+
+        Pins the relocated backoff math: delay = retry_delay * 2**attempt
+        for every attempt except the final one, which yields ``None``.
+        """
+        provider = AnthropicProvider(
+            "sk-test",
+            model=ModelConfig.SONNET,
+            max_retries=3,
+            retry_delay=1.0,
+        )
+        schedule = list(provider._retry_schedule())
+        assert schedule == [(0, 1.0), (1, 2.0), (2, 4.0), (3, None)]
+
+
+class TestLLMProviderInterface:
+    """The abstract base cannot be used as a concrete provider."""
+
+    def test_cannot_instantiate_abstract_base(self) -> None:
+        """Instantiating the ABC directly raises ``TypeError``."""
+        with pytest.raises(TypeError):
+            LLMProvider()  # type: ignore[abstract]
+
+    def test_interface_declares_expected_capabilities(self) -> None:
+        """Every documented capability is an abstract method/property."""
+        abstract = LLMProvider.__abstractmethods__
+        assert abstract == {
+            "model",
+            "generate",
+            "generate_async",
+            "generate_tool_use_async",
+            "submit_tool_use_batch",
+            "poll_batch",
+            "fetch_batch_results",
+            "aclose",
+        }
+
+    def test_async_capabilities_are_coroutines(self) -> None:
+        """The async-contract methods are declared ``async def``."""
+        for name in (
+            "generate_async",
+            "generate_tool_use_async",
+            "submit_tool_use_batch",
+            "poll_batch",
+            "fetch_batch_results",
+            "aclose",
+        ):
+            assert inspect.iscoroutinefunction(getattr(LLMProvider, name))
+
+
+class TestOrchestratorDefaultsToAnthropicProvider:
+    """With no injected provider, the orchestrator builds an Anthropic one."""
+
+    def test_default_provider_is_anthropic(self) -> None:
+        """A bare orchestrator wires up an ``AnthropicProvider``."""
+        orchestrator = AIOrchestrator(api_key="sk-test")
+        assert isinstance(orchestrator._provider, AnthropicProvider)
+
+    def test_default_provider_inherits_model_and_retry_config(self) -> None:
+        """Construction args flow through to the default provider."""
+        orchestrator = AIOrchestrator(
+            api_key="sk-test",
+            model=ModelConfig.OPUS,
+            max_retries=7,
+            retry_delay=2.5,
+        )
+        provider = orchestrator._provider
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.model == ModelConfig.OPUS
+        assert provider.max_retries == 7
+        assert provider.retry_delay == 2.5
+
+    def test_injected_provider_is_used_verbatim(self) -> None:
+        """An explicitly injected provider is stored without wrapping."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+        assert orchestrator._provider is fake
+
+
+class TestOrchestratorDelegatesToProvider:
+    """Each public method forwards to the provider with identical args."""
+
+    def test_generate_delegates(self) -> None:
+        """``generate`` validates then forwards to ``provider.generate``."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        result = orchestrator.generate("hello", "yaml")
+
+        fake.generate.assert_called_once_with("hello", "yaml")
+        assert result is fake.generate.return_value
+
+    def test_generate_validates_before_delegating(self) -> None:
+        """Empty prompt is rejected by the orchestrator, never reaching the provider."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        with pytest.raises(ValueError, match="Prompt cannot be empty"):
+            orchestrator.generate("", "yaml")
+        fake.generate.assert_not_called()
+
+    def test_generate_rejects_bad_format_before_delegating(self) -> None:
+        """Unsupported format is rejected before the provider is touched."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        with pytest.raises(ValueError, match="Unsupported output format"):
+            orchestrator.generate("hi", "xml")  # type: ignore[arg-type]
+        fake.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_async_delegates(self) -> None:
+        """``generate_async`` forwards to the provider's async method."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        result = await orchestrator.generate_async("hello", "markdown")
+
+        fake.generate_async.assert_awaited_once_with("hello", "markdown")
+        assert result is fake.generate_async.return_value
+
+    @pytest.mark.asyncio
+    async def test_generate_async_validates_before_delegating(self) -> None:
+        """Empty prompt short-circuits before the provider is awaited."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        with pytest.raises(ValueError, match="Prompt cannot be empty"):
+            await orchestrator.generate_async("   ", "markdown")
+        fake.generate_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_generate_tool_use_async_delegates_with_kwargs(self) -> None:
+        """Tool-use call forwards system_blocks and tool_schema by keyword."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+        system_blocks: list[dict[str, object]] = [{"type": "text", "text": "S"}]
+        tool_schema: dict[str, object] = {"name": "report_tuning"}
+
+        result = await orchestrator.generate_tool_use_async(
+            "msg",
+            system_blocks=system_blocks,
+            tool_schema=tool_schema,
+        )
+
+        fake.generate_tool_use_async.assert_awaited_once_with(
+            "msg",
+            system_blocks=system_blocks,
+            tool_schema=tool_schema,
+        )
+        assert result is fake.generate_tool_use_async.return_value
+
+    @pytest.mark.asyncio
+    async def test_generate_tool_use_async_validates_prompt(self) -> None:
+        """Empty tool-use prompt is rejected before delegation."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        with pytest.raises(ValueError, match="Prompt cannot be empty"):
+            await orchestrator.generate_tool_use_async(
+                "",
+                system_blocks=[],
+                tool_schema={"name": "x"},
+            )
+        fake.generate_tool_use_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_submit_tool_use_batch_delegates(self) -> None:
+        """Batch submit forwards the request sequence unchanged."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+        requests: Sequence[ToolUseBatchRequest] = [
+            ToolUseBatchRequest(
+                custom_id="a",
+                prompt="p",
+                system_blocks=[],
+                tool_schema={"name": "x"},
+            ),
+        ]
+
+        result = await orchestrator.submit_tool_use_batch(requests)
+
+        fake.submit_tool_use_batch.assert_awaited_once_with(requests)
+        assert result is fake.submit_tool_use_batch.return_value
+
+    @pytest.mark.asyncio
+    async def test_poll_batch_delegates(self) -> None:
+        """Poll forwards the batch id unchanged."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        result = await orchestrator.poll_batch("b1")
+
+        fake.poll_batch.assert_awaited_once_with("b1")
+        assert result is fake.poll_batch.return_value
+
+    @pytest.mark.asyncio
+    async def test_fetch_batch_results_delegates(self) -> None:
+        """Fetch forwards the batch id unchanged."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        result = await orchestrator.fetch_batch_results("b1")
+
+        fake.fetch_batch_results.assert_awaited_once_with("b1")
+        assert result is fake.fetch_batch_results.return_value
+
+    @pytest.mark.asyncio
+    async def test_aclose_delegates(self) -> None:
+        """``aclose`` forwards to the provider's ``aclose``."""
+        fake = _spy_provider()
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=fake)
+
+        await orchestrator.aclose()
+
+        fake.aclose.assert_awaited_once_with()
+
+
+class TestAttemptOutcomeHelpers:
+    """The relocated retry-outcome dataclasses keep their tiny contract."""
+
+    def test_attempt_outcome_holds_result_xor_error(self) -> None:
+        """``AttemptOutcome`` carries a result and an error slot."""
+        ok = AttemptOutcome(result=_generation_result(), error=None)
+        assert ok.result is not None
+        assert ok.error is None
+
+        boom = AttemptOutcome(result=None, error=ValueError("x"))
+        assert boom.result is None
+        assert isinstance(boom.error, ValueError)
+
+    def test_tool_attempt_outcome_holds_result_xor_error(self) -> None:
+        """``ToolAttemptOutcome`` mirrors ``AttemptOutcome`` for tool calls."""
+        ok = ToolAttemptOutcome(result=_tool_use_result(), error=None)
+        assert ok.result is not None
+        assert ok.error is None
+
+        boom = ToolAttemptOutcome(result=None, error=RuntimeError("x"))
+        assert boom.result is None
+        assert isinstance(boom.error, RuntimeError)
+
+
+def _text_response(text: str, *, model: str = ModelConfig.SONNET) -> MagicMock:
+    """Build a mock async response carrying a single text block."""
+    response = MagicMock()
+    response.id = "msg_async"
+    response.model = model
+    response.usage.input_tokens = 11
+    response.usage.output_tokens = 4
+    response.usage.cache_read_input_tokens = 0
+    response.usage.cache_creation_input_tokens = 0
+    block = MagicMock(spec=TextBlock)
+    block.text = text
+    response.content = [block]
+    return response
+
+
+def _async_client(create: AsyncMock) -> MagicMock:
+    """Build a mock AsyncAnthropic client with awaitable create/close."""
+    client = MagicMock()
+    client.messages.create = create
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def active_report() -> Iterator[TimingReport]:
+    """Install a fresh ``TimingReport`` for the test, then clear it."""
+    report = TimingReport()
+    set_active_report(report)
+    try:
+        yield report
+    finally:
+        set_active_report(None)
+
+
+class TestAnthropicProviderAsyncPaths:
+    """Directly exercise the relocated async generate / retry branches."""
+
+    @pytest.mark.asyncio
+    async def test_generate_async_returns_result(self) -> None:
+        """A successful async call yields a populated result."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        provider._async_client = _async_client(
+            AsyncMock(return_value=_text_response("hello"))
+        )
+        try:
+            result = await provider.generate_async("p", "markdown")
+        finally:
+            await provider.aclose()
+
+        assert isinstance(result, GenerationResult)
+        assert result.content == "hello"
+        assert result.token_usage.input_tokens == 11
+
+    @pytest.mark.asyncio
+    async def test_generate_async_retries_then_succeeds(self) -> None:
+        """Async retry loop sleeps after a failure, then returns success."""
+        provider = AnthropicProvider(
+            "sk-test", model=ModelConfig.SONNET, max_retries=2, retry_delay=0.0
+        )
+        provider._async_client = _async_client(
+            AsyncMock(
+                side_effect=[RuntimeError("boom"), _text_response("ok")],
+            )
+        )
+        try:
+            result = await provider.generate_async("p", "yaml")
+        finally:
+            await provider.aclose()
+
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_generate_async_exhausts_retries_and_raises(
+        self, active_report: TimingReport
+    ) -> None:
+        """Persistent failure raises and records a zero-token failure call."""
+        provider = AnthropicProvider(
+            "sk-test", model=ModelConfig.SONNET, max_retries=0, retry_delay=0.001
+        )
+        boom = RuntimeError("always down")
+        provider._async_client = _async_client(AsyncMock(side_effect=boom))
+
+        try:
+            with pytest.raises(GenerationError, match="Failed to generate content"):
+                await provider.generate_async("p", "yaml")
+        finally:
+            await provider.aclose()
+
+        # The failure path still records one API call with no tokens.
+        assert len(active_report.api_calls) == 1
+        assert active_report.api_calls[0].input_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_generate_async_non_text_block_raises(self) -> None:
+        """A non-TextBlock first block is a hard error on the async path."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        response = MagicMock()
+        response.id = "msg_x"
+        response.model = ModelConfig.SONNET
+        response.usage.input_tokens = 1
+        response.usage.output_tokens = 1
+        non_text = MagicMock()  # not a TextBlock spec
+        response.content = [non_text]
+        provider._async_client = _async_client(AsyncMock(return_value=response))
+
+        try:
+            with pytest.raises(GenerationError, match="Expected TextBlock"):
+                await provider.generate_async("p", "yaml")
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_tool_use_non_dict_input_raises(self) -> None:
+        """A tool block whose ``input`` is not a dict is rejected."""
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        response = MagicMock()
+        response.id = "msg_x"
+        response.model = ModelConfig.SONNET
+        response.usage.input_tokens = 1
+        response.usage.output_tokens = 1
+        response.usage.cache_read_input_tokens = 0
+        response.usage.cache_creation_input_tokens = 0
+        tool_block = MagicMock(spec=ToolUseBlock)
+        tool_block.name = "report_tuning"
+        tool_block.input = ["not", "a", "dict"]
+        response.content = [tool_block]
+        provider._async_client = _async_client(AsyncMock(return_value=response))
+
+        try:
+            with pytest.raises(GenerationError, match="not a JSON object"):
+                await provider.generate_tool_use_async(
+                    "p",
+                    system_blocks=[{"type": "text", "text": "S"}],
+                    tool_schema={"name": "report_tuning"},
+                )
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_tool_use_retries_then_raises_on_exhaustion(self) -> None:
+        """The tool-use retry loop sleeps then raises when retries run out."""
+        provider = AnthropicProvider(
+            "sk-test", model=ModelConfig.SONNET, max_retries=1, retry_delay=0.0
+        )
+        provider._async_client = _async_client(
+            AsyncMock(side_effect=RuntimeError("down"))
+        )
+
+        try:
+            with pytest.raises(GenerationError, match="Failed to generate content"):
+                await provider.generate_tool_use_async(
+                    "p",
+                    system_blocks=[{"type": "text", "text": "S"}],
+                    tool_schema={"name": "report_tuning"},
+                )
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_fetch_batch_results_consumes_true_async_iterable(self) -> None:
+        """``_aiter`` handles a genuine async iterator, not just a list.
+
+        The SDK returns an async iterator at runtime; this covers that
+        branch of the relocated ``_aiter`` helper.
+        """
+
+        async def _stream() -> AsyncIterator[dict[str, object]]:
+            yield {
+                "custom_id": "a",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "id": "m",
+                        "model": "claude",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "report_tuning",
+                                "input": {"k": "v"},
+                            },
+                        ],
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    },
+                },
+            }
+
+        provider = AnthropicProvider("sk-test", model=ModelConfig.SONNET)
+        client = MagicMock()
+        client.messages.batches.results = AsyncMock(return_value=_stream())
+        provider._async_client = client
+
+        bundle = await provider.fetch_batch_results("b1")
+
+        assert set(bundle.successes) == {"a"}
+        assert isinstance(bundle.successes["a"], ToolUseResult)


### PR DESCRIPTION
## Summary
- Introduces `start_green_stay_green/ai/providers/`: an `LLMProvider` ABC (auth/lifecycle, model config, sync/async complete, tool-use, batch) and a single concrete `AnthropicProvider` holding **all** `anthropic` SDK code (clients, retry/backoff, prompt-cache token accounting, Message Batches API), relocated verbatim.
- `AIOrchestrator` now owns input validation + the stable public API and delegates to an injected provider (defaults to `AnthropicProvider`), so every existing caller is unchanged. It no longer imports `anthropic`.
- Provider-neutral retry helpers hoisted to `providers/outcomes.py`. Tracer **T1** of epic #379 — creates the seam later tracers build on.

## Test plan
- New `tests/unit/ai/test_providers.py` (33 tests): interface conformance, no-I/O construction, orchestrator-delegates-verbatim, relocated async/retry/tool-use/batch branches.
- **Zero behavior change**: model IDs, retry schedule, telemetry, defaults all identical. Existing tests unchanged except mock **patch-target retargeting** (module globals → provider module) and internal-attribute access that necessarily follows the moved code — no assertions/expected values altered.
- `./scripts/check-all.sh` 7/7; `pre-commit run --all-files` 29/29; full suite 1700 passed; coverage 94.06%.

## Notes for reviewer
- `anthropic` remains a hard dependency (made optional in T2). No CLI/config changes.
- The only existing-test edits are mock patch paths that had to follow code moving from `orchestrator` into `providers/` — flagged here for transparency.

Closes #381
Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
