### PR TITLE
feat(ai): selectable provider/model via config, CLI flag, env (#383)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1567
+        "line_number": 1573
       }
     ]
   },
-  "generated_at": "2026-05-31T16:18:50Z"
+  "generated_at": "2026-05-31T16:38:07Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1464
+        "line_number": 1567
       }
     ]
   },
-  "generated_at": "2026-05-31T03:55:46Z"
+  "generated_at": "2026-05-31T16:18:50Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "rich>=13.0.0",
     "jinja2>=3.1.0",
     "pyyaml>=6.0.0",
-    "anthropic>=0.18.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
@@ -34,7 +33,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Anthropic provider SDK. Optional as of #383: the core CLI imports and
+# runs without it. Install with
+# ``pip install 'start-green-stay-green[anthropic]'`` to enable the
+# (default) Anthropic-backed AI features.
+anthropic = [
+    "anthropic>=0.18.0",
+]
 dev = [
+    # AI provider SDK — optional runtime extra (#383), but required for the
+    # test suite, so installed in dev.
+    "anthropic>=0.18.0",
+
     # Linting and formatting
     "ruff>=0.2.0",
     "black>=24.1.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,10 @@
 # Include runtime dependencies
 -r requirements.txt
 
+# AI provider SDK — an optional runtime extra (#383), but required for
+# the test suite and local AI features, so it is always installed in dev.
+anthropic>=0.18.0,<1.0.0
+
 # Linting and formatting
 ruff>=0.2.0,<1.0.0
 black==26.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,12 @@ jinja2>=3.1.0,<4.0.0
 pyyaml>=6.0.0,<7.0.0
 toml>=0.10.2,<1.0.0
 
-# AI integration
-anthropic>=0.18.0,<1.0.0
+# AI integration is an optional extra as of #383 — the core CLI imports
+# and runs without it. Install the provider SDK with:
+#   pip install 'start-green-stay-green[anthropic]'
+# (declared under [project.optional-dependencies].anthropic in
+# pyproject.toml). Intentionally NOT listed here so the core install
+# stays SDK-free.
 
 # HTTP client
 httpx>=0.25.0,<1.0.0

--- a/start_green_stay_green/ai/provider_selection.py
+++ b/start_green_stay_green/ai/provider_selection.py
@@ -157,36 +157,52 @@ def supported_providers() -> tuple[str, ...]:
     return tuple(sorted(_PROVIDERS))
 
 
-def _normalize(value: str | None) -> str | None:
-    """Trim and case-fold ``value``; treat blank/``None`` as unset.
+def _normalize(value: str | None, *, fold: bool = True) -> str | None:
+    """Trim ``value`` (optionally case-folding); treat blank/``None`` as unset.
+
+    Args:
+        value: The raw candidate value, or ``None``.
+        fold: When ``True`` (the default), the trimmed value is
+            case-folded — correct for provider names, which are
+            case-insensitive registry keys. Pass ``fold=False`` for
+            model ids, which are case-sensitive API identifiers whose
+            case must be preserved verbatim.
 
     Returns:
-        The normalized non-empty string, or ``None`` when ``value`` is
-        ``None`` or only whitespace (so the next precedence tier wins).
+        The trimmed string (case-folded only when ``fold`` is ``True``),
+        or ``None`` when ``value`` is ``None`` or only whitespace (so the
+        next precedence tier wins).
     """
     if value is None:
         return None
     trimmed = value.strip()
-    return trimmed.casefold() if trimmed else None
+    if not trimmed:
+        return None
+    return trimmed.casefold() if fold else trimmed
 
 
-def _coalesce(*candidates: str | None) -> str | None:
+def _coalesce(*candidates: str | None, fold: bool = True) -> str | None:
     """Return the first normalized, non-blank candidate, or ``None``.
 
     Args:
         *candidates: Values in descending precedence order.
+        fold: Threaded into each :func:`_normalize` call. ``True``
+            case-folds (provider names); ``False`` preserves case
+            (model ids).
 
     Returns:
         The first candidate that is not ``None`` after normalization.
     """
     for candidate in candidates:
-        normalized = _normalize(candidate)
+        normalized = _normalize(candidate, fold=fold)
         if normalized is not None:
             return normalized
     return None
 
 
-def _coalesce_with_default(default: str, *candidates: str | None) -> str:
+def _coalesce_with_default(
+    default: str, *candidates: str | None, fold: bool = True
+) -> str:
     """Coalesce ``candidates`` then fall back to a guaranteed ``default``.
 
     Args:
@@ -194,13 +210,19 @@ def _coalesce_with_default(default: str, *candidates: str | None) -> str:
             Module-level constants (:data:`DEFAULT_PROVIDER`,
             :data:`DEFAULT_MODEL`) supply this, so the result is always
             a concrete ``str`` — no ``None`` and therefore no defensive
-            ``assert`` at the call site.
+            ``assert`` at the call site. The default is returned verbatim
+            (never folded) when every candidate is unset.
         *candidates: Higher-precedence values in descending order.
+        fold: Threaded into :func:`_coalesce`. ``True`` case-folds the
+            chosen candidate (provider names); ``False`` preserves case
+            (model ids). Has no effect on ``default``, which is returned
+            as-is.
 
     Returns:
-        The first non-blank candidate, or the ``default`` (normalized).
+        The first non-blank candidate (normalized per ``fold``), or the
+        ``default``.
     """
-    return _coalesce(*candidates, default) or default
+    return _coalesce(*candidates, fold=fold) or default
 
 
 def _require_known(provider: str) -> str:
@@ -242,6 +264,11 @@ def resolve_provider_selection(
     Blank / whitespace-only values at any tier are treated as unset, so
     they fall through to the next tier rather than erroring.
 
+    Provider names are normalized case-insensitively (they are registry
+    keys), but model ids are preserved verbatim (only trimmed): they are
+    case-sensitive API identifiers, so ``--model GPT-4o`` reaches the
+    provider as ``GPT-4o``.
+
     Args:
         provider_flag: Value of the ``--provider`` CLI flag, or ``None``.
         model_flag: Value of the ``--model`` CLI flag, or ``None``.
@@ -256,17 +283,21 @@ def resolve_provider_selection(
     Raises:
         ValueError: If the resolved provider is not registered.
     """
+    # Provider names are case-insensitive registry keys → fold.
     provider = _coalesce_with_default(
         DEFAULT_PROVIDER,
         provider_flag,
         env.get(ENV_PROVIDER),
         config.get(_CONFIG_PROVIDER_KEY),
     )
+    # Model ids are case-sensitive API identifiers → preserve case
+    # (trim only). ``--model GPT-4o`` must reach the API as ``GPT-4o``.
     model = _coalesce_with_default(
         DEFAULT_MODEL,
         model_flag,
         env.get(ENV_MODEL),
         config.get(_CONFIG_MODEL_KEY),
+        fold=False,
     )
     return ProviderSelection(provider=_require_known(provider), model=model)
 

--- a/start_green_stay_green/ai/provider_selection.py
+++ b/start_green_stay_green/ai/provider_selection.py
@@ -1,0 +1,358 @@
+"""Provider/model selection for the AI subsystem (tracer T2, #383).
+
+Turns the :class:`~start_green_stay_green.ai.providers.base.LLMProvider`
+seam from tracer T1 (#381) into a *selectable* backend. Three things
+live here, all provider-neutral:
+
+* **Resolution** — :func:`resolve_provider_selection` collapses the
+  four configuration tiers into a single :class:`ProviderSelection`
+  with documented precedence: **CLI flag > env var
+  (``GREEN_LLM_PROVIDER`` / ``GREEN_LLM_MODEL``) > config-file key >
+  built-in default** (Anthropic + the current model id). The default
+  is byte-for-byte today's behavior, so callers that pass nothing are
+  unchanged.
+* **Construction** — :func:`build_provider` lazily imports the
+  selected provider's module so the heavy vendor SDK can be an
+  optional install extra. A missing extra is reported as a
+  :class:`ProviderUnavailableError` carrying an actionable
+  ``pip install`` hint rather than a raw :class:`ImportError`.
+* **Auth** — :func:`resolve_api_key_env_var` maps a provider to the
+  environment variable its key is read from, keeping
+  ``ANTHROPIC_API_KEY`` working untouched.
+
+No provider names, model ids, or env-var keys are logged here; the
+caller owns secret handling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from typing import Protocol
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from start_green_stay_green.ai.providers.base import LLMProvider
+
+
+class _ProviderFactory(Protocol):
+    """Constructor contract shared by every concrete provider class.
+
+    Every provider in the registry is built with the same keyword
+    arguments (``api_key`` plus retry/model policy), so typing the
+    lazily-imported class as this protocol lets :func:`build_provider`
+    call it without mypy losing the concrete ``__init__`` signature to
+    the abstract :class:`LLMProvider` base.
+    """
+
+    def __call__(
+        self,
+        api_key: str,
+        *,
+        model: str,
+        max_retries: int = ...,
+        retry_delay: float = ...,
+    ) -> LLMProvider:
+        """Construct a provider; see ``AnthropicProvider.__init__``."""
+        ...  # pragma: no cover - structural typing only
+
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_PROVIDER",
+    "ENV_MODEL",
+    "ENV_PROVIDER",
+    "ProviderSelection",
+    "ProviderUnavailableError",
+    "build_provider",
+    "resolve_api_key_env_var",
+    "resolve_provider_selection",
+    "supported_providers",
+]
+
+# Built-in default model id. Mirrors the value tracer T1 hardcoded on
+# ``ModelConfig.SONNET`` so the no-flags / no-env / no-config path is
+# identical to today's behavior. Duplicated here as a literal (rather
+# than importing ``ModelConfig``) to keep this selection layer free of
+# any dependency on the orchestrator; the equality is pinned by a test.
+DEFAULT_MODEL: Final[str] = "claude-sonnet-4-5-20250929"
+
+# Built-in default provider. Anthropic remains the zero-config default.
+DEFAULT_PROVIDER: Final[str] = "anthropic"
+
+# Environment variables for the selection layer. Documented precedence
+# tier 2 (below CLI flags, above config-file keys).
+ENV_PROVIDER: Final[str] = "GREEN_LLM_PROVIDER"
+ENV_MODEL: Final[str] = "GREEN_LLM_MODEL"
+
+# Config-file keys read for tier 3.
+_CONFIG_PROVIDER_KEY: Final[str] = "llm_provider"
+_CONFIG_MODEL_KEY: Final[str] = "llm_model"
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Static metadata describing a selectable provider.
+
+    Attributes:
+        module: Dotted path of the module hosting the concrete
+            :class:`LLMProvider`. Imported lazily so the vendor SDK
+            can be an optional extra.
+        class_name: Name of the provider class within ``module``.
+        api_key_env_var: Environment variable the provider's API key
+            is read from (kept stable for backward compatibility).
+    """
+
+    module: str
+    class_name: str
+    api_key_env_var: str
+
+
+# Registry of every selectable provider. Tracer T2 ships only the
+# Anthropic entry (T3, #385, adds the second concrete provider). Keying
+# by the normalized provider name keeps lookup, validation, and the
+# "supported set" error message all driven by one source of truth.
+_PROVIDERS: Final[dict[str, ProviderSpec]] = {
+    "anthropic": ProviderSpec(
+        module="start_green_stay_green.ai.providers.anthropic_provider",
+        class_name="AnthropicProvider",
+        api_key_env_var="ANTHROPIC_API_KEY",  # pragma: allowlist secret
+    ),
+}
+
+
+class ProviderUnavailableError(ImportError):
+    """A selected provider's optional dependency is not installed.
+
+    Subclasses :class:`ImportError` so existing ``except ImportError``
+    handlers keep working, while the message adds an actionable
+    ``pip install ...[extra]`` hint instead of a bare
+    "No module named ...". The triggering :class:`ImportError` is
+    chained as ``__cause__``.
+    """
+
+
+@dataclass(frozen=True)
+class ProviderSelection:
+    """Resolved provider + model after applying precedence.
+
+    Attributes:
+        provider: Normalized provider name (a key of the registry).
+        model: Model identifier to generate with.
+    """
+
+    provider: str
+    model: str
+
+
+def supported_providers() -> tuple[str, ...]:
+    """Return the sorted tuple of registered provider names.
+
+    Returns:
+        Provider names in stable alphabetical order, suitable for
+        help text and error messages.
+    """
+    return tuple(sorted(_PROVIDERS))
+
+
+def _normalize(value: str | None) -> str | None:
+    """Trim and case-fold ``value``; treat blank/``None`` as unset.
+
+    Returns:
+        The normalized non-empty string, or ``None`` when ``value`` is
+        ``None`` or only whitespace (so the next precedence tier wins).
+    """
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed.casefold() if trimmed else None
+
+
+def _coalesce(*candidates: str | None) -> str | None:
+    """Return the first normalized, non-blank candidate, or ``None``.
+
+    Args:
+        *candidates: Values in descending precedence order.
+
+    Returns:
+        The first candidate that is not ``None`` after normalization.
+    """
+    for candidate in candidates:
+        normalized = _normalize(candidate)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def _coalesce_with_default(default: str, *candidates: str | None) -> str:
+    """Coalesce ``candidates`` then fall back to a guaranteed ``default``.
+
+    Args:
+        default: Non-blank fallback used when every candidate is unset.
+            Module-level constants (:data:`DEFAULT_PROVIDER`,
+            :data:`DEFAULT_MODEL`) supply this, so the result is always
+            a concrete ``str`` — no ``None`` and therefore no defensive
+            ``assert`` at the call site.
+        *candidates: Higher-precedence values in descending order.
+
+    Returns:
+        The first non-blank candidate, or the ``default`` (normalized).
+    """
+    return _coalesce(*candidates, default) or default
+
+
+def _require_known(provider: str) -> str:
+    """Validate ``provider`` is registered; return it unchanged.
+
+    Args:
+        provider: An already-normalized provider name.
+
+    Returns:
+        The same name when it is a registry key.
+
+    Raises:
+        ValueError: If the provider is not registered. The message
+            names the supported set so the user can self-correct.
+    """
+    if provider not in _PROVIDERS:
+        supported = ", ".join(supported_providers())
+        msg = f"Unknown LLM provider {provider!r}. Supported providers: {supported}."
+        raise ValueError(msg)
+    return provider
+
+
+def resolve_provider_selection(
+    *,
+    provider_flag: str | None,
+    model_flag: str | None,
+    config: Mapping[str, str],
+    env: Mapping[str, str],
+) -> ProviderSelection:
+    """Collapse the four config tiers into one :class:`ProviderSelection`.
+
+    Precedence (highest first), resolved independently per field:
+
+    1. CLI flag (``provider_flag`` / ``model_flag``)
+    2. Environment (``GREEN_LLM_PROVIDER`` / ``GREEN_LLM_MODEL``)
+    3. Config-file keys (``llm_provider`` / ``llm_model``)
+    4. Built-in default (:data:`DEFAULT_PROVIDER` / :data:`DEFAULT_MODEL`)
+
+    Blank / whitespace-only values at any tier are treated as unset, so
+    they fall through to the next tier rather than erroring.
+
+    Args:
+        provider_flag: Value of the ``--provider`` CLI flag, or ``None``.
+        model_flag: Value of the ``--model`` CLI flag, or ``None``.
+        config: Parsed config-file mapping (may be empty).
+        env: Environment mapping to read selection vars from (pass
+            ``os.environ`` in production; an explicit mapping keeps the
+            resolver pure and testable).
+
+    Returns:
+        The resolved :class:`ProviderSelection`.
+
+    Raises:
+        ValueError: If the resolved provider is not registered.
+    """
+    provider = _coalesce_with_default(
+        DEFAULT_PROVIDER,
+        provider_flag,
+        env.get(ENV_PROVIDER),
+        config.get(_CONFIG_PROVIDER_KEY),
+    )
+    model = _coalesce_with_default(
+        DEFAULT_MODEL,
+        model_flag,
+        env.get(ENV_MODEL),
+        config.get(_CONFIG_MODEL_KEY),
+    )
+    return ProviderSelection(provider=_require_known(provider), model=model)
+
+
+def resolve_api_key_env_var(provider: str) -> str:
+    """Return the env var holding ``provider``'s API key.
+
+    Args:
+        provider: Provider name (normalized internally).
+
+    Returns:
+        The environment-variable name (for Anthropic,
+        ``ANTHROPIC_API_KEY`` — unchanged from before T2).
+
+    Raises:
+        ValueError: If the provider is not registered.
+    """
+    normalized = _normalize(provider) or ""
+    return _PROVIDERS[_require_known(normalized)].api_key_env_var
+
+
+def build_provider(
+    provider: str,
+    *,
+    api_key: str,
+    model: str,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
+) -> LLMProvider:
+    """Construct the concrete :class:`LLMProvider` for ``provider``.
+
+    The provider's module is imported lazily so the vendor SDK can be
+    an optional install extra: importing this selection module — and
+    therefore ``import start_green_stay_green`` and ``green --help`` —
+    never requires any provider SDK.
+
+    Args:
+        provider: Provider name (normalized internally).
+        api_key: API key forwarded to the provider constructor.
+        model: Model identifier to generate with.
+        max_retries: Maximum retry attempts. Defaults to 3.
+        retry_delay: Initial retry delay in seconds. Defaults to 1.0.
+
+    Constructing the provider is cheap and performs no I/O or SDK
+    import: the vendor SDK is only loaded when a generation method
+    runs, at which point a missing extra is reported as a
+    :class:`ProviderUnavailableError` by the provider itself. This is
+    what lets ``import start_green_stay_green`` and ``green --help``
+    work without the extra installed.
+
+    Returns:
+        A constructed provider satisfying the :class:`LLMProvider`
+        contract.
+
+    Raises:
+        ValueError: If the provider is not registered.
+    """
+    normalized = _normalize(provider) or ""
+    spec = _PROVIDERS[_require_known(normalized)]
+    provider_cls = _load_provider_class(spec)
+    return provider_cls(
+        api_key,
+        model=model,
+        max_retries=max_retries,
+        retry_delay=retry_delay,
+    )
+
+
+def _load_provider_class(spec: ProviderSpec) -> _ProviderFactory:
+    """Import and return the provider class named by ``spec``.
+
+    The provider *module* is import-clean (it imports its vendor SDK
+    lazily), so importing it here does not require the optional extra.
+    The extra is only needed when a provider method runs.
+
+    Args:
+        spec: Registry entry describing where the class lives.
+
+    Returns:
+        The provider class, typed as the shared
+        :class:`_ProviderFactory` constructor protocol.
+    """
+    from importlib import (  # noqa: PLC0415 — keep import-time cost off the hot path
+        import_module,
+    )
+
+    module = import_module(spec.module)
+    provider_cls: _ProviderFactory = getattr(module, spec.class_name)
+    return provider_cls

--- a/start_green_stay_green/ai/providers/anthropic_provider.py
+++ b/start_green_stay_green/ai/providers/anthropic_provider.py
@@ -11,8 +11,16 @@ interface instead of on ``anthropic`` directly.
 
 This is a pure relocation: the behavior, model identifiers, retry
 schedule, and telemetry are byte-for-byte the same as before the
-split. ``anthropic`` remains a hard dependency here (made optional in
-a later tracer, not now).
+split.
+
+As of tracer T2 (#383) ``anthropic`` is an *optional* install extra
+(``pip install 'start-green-stay-green[anthropic]'``). Every reference
+to the SDK is therefore imported lazily inside the methods that need
+it — never at module import time — so ``import start_green_stay_green``
+and ``green --help`` work without the extra installed. The selection
+layer (:mod:`start_green_stay_green.ai.provider_selection`) imports
+this module lazily and translates the resulting :class:`ImportError`
+into an actionable install hint.
 """
 
 from __future__ import annotations
@@ -21,15 +29,13 @@ import asyncio
 from collections.abc import AsyncIterable
 from datetime import UTC
 from datetime import datetime
+import sys
 import time
 from typing import Final
+from typing import Never
 from typing import TYPE_CHECKING
+from typing import TypeGuard
 from typing import cast
-
-from anthropic import Anthropic
-from anthropic import AsyncAnthropic
-from anthropic.types import TextBlock
-from anthropic.types import ToolUseBlock
 
 from start_green_stay_green.ai.batch import BatchError
 from start_green_stay_green.ai.batch import BatchPoll
@@ -53,6 +59,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Sequence
 
+    from anthropic import Anthropic
+    from anthropic import AsyncAnthropic
+    from anthropic.types import TextBlock
+    from anthropic.types import ToolUseBlock
     from anthropic.types.messages.batch_create_params import (
         Request as BatchCreateRequest,
     )
@@ -61,6 +71,117 @@ if TYPE_CHECKING:
     from start_green_stay_green.utils.timing import TimingReport
 
 __all__ = ["AnthropicProvider"]
+
+# ``pip`` extra that installs the SDK; named in the missing-dependency
+# hint so users can copy/paste the fix.
+_INSTALL_EXTRA: Final[str] = "anthropic"
+
+# Names this module exposes lazily from the ``anthropic`` SDK via
+# :func:`__getattr__`. Resolved on first *attribute* access
+# (``anthropic_provider.Anthropic``) rather than at import time, so the
+# module imports without the optional extra. ``unittest.mock.patch``
+# targets these exact attribute paths, so the lazy seam is also the
+# test seam — existing patches keep working unchanged.
+_SDK_EXPORTS: Final[dict[str, tuple[str, str]]] = {
+    "Anthropic": ("anthropic", "Anthropic"),
+    "AsyncAnthropic": ("anthropic", "AsyncAnthropic"),
+    "TextBlock": ("anthropic.types", "TextBlock"),
+    "ToolUseBlock": ("anthropic.types", "ToolUseBlock"),
+}
+
+
+def _raise_missing_sdk(exc: ImportError) -> Never:
+    """Re-raise an SDK ``ImportError`` as an actionable error.
+
+    The ``anthropic`` SDK is an optional install extra (#383). When a
+    provider method needs it but it is absent, surface a
+    :class:`~start_green_stay_green.ai.provider_selection.ProviderUnavailableError`
+    carrying a ``pip install`` hint instead of a bare "No module named
+    'anthropic'". The triggering :class:`ImportError` is chained.
+
+    Args:
+        exc: The original import failure.
+
+    Raises:
+        ProviderUnavailableError: Always.
+    """
+    from start_green_stay_green.ai.provider_selection import (  # noqa: PLC0415 — lazy to avoid an import cycle
+        ProviderUnavailableError,
+    )
+
+    msg = (
+        f"The {_INSTALL_EXTRA!r} provider requires an optional dependency "
+        f"that is not installed. Install it with: "
+        f"pip install 'start-green-stay-green[{_INSTALL_EXTRA}]'"
+    )
+    raise ProviderUnavailableError(msg) from exc
+
+
+def __getattr__(name: str) -> object:
+    """Lazily resolve SDK names off the optional ``anthropic`` extra.
+
+    Implements PEP 562 module-level attribute access so
+    ``anthropic_provider.Anthropic`` (and the other entries in
+    :data:`_SDK_EXPORTS`) import the SDK on first use rather than at
+    module import time. A missing extra is reported as an actionable
+    :class:`ProviderUnavailableError`, never a raw :class:`ImportError`.
+
+    Args:
+        name: The attribute being accessed on the module.
+
+    Returns:
+        The requested SDK object.
+
+    Raises:
+        AttributeError: If ``name`` is not a known SDK export.
+        ProviderUnavailableError: If the SDK extra is not installed.
+    """
+    target = _SDK_EXPORTS.get(name)
+    if target is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr = target
+    from importlib import (  # noqa: PLC0415 — lazy, keeps import cost off hot path
+        import_module,
+    )
+
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        _raise_missing_sdk(exc)
+    return getattr(module, attr)
+
+
+def _sdk_attr(name: str) -> object:
+    """Fetch an SDK export off *this module*, honoring any test patch.
+
+    Reading through ``sys.modules[__name__]`` means a
+    ``unittest.mock.patch("...anthropic_provider.Anthropic")`` (which
+    sets the attribute in the module ``__dict__``) is found first, and
+    otherwise :func:`__getattr__` resolves the real SDK lazily. This is
+    what keeps the lazy-import seam and the existing test seam one and
+    the same.
+    """
+    return getattr(sys.modules[__name__], name)
+
+
+def _is_text_block(block: object) -> TypeGuard[TextBlock]:
+    """Return whether ``block`` is an Anthropic ``TextBlock``.
+
+    The SDK type is resolved lazily via :func:`__getattr__` so the
+    module stays import-clean without the extra. Returning
+    :class:`~typing.TypeGuard` preserves the type narrowing callers
+    relied on before the SDK import was made lazy, so accessing
+    ``block.text`` afterwards stays type-safe.
+    """
+    text_block_cls = cast("type[TextBlock]", _sdk_attr("TextBlock"))
+    return isinstance(block, text_block_cls)
+
+
+def _is_tool_use_block(block: object) -> TypeGuard[ToolUseBlock]:
+    """Return whether ``block`` is an Anthropic ``ToolUseBlock``."""
+    tool_use_block_cls = cast("type[ToolUseBlock]", _sdk_attr("ToolUseBlock"))
+    return isinstance(block, tool_use_block_cls)
 
 
 # Per-call max_tokens for every Claude request the provider issues —
@@ -203,7 +324,7 @@ class AnthropicProvider(LLMProvider):
 
         # Extract content from response
         first_block = response.content[0]
-        if not isinstance(first_block, TextBlock):
+        if not _is_text_block(first_block):
             msg = "Expected TextBlock in response"
             raise GenerationError(msg)
 
@@ -339,8 +460,14 @@ class AnthropicProvider(LLMProvider):
         Raises:
             GenerationError: If API call fails or response invalid.
         """
-        # Use context manager to ensure httpx client is properly closed
-        with Anthropic(api_key=self._api_key) as client:
+        # Resolve the SDK client lazily through the module's __getattr__
+        # seam so the module imports without the optional ``anthropic``
+        # extra (#383); a missing extra becomes an actionable
+        # ProviderUnavailableError, not a raw ImportError.
+        client_cls = cast("type[Anthropic]", _sdk_attr("Anthropic"))
+
+        # Use context manager to ensure httpx client is properly closed.
+        with client_cls(api_key=self._api_key) as client:
             return self._retry_with_backoff(client, prompt, output_format)
 
     def _get_async_client(self) -> AsyncAnthropic:
@@ -355,7 +482,11 @@ class AnthropicProvider(LLMProvider):
         *not* call this from ``ThreadPoolExecutor``.
         """
         if self._async_client is None:
-            self._async_client = AsyncAnthropic(api_key=self._api_key)
+            # Resolve lazily through the module __getattr__ seam so the
+            # optional ``anthropic`` extra stays optional (#383); a
+            # missing extra becomes an actionable ProviderUnavailableError.
+            async_cls = cast("type[AsyncAnthropic]", _sdk_attr("AsyncAnthropic"))
+            self._async_client = async_cls(api_key=self._api_key)
         return self._async_client
 
     async def _call_api_async(
@@ -381,7 +512,7 @@ class AnthropicProvider(LLMProvider):
         )
 
         first_block = response.content[0]
-        if not isinstance(first_block, TextBlock):
+        if not _is_text_block(first_block):
             msg = "Expected TextBlock in response"
             raise GenerationError(msg)
 
@@ -487,7 +618,7 @@ class AnthropicProvider(LLMProvider):
         response = await client.messages.create(**params)  # type: ignore[call-overload]
 
         tool_block = next(
-            (b for b in response.content if isinstance(b, ToolUseBlock)),
+            (b for b in response.content if _is_tool_use_block(b)),
             None,
         )
         if tool_block is None:

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -42,6 +42,12 @@ from start_green_stay_green.ai.batch_dispatch import resume_subagent_batch
 from start_green_stay_green.ai.batch_dispatch import submit_subagent_batch
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
+from start_green_stay_green.ai.provider_selection import ProviderSelection
+from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
+from start_green_stay_green.ai.provider_selection import build_provider
+from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
+from start_green_stay_green.ai.provider_selection import resolve_provider_selection
+from start_green_stay_green.ai.provider_selection import supported_providers
 from start_green_stay_green.generators.architecture import (
     ArchitectureEnforcementGenerator,
 )
@@ -132,6 +138,31 @@ config_file_option = Annotated[
         "--config-file",
         help="Path to configuration file (YAML or TOML).",
         exists=False,
+    ),
+]
+
+provider_option = Annotated[
+    str | None,
+    typer.Option(
+        "--provider",
+        help=(
+            "LLM provider for AI features. Precedence: this flag > "
+            "GREEN_LLM_PROVIDER env > config file > default (anthropic). "
+            "The provider's API key is read from its own env var "
+            "(ANTHROPIC_API_KEY for anthropic)."
+        ),
+    ),
+]
+
+model_option = Annotated[
+    str | None,
+    typer.Option(
+        "--model",
+        help=(
+            "Model identifier for AI features. Precedence: this flag > "
+            "GREEN_LLM_MODEL env > config file > the provider's default "
+            "model."
+        ),
     ),
 ]
 
@@ -503,6 +534,7 @@ def _warn_if_cli_api_key(source: str) -> None:
 
 def _lazy_api_key_sources(
     api_key_arg: str | None,
+    api_key_env_var: str = "ANTHROPIC_API_KEY",
 ) -> Generator[tuple[str | None, str]]:
     """Yield API key sources lazily to avoid unnecessary keychain prompts.
 
@@ -511,26 +543,35 @@ def _lazy_api_key_sources(
 
     Args:
         api_key_arg: API key from command line argument.
+        api_key_env_var: Name of the environment variable holding the
+            selected provider's key (``ANTHROPIC_API_KEY`` for the
+            default Anthropic provider, kept unchanged).
 
     Yields:
         (key_or_none, source_name) tuples.
     """
     yield api_key_arg, "command line"
     yield get_api_key_from_keyring(), "keyring"
-    yield os.getenv("ANTHROPIC_API_KEY"), "environment variable"
+    yield os.getenv(api_key_env_var), "environment variable"
 
 
 def _get_api_key_with_source(
     api_key_arg: str | None,
+    api_key_env_var: str = "ANTHROPIC_API_KEY",
     *,
     no_interactive: bool,
 ) -> tuple[str, str] | tuple[None, None]:
     """Get API key from the first available source.
 
+    Args:
+        api_key_arg: API key from the command line argument.
+        api_key_env_var: Environment variable to read the key from.
+        no_interactive: Disable the interactive keyring prompt.
+
     Returns:
         (api_key, source) tuple, or (None, None) if not found.
     """
-    for key, source in _lazy_api_key_sources(api_key_arg):
+    for key, source in _lazy_api_key_sources(api_key_arg, api_key_env_var):
         if key:
             _warn_if_cli_api_key(source)
             return key, source
@@ -543,34 +584,135 @@ def _get_api_key_with_source(
     return None, None
 
 
+@dataclass(frozen=True)
+class _SelectionInputs:
+    """The three provider/model selection inputs threaded from a command.
+
+    Bundles the ``--provider`` / ``--model`` flag values and the parsed
+    config-file mapping so the orchestrator-init helpers pass one object
+    instead of three loose arguments (keeping them under the project's
+    argument-count limit).
+
+    Attributes:
+        provider_flag: Value of ``--provider`` (or ``None``).
+        model_flag: Value of ``--model`` (or ``None``).
+        config_data: Parsed config-file mapping (may be empty).
+    """
+
+    provider_flag: str | None = None
+    model_flag: str | None = None
+    config_data: dict[str, str] | None = None
+
+
+def _resolve_orchestrator_selection(
+    inputs: _SelectionInputs,
+) -> ProviderSelection | None:
+    """Resolve the provider/model selection, reporting any bad input.
+
+    Args:
+        inputs: The bundled ``--provider`` / ``--model`` / config-file
+            selection inputs.
+
+    Returns:
+        The resolved :class:`ProviderSelection`, or ``None`` when the
+        provider name is unknown (an error has already been printed).
+    """
+    try:
+        return resolve_provider_selection(
+            provider_flag=inputs.provider_flag,
+            model_flag=inputs.model_flag,
+            config=inputs.config_data or {},
+            env=os.environ,
+        )
+    except ValueError as e:
+        supported = ", ".join(supported_providers())
+        console.print(
+            f"[red]Error:[/red] {e} (supported: {supported})",
+            style="bold",
+        )
+        return None
+
+
+def _build_orchestrator_from_selection(
+    selection: ProviderSelection,
+    api_key: str,
+    source: str,
+) -> AIOrchestrator | None:
+    """Build an orchestrator from a resolved selection and key.
+
+    Args:
+        selection: Resolved provider/model.
+        api_key: Resolved API key for the provider.
+        source: Human-readable origin of the key (for the status line).
+
+    Returns:
+        The constructed :class:`AIOrchestrator`, or ``None`` if the
+        provider's optional extra is missing or the key is rejected
+        (an actionable error has already been printed).
+    """
+    try:
+        provider = build_provider(
+            selection.provider,
+            api_key=api_key,
+            model=selection.model,
+        )
+        orchestrator = AIOrchestrator(
+            api_key=api_key,
+            model=selection.model,
+            provider=provider,
+        )
+    except ProviderUnavailableError as e:
+        console.print(f"[red]Error:[/red] {e}", style="bold")
+        return None
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] Invalid API key: {e}", style="bold")
+        return None
+    console.print(
+        f"[green]✓[/green] AI features enabled "
+        f"({selection.provider} {selection.model}, key from {source})"
+    )
+    return orchestrator
+
+
 def _initialize_orchestrator(
     api_key_arg: str | None = None,
     *,
     no_interactive: bool = False,
+    selection_inputs: _SelectionInputs | None = None,
 ) -> AIOrchestrator | None:
-    """Initialize AI orchestrator with optional API key.
+    """Initialize AI orchestrator with a resolved provider/model + key.
+
+    Provider and model are resolved with the precedence CLI flag > env
+    (``GREEN_LLM_PROVIDER`` / ``GREEN_LLM_MODEL``) > config file >
+    built-in default (Anthropic + the current model id). The API key is
+    then read from the *selected* provider's env var
+    (``ANTHROPIC_API_KEY`` for Anthropic), keyring, or CLI argument.
 
     Args:
         api_key_arg: API key from CLI argument.
         no_interactive: Disable interactive prompts.
+        selection_inputs: Bundled ``--provider`` / ``--model`` /
+            config-file selection inputs. Defaults to an empty bundle,
+            which resolves to the built-in Anthropic default.
 
     Returns:
-        AIOrchestrator instance if API key found, None otherwise.
+        AIOrchestrator instance if a provider and key resolve, else None.
     """
-    api_key, source = _get_api_key_with_source(
-        api_key_arg, no_interactive=no_interactive
+    selection = _resolve_orchestrator_selection(
+        selection_inputs or _SelectionInputs(),
     )
-
-    if not api_key:
+    if selection is None:
         return None
 
-    try:
-        orchestrator = AIOrchestrator(api_key=api_key)
-        console.print(f"[green]✓[/green] AI features enabled (from {source})")
-        return orchestrator  # noqa: TRY300  # Happy path return is clearer
-    except ValueError as e:
-        console.print(f"[red]Error:[/red] Invalid API key: {e}", style="bold")
+    api_key, source = _get_api_key_with_source(
+        api_key_arg,
+        resolve_api_key_env_var(selection.provider),
+        no_interactive=no_interactive,
+    )
+    if api_key is None or source is None:
         return None
+
+    return _build_orchestrator_from_selection(selection, api_key, source)
 
 
 def _copy_reference_skills(
@@ -1490,6 +1632,7 @@ def _resolve_pass2_orchestrator(
     offline: bool,
     no_enhance: bool,
     no_interactive: bool,
+    selection_inputs: _SelectionInputs | None = None,
 ) -> AIOrchestrator | None:
     """Decide whether Pass 2 should run, and return the orchestrator if so.
 
@@ -1513,7 +1656,11 @@ def _resolve_pass2_orchestrator(
         )
         return None
 
-    orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
+    orchestrator = _initialize_orchestrator(
+        api_key,
+        no_interactive=no_interactive,
+        selection_inputs=selection_inputs,
+    )
 
     if no_enhance:
         # Always print *something* so the user knows --no-enhance had an
@@ -1706,6 +1853,8 @@ def init(  # noqa: PLR0913
         ),
     ] = None,
     config: config_file_option = None,
+    provider: provider_option = None,
+    model: model_option = None,
 ) -> None:
     """Initialize a new project with quality controls.
 
@@ -1731,6 +1880,8 @@ def init(  # noqa: PLR0913
         enable_live_dashboard: Generate live metrics dashboard with workflow.
         timing_json: Optional path to write a timing/telemetry JSON report.
         config: Configuration file path.
+        provider: Optional LLM provider override (``--provider``).
+        model: Optional model override (``--model``).
 
     Raises:
         typer.Exit: If validation fails or generation errors occur.
@@ -1775,6 +1926,11 @@ def init(  # noqa: PLR0913
         offline=offline,
         no_enhance=no_enhance,
         no_interactive=no_interactive,
+        selection_inputs=_SelectionInputs(
+            provider_flag=provider,
+            model_flag=model,
+            config_data=config_data,
+        ),
     )
 
     # Create project directory
@@ -1928,6 +2084,7 @@ def _require_enhance_orchestrator(
     api_key: str | None,
     *,
     no_interactive: bool,
+    selection_inputs: _SelectionInputs | None = None,
 ) -> AIOrchestrator:
     """Resolve an :class:`AIOrchestrator` for the ``enhance`` command.
 
@@ -1939,6 +2096,8 @@ def _require_enhance_orchestrator(
     Args:
         api_key: Optional CLI-supplied key.
         no_interactive: Skip any keyring prompts.
+        selection_inputs: Bundled ``--provider`` / ``--model`` /
+            config-file selection inputs.
 
     Returns:
         A real ``AIOrchestrator`` ready to dispatch.
@@ -1946,7 +2105,11 @@ def _require_enhance_orchestrator(
     Raises:
         typer.Exit: With code 1 if no key could be resolved.
     """
-    orchestrator = _initialize_orchestrator(api_key, no_interactive=no_interactive)
+    orchestrator = _initialize_orchestrator(
+        api_key,
+        no_interactive=no_interactive,
+        selection_inputs=selection_inputs,
+    )
     if orchestrator is None:
         console.print(
             "[red]Error:[/red] `green enhance` requires an Anthropic API "
@@ -2766,6 +2929,8 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
             ),
         ),
     ] = False,
+    provider: provider_option = None,
+    model: model_option = None,
 ) -> None:
     r"""Re-run Pass 2 (AI tuning) on an existing green-init project.
 
@@ -2799,6 +2964,8 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
             with ``--wait`` for in-process polling.
         wait: Block in-process when ``--batch`` is set; polls every
             30 s until the batch ends or the timeout elapses.
+        provider: Optional LLM provider override (``--provider``).
+        model: Optional model override (``--model``).
 
     Raises:
         typer.Exit: If the path is invalid, project metadata cannot
@@ -2820,7 +2987,14 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
     if wait and not batch:
         console.print("[red]Error:[/red] --wait only applies in --batch mode.")
         raise typer.Exit(code=1)
-    orchestrator = _require_enhance_orchestrator(api_key, no_interactive=no_interactive)
+    orchestrator = _require_enhance_orchestrator(
+        api_key,
+        no_interactive=no_interactive,
+        selection_inputs=_SelectionInputs(
+            provider_flag=provider,
+            model_flag=model,
+        ),
+    )
     file_writer = FileWriter(
         project_root=project_path,
         force=force,

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -47,7 +47,6 @@ from start_green_stay_green.ai.provider_selection import ProviderUnavailableErro
 from start_green_stay_green.ai.provider_selection import build_provider
 from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
 from start_green_stay_green.ai.provider_selection import resolve_provider_selection
-from start_green_stay_green.ai.provider_selection import supported_providers
 from start_green_stay_green.generators.architecture import (
     ArchitectureEnforcementGenerator,
 )
@@ -625,9 +624,10 @@ def _resolve_orchestrator_selection(
             env=os.environ,
         )
     except ValueError as e:
-        supported = ", ".join(supported_providers())
+        # ``e`` already names the supported set ("Supported providers: …"),
+        # so we must not append a second copy here (regression: #383).
         console.print(
-            f"[red]Error:[/red] {e} (supported: {supported})",
+            f"[red]Error:[/red] {e}",
             style="bold",
         )
         return None
@@ -2112,10 +2112,10 @@ def _require_enhance_orchestrator(
     )
     if orchestrator is None:
         console.print(
-            "[red]Error:[/red] `green enhance` requires an Anthropic API "
-            "key — there is no deterministic fallback for AI-tuned "
-            "artifacts.\n  Set ANTHROPIC_API_KEY (or store one in the "
-            "keyring on first run).",
+            "[red]Error:[/red] `green enhance` requires an API key for the "
+            "selected provider — there is no deterministic fallback for "
+            "AI-tuned artifacts.\n  Set ANTHROPIC_API_KEY (or store one in "
+            "the keyring on first run).",
             style="bold",
         )
         raise typer.Exit(code=1)

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -2965,7 +2965,15 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         wait: Block in-process when ``--batch`` is set; polls every
             30 s until the batch ends or the timeout elapses.
         provider: Optional LLM provider override (``--provider``).
-        model: Optional model override (``--model``).
+        model: Optional model override (``--model``). The case of the
+            model id is preserved verbatim (API identifiers are
+            case-sensitive).
+
+    Note:
+        Unlike ``green init``, ``enhance`` has no config-file tier: it
+        loads no config file, so provider/model resolve from CLI flag >
+        env (``GREEN_LLM_PROVIDER`` / ``GREEN_LLM_MODEL``) > built-in
+        default only. Wiring a config source is tracked as issue #396.
 
     Raises:
         typer.Exit: If the path is invalid, project metadata cannot
@@ -2990,6 +2998,11 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
     orchestrator = _require_enhance_orchestrator(
         api_key,
         no_interactive=no_interactive,
+        # ``enhance`` intentionally omits the config-file tier: it has no
+        # ``--config`` flag and loads no config file, so only CLI flag >
+        # env > built-in default apply here (3 tiers, vs. ``init``'s 4).
+        # ``config_data`` is therefore left unset (``None``). Wiring a
+        # config source into ``enhance`` is tracked as issue #396.
         selection_inputs=_SelectionInputs(
             provider_flag=provider,
             model_flag=model,

--- a/tests/unit/ai/test_provider_selection.py
+++ b/tests/unit/ai/test_provider_selection.py
@@ -1,0 +1,258 @@
+"""Unit tests for provider/model selection (tracer T2, #383).
+
+Pins three contracts the selection layer must satisfy:
+
+* **Precedence** — CLI flag > env (``GREEN_LLM_PROVIDER`` /
+  ``GREEN_LLM_MODEL``) > config-file key > built-in default
+  (Anthropic + :data:`DEFAULT_MODEL`). Each lower tier only wins when
+  every higher tier is unset.
+* **Normalization / validation** — provider names are normalized
+  (case-folded, trimmed) and unknown providers raise a clear
+  ``ValueError`` naming the supported set, never silently falling
+  back.
+* **Optional extra** — building the Anthropic provider succeeds when
+  the SDK is importable, and surfaces a
+  :class:`ProviderUnavailableError` with an actionable
+  ``pip install`` hint (not a raw ``ImportError``) when the extra is
+  absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+from start_green_stay_green.ai.orchestrator import ModelConfig
+from start_green_stay_green.ai.provider_selection import DEFAULT_MODEL
+from start_green_stay_green.ai.provider_selection import DEFAULT_PROVIDER
+from start_green_stay_green.ai.provider_selection import ProviderSelection
+from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
+from start_green_stay_green.ai.provider_selection import _coalesce
+from start_green_stay_green.ai.provider_selection import build_provider
+from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
+from start_green_stay_green.ai.provider_selection import resolve_provider_selection
+from start_green_stay_green.ai.providers.base import LLMProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# ----------------------------- precedence ---------------------------------
+def test_default_selection_matches_today() -> None:
+    """No flag / env / config → Anthropic + the current default model."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag=None,
+        config={},
+        env={},
+    )
+    assert selection == ProviderSelection(
+        provider=DEFAULT_PROVIDER,
+        model=DEFAULT_MODEL,
+    )
+    # The default model must be byte-for-byte today's hardcoded SONNET id
+    # so existing behavior is unchanged.
+    assert DEFAULT_MODEL == ModelConfig.SONNET
+    assert DEFAULT_PROVIDER == "anthropic"
+
+
+def test_cli_flag_beats_env_and_config() -> None:
+    """CLI flag wins over both env and config for provider and model."""
+    selection = resolve_provider_selection(
+        provider_flag="anthropic",
+        model_flag="model-from-flag",
+        config={"llm_provider": "config-provider", "llm_model": "config-model"},
+        env={
+            "GREEN_LLM_PROVIDER": "env-provider",
+            "GREEN_LLM_MODEL": "env-model",
+        },
+    )
+    assert selection.provider == "anthropic"
+    assert selection.model == "model-from-flag"
+
+
+def test_env_beats_config() -> None:
+    """Env var wins over config file when no CLI flag is given."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag=None,
+        config={"llm_provider": "anthropic", "llm_model": "config-model"},
+        env={"GREEN_LLM_MODEL": "env-model"},
+    )
+    assert selection.model == "env-model"
+
+
+def test_config_beats_default() -> None:
+    """Config-file key wins over the built-in default."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag=None,
+        config={"llm_model": "config-model"},
+        env={},
+    )
+    assert selection.model == "config-model"
+    assert selection.provider == DEFAULT_PROVIDER
+
+
+def test_per_field_precedence_is_independent() -> None:
+    """Provider and model resolve independently across tiers."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag="model-flag",
+        config={"llm_provider": "anthropic"},
+        env={},
+    )
+    assert selection.provider == "anthropic"
+    assert selection.model == "model-flag"
+
+
+# --------------------------- normalization --------------------------------
+@pytest.mark.parametrize("raw", ["Anthropic", "  anthropic  ", "ANTHROPIC"])
+def test_provider_name_is_normalized(raw: str) -> None:
+    """Provider names are case-folded and trimmed before lookup."""
+    selection = resolve_provider_selection(
+        provider_flag=raw,
+        model_flag=None,
+        config={},
+        env={},
+    )
+    assert selection.provider == "anthropic"
+
+
+def test_unknown_provider_raises_with_supported_set() -> None:
+    """An unknown provider fails loudly and names the supported set."""
+    with pytest.raises(ValueError, match="Unknown LLM provider") as exc:
+        resolve_provider_selection(
+            provider_flag="openai",
+            model_flag=None,
+            config={},
+            env={},
+        )
+    assert "anthropic" in str(exc.value)
+
+
+def test_blank_provider_falls_through_to_next_tier() -> None:
+    """A whitespace-only flag is treated as unset, not as an error."""
+    selection = resolve_provider_selection(
+        provider_flag="   ",
+        model_flag=None,
+        config={"llm_provider": "anthropic"},
+        env={},
+    )
+    assert selection.provider == "anthropic"
+
+
+def test_blank_model_falls_through_to_default() -> None:
+    """A whitespace-only model flag falls through to the default."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag="  ",
+        config={},
+        env={},
+    )
+    assert selection.model == DEFAULT_MODEL
+
+
+def test_coalesce_returns_none_when_all_candidates_blank() -> None:
+    """All-blank inputs collapse to ``None`` (the no-default fallthrough)."""
+    assert _coalesce(None, "", "   ") is None
+
+
+# --------------------------- api-key env var ------------------------------
+def test_anthropic_api_key_env_var_is_unchanged() -> None:
+    """The Anthropic provider still reads ``ANTHROPIC_API_KEY``."""
+    assert resolve_api_key_env_var("anthropic") == "ANTHROPIC_API_KEY"
+
+
+def test_api_key_env_var_normalizes_provider() -> None:
+    """Provider name is normalized before env-var lookup."""
+    assert resolve_api_key_env_var("  Anthropic ") == "ANTHROPIC_API_KEY"
+
+
+def test_api_key_env_var_unknown_provider_raises() -> None:
+    """An unknown provider has no key env var and raises."""
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        resolve_api_key_env_var("nope")
+
+
+# ----------------------------- build_provider -----------------------------
+def test_build_provider_returns_anthropic_instance() -> None:
+    """``build_provider`` constructs a real provider when SDK present."""
+    provider = build_provider(
+        "anthropic",
+        api_key="sk-test",  # pragma: allowlist secret
+        model=DEFAULT_MODEL,
+        max_retries=2,
+        retry_delay=0.5,
+    )
+    assert isinstance(provider, LLMProvider)
+    assert provider.model == DEFAULT_MODEL
+
+
+def test_build_provider_unknown_raises() -> None:
+    """Building an unknown provider raises a clear ValueError."""
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        build_provider("openai", api_key="x", model="m")
+
+
+def _block_anthropic_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Make resolving the ``anthropic`` SDK raise ``ModuleNotFoundError``.
+
+    Simulates the optional extra being absent without uninstalling it
+    from the test environment. The provider's lazy seam resolves the
+    SDK through :func:`importlib.import_module`, so patching that to
+    reject ``anthropic`` (while leaving every other module importable)
+    faithfully reproduces a missing extra.
+    """
+    real_import_module: Callable[..., object] = importlib.import_module
+
+    def _fake_import_module(name: str, *args: object, **kwargs: object) -> object:
+        if name == "anthropic" or name.startswith("anthropic."):
+            msg = "No module named 'anthropic'"
+            raise ModuleNotFoundError(msg)
+        return real_import_module(name, *args, **kwargs)
+
+    # The provider seam resolves the SDK via ``importlib.import_module``;
+    # patch that exact symbol so only ``anthropic`` is blocked.
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+
+def test_build_provider_succeeds_without_touching_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructing a provider never imports the SDK (cheap + I/O-free).
+
+    The optional extra is only needed once a generation method runs, so
+    ``build_provider`` must succeed even when the SDK is absent — this is
+    what keeps ``import start_green_stay_green`` / ``green --help``
+    working without the extra.
+    """
+    _block_anthropic_import(monkeypatch)
+    provider = build_provider("anthropic", api_key="x", model="m")
+    assert provider.model == "m"
+
+
+def test_missing_extra_raises_actionable_error_on_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Using a provider whose extra is absent yields an install hint."""
+    _block_anthropic_import(monkeypatch)
+    provider = build_provider("anthropic", api_key="x", model="m")
+
+    with pytest.raises(ProviderUnavailableError) as exc:
+        provider.generate("hello", "yaml")
+
+    message = str(exc.value)
+    assert "pip install" in message
+    assert "anthropic" in message
+    # The original ImportError must be chained, not swallowed.
+    assert isinstance(exc.value.__cause__, ImportError)
+
+
+def test_provider_unavailable_is_importerror_subclass() -> None:
+    """Callers catching ImportError still catch the friendlier error."""
+    assert issubclass(ProviderUnavailableError, ImportError)

--- a/tests/unit/ai/test_provider_selection.py
+++ b/tests/unit/ai/test_provider_selection.py
@@ -160,6 +160,74 @@ def test_coalesce_returns_none_when_all_candidates_blank() -> None:
     assert _coalesce(None, "", "   ") is None
 
 
+# ----------------------- model-id case preservation -----------------------
+def test_model_flag_preserves_mixed_case() -> None:
+    """A ``--model`` value keeps its exact case (model ids are case-sensitive)."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag="Claude-Sonnet-MixedCase",
+        config={},
+        env={},
+    )
+    assert selection.model == "Claude-Sonnet-MixedCase"
+
+
+def test_env_model_preserves_mixed_case() -> None:
+    """``GREEN_LLM_MODEL`` keeps its exact case through resolution."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag=None,
+        config={},
+        env={"GREEN_LLM_MODEL": "GPT-4o-Env"},
+    )
+    assert selection.model == "GPT-4o-Env"
+
+
+def test_config_model_preserves_mixed_case() -> None:
+    """A config ``llm_model`` value keeps its exact case through resolution."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag=None,
+        config={"llm_model": "Config-Model-CamelCase"},
+        env={},
+    )
+    assert selection.model == "Config-Model-CamelCase"
+
+
+def test_model_flag_is_trimmed_but_not_folded() -> None:
+    """Surrounding whitespace is stripped from the model, but case is kept."""
+    selection = resolve_provider_selection(
+        provider_flag=None,
+        model_flag="  Foo-Bar  ",
+        config={},
+        env={},
+    )
+    assert selection.model == "Foo-Bar"
+
+
+@pytest.mark.parametrize(
+    ("provider_flag", "config", "env"),
+    [
+        ("ANTHROPIC", {}, {}),
+        (None, {"llm_provider": "ANTHROPIC"}, {}),
+        (None, {}, {"GREEN_LLM_PROVIDER": "ANTHROPIC"}),
+    ],
+)
+def test_provider_remains_case_insensitive_across_tiers(
+    provider_flag: str | None,
+    config: dict[str, str],
+    env: dict[str, str],
+) -> None:
+    """Provider names stay case-insensitive (registry keys) at every tier."""
+    selection = resolve_provider_selection(
+        provider_flag=provider_flag,
+        model_flag=None,
+        config=config,
+        env=env,
+    )
+    assert selection.provider == "anthropic"
+
+
 # --------------------------- api-key env var ------------------------------
 def test_anthropic_api_key_env_var_is_unchanged() -> None:
     """The Anthropic provider still reads ``ANTHROPIC_API_KEY``."""

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1964,6 +1964,40 @@ class TestEnhanceCommand:
     @patch("start_green_stay_green.cli._enhance_subagents")
     @patch("start_green_stay_green.cli._enhance_claude_md")
     @patch("start_green_stay_green.cli._initialize_orchestrator")
+    def test_omits_config_tier_by_design(
+        self,
+        mock_init: Mock,
+        mock_claude: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_subagents: Mock,  # noqa: ARG002 — kept for @patch ordering
+        tmp_path: Path,
+    ) -> None:
+        """``enhance`` intentionally has no config-file tier (see #396).
+
+        Unlike ``green init`` (4 tiers), ``enhance`` has no ``--config``
+        flag and loads no config file, so it deliberately wires only
+        CLI flag > env > built-in default. The selection inputs it builds
+        must therefore carry ``config_data is None`` — the config tier is
+        a no-op here. Tracked for future wiring as issue #396.
+        """
+        _make_orch_mock(mock_init)
+        project = self._make_project(tmp_path, name="no-config", language="python")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            ["enhance", str(project), "--model", "Flag-Model", "--no-interactive"],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        selection_inputs = mock_init.call_args.kwargs["selection_inputs"]
+        # The config tier is omitted by design: enhance has no config input.
+        assert selection_inputs.config_data is None
+        # The CLI ``--model`` flag still flows through (case preserved).
+        assert selection_inputs.model_flag == "Flag-Model"
+
+    @patch("start_green_stay_green.cli._enhance_subagents")
+    @patch("start_green_stay_green.cli._enhance_claude_md")
+    @patch("start_green_stay_green.cli._initialize_orchestrator")
     def test_default_runs_every_target(
         self,
         mock_init: Mock,

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -42,6 +42,7 @@ from start_green_stay_green import cli
 from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
+from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 from start_green_stay_green.utils.enhance_state import BatchProgress
@@ -521,6 +522,108 @@ class TestGetAPIKeyWithSource:
             key, source = cli._get_api_key_with_source(None, no_interactive=True)
             assert key is None
             assert source is None
+
+
+class TestProviderModelSelection:
+    """Test the ``--provider`` / ``--model`` selection wiring in the CLI."""
+
+    def test_lazy_sources_read_provider_specific_env_var(self) -> None:
+        """The env-var source honors the per-provider key var name."""
+        with (
+            patch(
+                "start_green_stay_green.cli.get_api_key_from_keyring",
+                return_value=None,
+            ),
+            patch.dict(
+                "os.environ",
+                {"CUSTOM_KEY_VAR": "custom-env-key"},  # pragma: allowlist secret
+                clear=True,
+            ),
+        ):
+            sources = list(cli._lazy_api_key_sources(None, "CUSTOM_KEY_VAR"))
+        # Last yielded source is the env var; it must read CUSTOM_KEY_VAR.
+        assert sources[-1] == ("custom-env-key", "environment variable")
+
+    @patch("start_green_stay_green.cli.AIOrchestrator")
+    @patch("start_green_stay_green.cli.build_provider")
+    @patch(
+        "start_green_stay_green.cli._get_api_key_with_source",
+        return_value=("k", "command line"),
+    )
+    def test_initialize_orchestrator_threads_flags_into_selection(
+        self,
+        mock_get_key: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_build: Mock,
+        mock_orch: Mock,
+    ) -> None:
+        """Flags resolve to a selection that drives build_provider + orchestrator."""
+        with patch.dict("os.environ", {}, clear=True):
+            cli._initialize_orchestrator(
+                api_key_arg="k",
+                no_interactive=True,
+                selection_inputs=cli._SelectionInputs(model_flag="model-from-flag"),
+            )
+        # build_provider receives the resolved provider + model.
+        _, build_kwargs = mock_build.call_args
+        assert mock_build.call_args.args[0] == "anthropic"
+        assert build_kwargs["model"] == "model-from-flag"
+        # The orchestrator is constructed with the resolved model + provider.
+        _, orch_kwargs = mock_orch.call_args
+        assert orch_kwargs["model"] == "model-from-flag"
+        assert orch_kwargs["provider"] is mock_build.return_value
+
+    @patch("start_green_stay_green.cli.console")
+    def test_initialize_orchestrator_unknown_provider_prints_and_returns_none(
+        self, mock_console: Mock
+    ) -> None:
+        """An unknown ``--provider`` prints an error and yields no orchestrator."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = cli._initialize_orchestrator(
+                api_key_arg="k",
+                no_interactive=True,
+                selection_inputs=cli._SelectionInputs(provider_flag="does-not-exist"),
+            )
+        assert result is None
+        mock_console.print.assert_called()
+
+    @patch("start_green_stay_green.cli.console")
+    @patch(
+        "start_green_stay_green.cli.build_provider",
+        side_effect=ProviderUnavailableError("install hint here"),
+    )
+    @patch(
+        "start_green_stay_green.cli._get_api_key_with_source",
+        return_value=("k", "command line"),
+    )
+    def test_initialize_orchestrator_missing_extra_prints_hint(
+        self,
+        mock_get_key: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_build: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_console: Mock,
+    ) -> None:
+        """A missing provider extra surfaces the install hint, not a crash."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = cli._initialize_orchestrator(api_key_arg="k", no_interactive=True)
+        assert result is None
+        printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+        assert "install hint here" in printed
+
+    @patch("start_green_stay_green.cli.build_provider")
+    @patch("start_green_stay_green.cli.AIOrchestrator")
+    @patch(
+        "start_green_stay_green.cli._get_api_key_with_source",
+        return_value=("k", "command line"),
+    )
+    def test_env_var_selects_model_over_default(
+        self,
+        mock_get_key: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_orch: Mock,  # noqa: ARG002 — kept for @patch ordering
+        mock_build: Mock,
+    ) -> None:
+        """``GREEN_LLM_MODEL`` overrides the default model when no flag given."""
+        with patch.dict("os.environ", {"GREEN_LLM_MODEL": "env-model"}, clear=True):
+            cli._initialize_orchestrator(api_key_arg="k", no_interactive=True)
+        assert mock_build.call_args.kwargs["model"] == "env-model"
 
 
 class TestInitCommand:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -585,6 +585,12 @@ class TestProviderModelSelection:
             )
         assert result is None
         mock_console.print.assert_called()
+        printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+        # The supported set must appear exactly once — the underlying
+        # ``ValueError`` already names it, so the CLI must not append a
+        # second ``(supported: …)`` copy (regression: #383).
+        assert printed.count("Supported providers:") == 1
+        assert "(supported:" not in printed
 
     @patch("start_green_stay_green.cli.console")
     @patch(
@@ -1949,7 +1955,10 @@ class TestEnhanceCommand:
         )
         assert result.exit_code == 1
         flat = self._flat(result.stdout)
-        assert "requires an Anthropic API key" in flat
+        # ``enhance`` now accepts ``--provider``/``--model``, so the
+        # no-key message must be provider-neutral (regression: #383).
+        assert "requires an API key for the selected provider" in flat
+        assert "Anthropic API key" not in flat
         assert "ANTHROPIC_API_KEY" in flat
 
     @patch("start_green_stay_green.cli._enhance_subagents")


### PR DESCRIPTION
## Summary
- New `ai/provider_selection.py`: `resolve_provider_selection(...)` resolves provider & model independently with precedence **CLI flag > env (`GREEN_LLM_PROVIDER`/`GREEN_LLM_MODEL`) > config-file key > built-in default** (default `anthropic` + current SONNET id — byte-for-byte today's behavior). Unknown providers raise `ValueError`; `build_provider(...)` lazily imports the concrete provider.
- CLI: `--provider`/`--model` on `green init` and `green enhance`, threaded to orchestrator init; API-key env var resolved per selected provider.
- **`anthropic` is now an optional `[anthropic]` extra** (moved out of core deps; kept in requirements-dev for the test env). `anthropic_provider.py` uses a PEP 562 module `__getattr__` for lazy SDK import; using a provider without the extra raises `ProviderUnavailableError` (ImportError subclass) with a `pip install '...[anthropic]'` hint. `import start_green_stay_green` and `green --help` work with the SDK absent.

## Test plan
- `tests/unit/ai/test_provider_selection.py` (20 tests): precedence per tier, independent per-field resolution, normalization/validation, env-var resolution, missing-extra path (SDK import blocked).
- New CLI tests: flag→selection threading, unknown-provider, missing-extra hint, env model override.
- `pre-commit run --all-files` 29/0; coverage 94.23% (`provider_selection.py` 100%, `anthropic_provider.py` 97%); full suite passes.
- No second concrete provider (that's T3 #385) and no behavior/model-default change.

Closes #383
Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
