### PR TITLE
test(release): automate v1.0.0 release-readiness checks + verification script (#152)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,10 @@ ignore = [
 "scripts/analyze_mutations.py" = [
     "S608",      # Allow SQL string formatting (parameterized queries used correctly)
 ]
+"scripts/verify_release_readiness.py" = [
+    "T201",      # CLI verification script prints user-facing pass/fail output
+    "S603",      # subprocess runs the trusted `sgsg` CLI resolved via shutil.which
+]
 "examples/**/*.py" = [
     "T201",      # Allow print in example scripts (user-facing output)
     "BLE001",    # Allow broad exception in example error handling

--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Automated v1.0.0 release-readiness verification (#152).
+
+Generates a Python project offline via the public ``sgsg`` CLI into a temporary
+directory and asserts the automatable, structural release-readiness criteria
+from the v1.0.0 manual testing plan:
+
+* core project structure (precommit config, scripts, README, source, tests),
+* generated quality scripts exist and are executable,
+* the pre-commit config declares enough hooks,
+* a CI workflow is present and is valid YAML,
+* the live metrics dashboard flow produces dashboard/metrics/workflow/script
+  artifacts.
+
+The script is deterministic and fully offline: no Anthropic API key is required
+and no network calls are made. Each check returns a (possibly empty) list of
+failure messages; the script reports all failures and exits non-zero if any
+check fails, so it can gate a release in CI.
+
+Usage:
+    python3 scripts/verify_release_readiness.py [--keep] [--help]
+
+Exit codes:
+    0  All automatable release-readiness checks passed.
+    1  One or more checks failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+# Minimum number of pre-commit hooks a generated Python project must declare.
+MIN_PRECOMMIT_HOOKS = 25
+
+# Quality scripts that must be generated and executable.
+REQUIRED_SCRIPTS = (
+    "check-all.sh",
+    "test.sh",
+    "lint.sh",
+    "format.sh",
+    "security.sh",
+    "mutation.sh",
+    "fix-all.sh",
+)
+
+# Critical structural files every generated Python project must contain.
+REQUIRED_FILES = (
+    ".pre-commit-config.yaml",
+    "README.md",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml",
+)
+
+# Dashboard artifacts produced by --enable-live-dashboard.
+DASHBOARD_ARTIFACTS = (
+    "docs/dashboard.html",
+    "docs/metrics.json",
+    ".github/workflows/metrics.yml",
+    "scripts/collect_metrics.py",
+)
+
+# Keys that the generated docs/metrics.json must contain.
+REQUIRED_METRICS_KEYS = ("timestamp", "project", "thresholds", "metrics")
+
+PROJECT_NAME = "release-readiness-check"
+
+
+def _offline_env() -> dict[str, str]:
+    """Return an environment with API keys stripped and keyring disabled.
+
+    Returns:
+        A copy of ``os.environ`` that prevents real Anthropic API calls.
+    """
+    env = os.environ.copy()
+    for key in ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"):
+        env.pop(key, None)
+    # Disable keyring lookups so no stored credentials trigger API calls.
+    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    return env
+
+
+def _run_init(output_dir: Path) -> list[str]:
+    """Generate a Python project with the live dashboard enabled, offline.
+
+    Args:
+        output_dir: Directory that will contain the generated project.
+
+    Returns:
+        A list of failure messages (empty when the CLI succeeds).
+    """
+    sgsg = shutil.which("sgsg")
+    if sgsg is None:
+        return ["'sgsg' CLI not found on PATH (install with: pip install -e .)"]
+
+    result = subprocess.run(
+        [
+            sgsg,
+            "init",
+            "--project-name",
+            PROJECT_NAME,
+            "--language",
+            "python",
+            "--output-dir",
+            str(output_dir),
+            "--enable-live-dashboard",
+            "--no-interactive",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_offline_env(),
+    )
+    if result.returncode != 0:
+        detail = f"{result.stdout}\n{result.stderr}".strip()
+        return [f"'sgsg init' failed (exit {result.returncode}): {detail}"]
+    return []
+
+
+def _check_required_files(project_dir: Path) -> list[str]:
+    """Check that critical structural files exist and are non-empty.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        A list of failure messages (empty when all files are present).
+    """
+    failures: list[str] = []
+    for relative in REQUIRED_FILES:
+        path = project_dir / relative
+        if not path.is_file():
+            failures.append(f"missing required file: {relative}")
+        elif path.stat().st_size == 0:
+            failures.append(f"required file is empty: {relative}")
+    return failures
+
+
+def _check_scripts_executable(project_dir: Path) -> list[str]:
+    """Check that each required quality script exists and is executable.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        A list of failure messages (empty when all scripts are runnable).
+    """
+    failures: list[str] = []
+    scripts_dir = project_dir / "scripts"
+    for name in REQUIRED_SCRIPTS:
+        path = scripts_dir / name
+        if not path.is_file():
+            failures.append(f"missing quality script: scripts/{name}")
+        elif not path.stat().st_mode & 0o111:
+            failures.append(f"quality script not executable: scripts/{name}")
+    return failures
+
+
+def _check_precommit_hooks(project_dir: Path) -> list[str]:
+    """Check that the pre-commit config declares at least the minimum hooks.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        A list of failure messages (empty when enough hooks are declared).
+    """
+    config = project_dir / ".pre-commit-config.yaml"
+    text = config.read_text(encoding="utf-8")
+    hook_count = sum(
+        1 for line in text.splitlines() if line.strip().startswith("- id:")
+    )
+    if hook_count < MIN_PRECOMMIT_HOOKS:
+        return [
+            f"pre-commit config declares {hook_count} hooks, "
+            f"expected >= {MIN_PRECOMMIT_HOOKS}"
+        ]
+    return []
+
+
+def _check_ci_workflow(project_dir: Path) -> list[str]:
+    """Check that at least one CI workflow exists and parses as valid YAML.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        A list of failure messages (empty when a valid workflow exists).
+    """
+    workflows_dir = project_dir / ".github" / "workflows"
+    workflows = sorted(workflows_dir.glob("*.yml")) if workflows_dir.is_dir() else []
+    if not workflows:
+        return ["no CI workflows found under .github/workflows/"]
+
+    failures: list[str] = []
+    for workflow in workflows:
+        try:
+            yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            failures.append(f"invalid YAML in {workflow.name}: {exc}")
+    return failures
+
+
+def _check_dashboard(project_dir: Path) -> list[str]:
+    """Check that dashboard artifacts exist and metrics.json is well-formed.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        A list of failure messages (empty when the dashboard is complete).
+    """
+    failures: list[str] = []
+    for relative in DASHBOARD_ARTIFACTS:
+        path = project_dir / relative
+        if not path.is_file():
+            failures.append(f"missing dashboard artifact: {relative}")
+        elif path.stat().st_size == 0:
+            failures.append(f"dashboard artifact is empty: {relative}")
+
+    metrics_path = project_dir / "docs" / "metrics.json"
+    if not metrics_path.is_file():
+        return failures
+
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    failures.extend(
+        f"metrics.json missing key: {key}"
+        for key in REQUIRED_METRICS_KEYS
+        if key not in metrics
+    )
+    if metrics.get("project") != PROJECT_NAME:
+        actual = metrics.get("project")
+        failures.append(
+            f"metrics.json project mismatch: {actual!r} != {PROJECT_NAME!r}"
+        )
+    return failures
+
+
+CHECKS = (
+    ("required files present", _check_required_files),
+    ("quality scripts executable", _check_scripts_executable),
+    ("pre-commit hook count", _check_precommit_hooks),
+    ("CI workflow valid", _check_ci_workflow),
+    ("live dashboard artifacts", _check_dashboard),
+)
+
+
+def _verify(project_dir: Path) -> int:
+    """Run every check against the generated project.
+
+    Args:
+        project_dir: Root of the generated project.
+
+    Returns:
+        Process exit code: 0 if all checks pass, 1 otherwise.
+    """
+    total_failures = 0
+    for label, check in CHECKS:
+        failures = check(project_dir)
+        if failures:
+            total_failures += len(failures)
+            for failure in failures:
+                print(f"  FAIL  {label}: {failure}")
+        else:
+            print(f"  PASS  {label}")
+    return 1 if total_failures else 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        The parsed arguments namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Automated v1.0.0 release-readiness verification (#152)."
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep the generated temp project for inspection.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate a project and run all release-readiness checks.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code: 0 on success, 1 on any failure.
+    """
+    args = _parse_args(argv)
+
+    print("Release-readiness verification (#152)")
+    tmpdir = Path(tempfile.mkdtemp(prefix="sgsg-release-"))
+    try:
+        print(f"Generating project in {tmpdir} ...")
+        init_failures = _run_init(tmpdir)
+        if init_failures:
+            for failure in init_failures:
+                print(f"  FAIL  generate project: {failure}")
+            return 1
+
+        project_dir = tmpdir / PROJECT_NAME
+        if not project_dir.is_dir():
+            print(f"  FAIL  project directory not created: {project_dir}")
+            return 1
+        exit_code = _verify(project_dir)
+    finally:
+        if args.keep:
+            print(f"Kept generated project at {tmpdir}")
+        else:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    if exit_code == 0:
+        print("All automatable release-readiness checks PASSED.")
+    else:
+        print("Release-readiness verification FAILED.")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -231,7 +231,11 @@ def _check_dashboard(project_dir: Path) -> list[str]:
     if not metrics_path.is_file():
         return failures
 
-    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    try:
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        failures.append(f"metrics.json is not valid JSON: {exc}")
+        return failures
     failures.extend(
         f"metrics.json missing key: {key}"
         for key in REQUIRED_METRICS_KEYS

--- a/scripts/verify_release_readiness.sh
+++ b/scripts/verify_release_readiness.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/verify_release_readiness.sh - Automated v1.0.0 release-readiness checks (#152)
+#
+# Thin wrapper around scripts/verify_release_readiness.py. Generates a Python
+# project offline via the public `sgsg` CLI and asserts the automatable
+# structural release-readiness criteria from the v1.0.0 manual testing plan.
+#
+# Usage: ./scripts/verify_release_readiness.sh [--keep] [--help]
+#
+# Exit codes:
+#   0  All automatable release-readiness checks passed.
+#   1  One or more checks failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage: ./scripts/verify_release_readiness.sh [--keep] [--help]
+
+Run automated v1.0.0 release-readiness verification (#152). Generates a Python
+project offline via the `sgsg` CLI and asserts critical files, executable
+scripts, pre-commit hook count, CI workflow validity, and live dashboard
+artifacts.
+
+Options:
+  --keep    Keep the generated temporary project for inspection.
+  --help    Show this help message and exit.
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
+exec python3 "$SCRIPT_DIR/verify_release_readiness.py" "$@"

--- a/tests/e2e/test_release_readiness_e2e.py
+++ b/tests/e2e/test_release_readiness_e2e.py
@@ -1,0 +1,162 @@
+"""E2E release-readiness checks for the v1.0.0 manual testing plan (#152).
+
+These tests automate the *automatable* portions of the v1.0.0 manual testing
+plan that were not already covered by the existing test suite. In particular
+they exercise the live metrics dashboard flow (``--enable-live-dashboard``)
+end-to-end through the real ``sgsg`` CLI, asserting the generated artifacts
+exist on disk and have the expected structure.
+
+The pre-existing dashboard tests in ``tests/unit/test_cli_mocked.py`` mock
+``MetricsGenerator`` and ``shutil.copy``, so they never verify that the real
+generator + template copy actually produces ``docs/dashboard.html``,
+``docs/metrics.json``, ``.github/workflows/metrics.yml`` and
+``scripts/collect_metrics.py`` on disk. This module fills that gap.
+
+All tests use an environment with API keys stripped and a null keyring backend
+to prevent real Anthropic API calls. See Issue #196. The dashboard flow is
+fully deterministic and offline (no API key required).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+from tests.conftest import get_env_without_api_keys
+
+# Artifacts that --enable-live-dashboard must produce (relative to project root).
+EXPECTED_DASHBOARD_ARTIFACTS = (
+    "docs/dashboard.html",
+    "docs/metrics.json",
+    ".github/workflows/metrics.yml",
+    "scripts/collect_metrics.py",
+)
+
+
+def _run_init_with_dashboard(
+    tmpdir: str, project_name: str
+) -> subprocess.CompletedProcess[str]:
+    """Run ``sgsg init`` with the live dashboard enabled, offline.
+
+    Args:
+        tmpdir: Output directory for the generated project.
+        project_name: Name of the project to generate.
+
+    Returns:
+        The completed subprocess result.
+    """
+    return subprocess.run(
+        [
+            "sgsg",
+            "init",
+            "--project-name",
+            project_name,
+            "--language",
+            "python",
+            "--output-dir",
+            tmpdir,
+            "--enable-live-dashboard",
+            "--no-interactive",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=get_env_without_api_keys(),
+    )
+
+
+class TestLiveDashboardE2E:
+    """E2E coverage for Part 1.3 of the #152 manual testing plan."""
+
+    def test_dashboard_artifacts_created_on_disk(self) -> None:
+        """Live dashboard flow creates all four expected artifacts on disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run_init_with_dashboard(tmpdir, "dash-e2e-project")
+
+            assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
+
+            project_dir = Path(tmpdir) / "dash-e2e-project"
+            assert project_dir.exists(), "Project directory not created"
+
+            for relative in EXPECTED_DASHBOARD_ARTIFACTS:
+                artifact = project_dir / relative
+                assert artifact.exists(), f"Missing dashboard artifact: {relative}"
+                assert (
+                    artifact.stat().st_size > 0
+                ), f"Empty dashboard artifact: {relative}"
+
+    def test_dashboard_html_references_metrics_json(self) -> None:
+        """Generated dashboard.html loads metrics.json and is a quality dashboard."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run_init_with_dashboard(tmpdir, "dash-html-project")
+            assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
+
+            dashboard = Path(tmpdir) / "dash-html-project" / "docs" / "dashboard.html"
+            content = dashboard.read_text(encoding="utf-8")
+
+            assert "Quality Metrics Dashboard" in content
+            assert "metrics.json" in content, "Dashboard should load metrics.json"
+
+    def test_metrics_json_has_expected_structure(self) -> None:
+        """Generated metrics.json is valid JSON with timestamp/project/metrics."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run_init_with_dashboard(tmpdir, "dash-json-project")
+            assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
+
+            metrics_path = Path(tmpdir) / "dash-json-project" / "docs" / "metrics.json"
+            data = json.loads(metrics_path.read_text(encoding="utf-8"))
+
+            assert "timestamp" in data, "metrics.json must record a timestamp"
+            assert data["project"] == "dash-json-project"
+            assert "thresholds" in data
+            assert "metrics" in data
+            # Thresholds match the release quality bar wired in cli.py.
+            assert data["thresholds"]["coverage"] == 90
+            assert data["thresholds"]["mutation_score"] == 80
+
+    def test_metrics_workflow_uses_project_name(self) -> None:
+        """metrics.yml is rebranded to the new project (no SGSG name leaks)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run_init_with_dashboard(tmpdir, "dash-wf-project")
+            assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
+
+            workflow = (
+                Path(tmpdir)
+                / "dash-wf-project"
+                / ".github"
+                / "workflows"
+                / "metrics.yml"
+            )
+            content = workflow.read_text(encoding="utf-8")
+
+            assert (
+                "start-green-stay-green" not in content
+            ), "Generated metrics.yml must not leak the SGSG project name"
+
+    def test_init_without_dashboard_omits_artifacts(self) -> None:
+        """Without --enable-live-dashboard, no dashboard artifacts are created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = subprocess.run(
+                [
+                    "sgsg",
+                    "init",
+                    "--project-name",
+                    "no-dash-project",
+                    "--language",
+                    "python",
+                    "--output-dir",
+                    tmpdir,
+                    "--no-interactive",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=get_env_without_api_keys(),
+            )
+            assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
+
+            project_dir = Path(tmpdir) / "no-dash-project"
+            assert not (project_dir / "docs" / "dashboard.html").exists()
+            assert not (project_dir / "docs" / "metrics.json").exists()

--- a/tests/e2e/test_release_readiness_e2e.py
+++ b/tests/e2e/test_release_readiness_e2e.py
@@ -96,7 +96,9 @@ class TestLiveDashboardE2E:
             dashboard = Path(tmpdir) / "dash-html-project" / "docs" / "dashboard.html"
             content = dashboard.read_text(encoding="utf-8")
 
-            assert "Quality Metrics Dashboard" in content
+            assert (
+                "Quality Metrics Dashboard" in content
+            ), "Dashboard should have its title heading"
             assert "metrics.json" in content, "Dashboard should load metrics.json"
 
     def test_metrics_json_has_expected_structure(self) -> None:
@@ -134,6 +136,9 @@ class TestLiveDashboardE2E:
             assert (
                 "start-green-stay-green" not in content
             ), "Generated metrics.yml must not leak the SGSG project name"
+            assert (
+                "dash-wf-project" in content
+            ), "Generated metrics.yml must reference the new project name"
 
     def test_init_without_dashboard_omits_artifacts(self) -> None:
         """Without --enable-live-dashboard, no dashboard artifacts are created."""
@@ -158,5 +163,7 @@ class TestLiveDashboardE2E:
             assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
 
             project_dir = Path(tmpdir) / "no-dash-project"
-            assert not (project_dir / "docs" / "dashboard.html").exists()
-            assert not (project_dir / "docs" / "metrics.json").exists()
+            for relative in EXPECTED_DASHBOARD_ARTIFACTS:
+                assert not (
+                    project_dir / relative
+                ).exists(), f"Unexpected dashboard artifact without flag: {relative}"

--- a/tests/unit/test_verify_release_readiness.py
+++ b/tests/unit/test_verify_release_readiness.py
@@ -1,0 +1,239 @@
+"""Tests for scripts/verify_release_readiness.py check functions (#152).
+
+These tests exercise the pure, filesystem-only check helpers against synthetic
+project trees so the logic is validated quickly and deterministically without
+invoking the real ``sgsg`` CLI. The end-to-end CLI flow is covered separately
+by ``tests/e2e/test_release_readiness_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import verify_release_readiness as vrr
+
+
+def _make_valid_project(root: Path) -> Path:
+    """Create a synthetic project tree that passes every check.
+
+    Args:
+        root: Directory under which to create the project.
+
+    Returns:
+        The project root path.
+    """
+    project = root / vrr.PROJECT_NAME
+    project.mkdir()
+
+    for relative in vrr.REQUIRED_FILES:
+        path = project / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("content\n", encoding="utf-8")
+
+    scripts_dir = project / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+    for name in vrr.REQUIRED_SCRIPTS:
+        script = scripts_dir / name
+        script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        script.chmod(0o755)
+
+    # Enough pre-commit hooks.
+    hooks = "repos:\n" + "".join(
+        f"  - id: hook-{i}\n" for i in range(vrr.MIN_PRECOMMIT_HOOKS)
+    )
+    (project / ".pre-commit-config.yaml").write_text(hooks, encoding="utf-8")
+
+    workflows = project / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / "ci.yml").write_text("name: CI\non: [push]\n", encoding="utf-8")
+    (workflows / "metrics.yml").write_text(
+        "name: Metrics\non: [push]\n", encoding="utf-8"
+    )
+
+    docs = project / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "dashboard.html").write_text(
+        "<html>metrics.json</html>\n", encoding="utf-8"
+    )
+    (docs / "metrics.json").write_text(
+        json.dumps(
+            {
+                "timestamp": "now",
+                "project": vrr.PROJECT_NAME,
+                "thresholds": {"coverage": 90},
+                "metrics": {"coverage": 0.0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (scripts_dir / "collect_metrics.py").write_text("# collector\n", encoding="utf-8")
+    return project
+
+
+class TestRequiredFiles:
+    """Tests for _check_required_files."""
+
+    def test_passes_when_all_present(self, tmp_path: Path) -> None:
+        """No failures when every required file exists and is non-empty."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._check_required_files(project) == []
+
+    def test_reports_missing_file(self, tmp_path: Path) -> None:
+        """A missing required file is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "README.md").unlink()
+        failures = vrr._check_required_files(project)
+        assert any("README.md" in f for f in failures)
+
+    def test_reports_empty_file(self, tmp_path: Path) -> None:
+        """An empty required file is reported as empty."""
+        project = _make_valid_project(tmp_path)
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+        failures = vrr._check_required_files(project)
+        assert any("empty" in f and "pyproject.toml" in f for f in failures)
+
+
+class TestScriptsExecutable:
+    """Tests for _check_scripts_executable."""
+
+    def test_passes_when_executable(self, tmp_path: Path) -> None:
+        """No failures when all scripts exist and are executable."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._check_scripts_executable(project) == []
+
+    def test_reports_missing_script(self, tmp_path: Path) -> None:
+        """A missing quality script is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "scripts" / "test.sh").unlink()
+        failures = vrr._check_scripts_executable(project)
+        assert any("test.sh" in f for f in failures)
+
+    def test_reports_non_executable_script(self, tmp_path: Path) -> None:
+        """A non-executable quality script is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "scripts" / "lint.sh").chmod(0o644)
+        failures = vrr._check_scripts_executable(project)
+        assert any("not executable" in f and "lint.sh" in f for f in failures)
+
+
+class TestPrecommitHooks:
+    """Tests for _check_precommit_hooks."""
+
+    def test_passes_with_enough_hooks(self, tmp_path: Path) -> None:
+        """No failures when hook count meets the minimum."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._check_precommit_hooks(project) == []
+
+    def test_reports_too_few_hooks(self, tmp_path: Path) -> None:
+        """Too few declared hooks are reported with the actual count."""
+        project = _make_valid_project(tmp_path)
+        (project / ".pre-commit-config.yaml").write_text(
+            "repos:\n  - id: only-one\n", encoding="utf-8"
+        )
+        failures = vrr._check_precommit_hooks(project)
+        assert len(failures) == 1
+        assert "1 hooks" in failures[0]
+
+
+class TestCIWorkflow:
+    """Tests for _check_ci_workflow."""
+
+    def test_passes_with_valid_yaml(self, tmp_path: Path) -> None:
+        """No failures when workflows exist and are valid YAML."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._check_ci_workflow(project) == []
+
+    def test_reports_no_workflows(self, tmp_path: Path) -> None:
+        """An absent workflows directory is reported."""
+        project = tmp_path / "empty"
+        project.mkdir()
+        failures = vrr._check_ci_workflow(project)
+        assert failures == ["no CI workflows found under .github/workflows/"]
+
+    def test_reports_invalid_yaml(self, tmp_path: Path) -> None:
+        """A malformed workflow YAML file is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / ".github" / "workflows" / "ci.yml").write_text(
+            "name: [unclosed\n", encoding="utf-8"
+        )
+        failures = vrr._check_ci_workflow(project)
+        assert any("invalid YAML" in f for f in failures)
+
+
+class TestDashboard:
+    """Tests for _check_dashboard."""
+
+    def test_passes_when_complete(self, tmp_path: Path) -> None:
+        """No failures when all dashboard artifacts are present and valid."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._check_dashboard(project) == []
+
+    def test_reports_missing_artifact(self, tmp_path: Path) -> None:
+        """A missing dashboard artifact is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "docs" / "dashboard.html").unlink()
+        failures = vrr._check_dashboard(project)
+        assert any("dashboard.html" in f for f in failures)
+
+    def test_reports_missing_metrics_key(self, tmp_path: Path) -> None:
+        """A metrics.json missing a required key is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "docs" / "metrics.json").write_text(
+            json.dumps({"project": vrr.PROJECT_NAME}), encoding="utf-8"
+        )
+        failures = vrr._check_dashboard(project)
+        assert any("missing key: timestamp" in f for f in failures)
+
+    def test_reports_project_name_mismatch(self, tmp_path: Path) -> None:
+        """A metrics.json with the wrong project name is reported."""
+        project = _make_valid_project(tmp_path)
+        (project / "docs" / "metrics.json").write_text(
+            json.dumps(
+                {
+                    "timestamp": "now",
+                    "project": "wrong-name",
+                    "thresholds": {},
+                    "metrics": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        failures = vrr._check_dashboard(project)
+        assert any("project mismatch" in f for f in failures)
+
+
+class TestOfflineEnv:
+    """Tests for _offline_env."""
+
+    def test_strips_api_keys_and_disables_keyring(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """API keys are removed and a null keyring backend is selected."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+        monkeypatch.setenv("CLAUDE_API_KEY", "secret")
+        env = vrr._offline_env()
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_API_KEY" not in env
+        assert env["PYTHON_KEYRING_BACKEND"] == "keyring.backends.null.Keyring"
+
+
+class TestVerify:
+    """Tests for _verify orchestration."""
+
+    def test_returns_zero_when_all_pass(self, tmp_path: Path) -> None:
+        """_verify returns 0 when every check passes."""
+        project = _make_valid_project(tmp_path)
+        assert vrr._verify(project) == 0
+
+    def test_returns_one_on_failure(self, tmp_path: Path) -> None:
+        """_verify returns 1 when any check fails."""
+        project = _make_valid_project(tmp_path)
+        (project / "README.md").unlink()
+        assert vrr._verify(project) == 1

--- a/tests/unit/test_verify_release_readiness.py
+++ b/tests/unit/test_verify_release_readiness.py
@@ -208,6 +208,15 @@ class TestDashboard:
         failures = vrr._check_dashboard(project)
         assert any("project mismatch" in f for f in failures)
 
+    def test_reports_malformed_metrics_json(self, tmp_path: Path) -> None:
+        """Malformed metrics.json is reported, not raised as a traceback."""
+        project = _make_valid_project(tmp_path)
+        (project / "docs" / "metrics.json").write_text(
+            "{not valid json", encoding="utf-8"
+        )
+        failures = vrr._check_dashboard(project)
+        assert any("not valid JSON" in f for f in failures)
+
 
 class TestOfflineEnv:
     """Tests for _offline_env."""


### PR DESCRIPTION
## Summary

Per the maintainer decision to "automate what's automatable," this PR converts
the automatable portions of the v1.0.0 manual testing plan (#152) into real
automated tests plus an offline release-readiness verification script.

Step 0 audited existing coverage first to avoid duplication. The bulk of #152 is
already covered by the suite (init flow, per-language generation, per-generator
unit tests, error handling). The genuine gap was the **live metrics dashboard
flow (Part 1.3 / 5.1)**: the only existing dashboard tests
(`tests/unit/test_cli_mocked.py`) mock `MetricsGenerator` and `shutil.copy`, so
they never assert that the real generator + template copy produces the dashboard
artifacts on disk.

### What changed

- **`tests/e2e/test_release_readiness_e2e.py`** (5 tests) — drives the real
  `sgsg init --enable-live-dashboard` CLI end-to-end (offline, API keys
  stripped) and asserts `docs/dashboard.html`, `docs/metrics.json`,
  `.github/workflows/metrics.yml`, and `scripts/collect_metrics.py` exist on
  disk; that `metrics.json` is well-formed (timestamp/project/thresholds/metrics
  with coverage=90, mutation_score=80); that the dashboard loads `metrics.json`;
  that the metrics workflow is rebranded (no SGSG name leak); and that the flag
  is load-bearing (no artifacts without it).
- **`scripts/verify_release_readiness.py`** + **`scripts/verify_release_readiness.sh`**
  — a deterministic, offline release-readiness gate. Generates a Python project
  and verifies: required structural files present + non-empty, all quality
  scripts present + executable, pre-commit hooks >= 25, at least one CI workflow
  that parses as valid YAML, and complete dashboard artifacts. Reports every
  failure and exits non-zero on any. `--help` / `--keep` supported.
- **`tests/unit/test_verify_release_readiness.py`** (18 tests) — exercises every
  check helper (pass and fail branches) against synthetic trees, fast and
  subprocess-free.
- **`pyproject.toml`** — per-file ruff ignores for the new script (`T201`
  user-facing prints; `S603` trusted `sgsg` subprocess resolved via
  `shutil.which`).

### Step 0 coverage audit (automatable items → covered / gap)

| #152 item | Status |
|---|---|
| Installation: `sgsg version`, `--help` | Covered (`test_cli_mocked.py::test_version_command_simple_output`, `test_help_text_includes_all_supported_languages`) |
| Part 1.1 Python init structure | Covered (`test_init_flow.py`, `test_init_command.py`) |
| Part 1.2 TypeScript init (prettier/eslint) | Covered (`test_language_e2e.py`, `test_language_generators.py`, `test_precommit.py`) |
| **Part 1.3 `--enable-live-dashboard` artifacts on disk** | **GAP → now covered** by `test_release_readiness_e2e.py` + verification script |
| Part 2.x script existence + executable | Covered (`test_init_flow.py`); also asserted by the verification script |
| Part 3.1–3.9 generator assertions | Covered (`tests/unit/generators/test_*.py`) |
| Part 4 error handling (invalid language, GenerationError, no-API-key) | Covered (`test_precommit.py`, `test_github_actions.py`, `test_skills.py`) |
| Part 5.3 multi-language | Covered (`test_language_e2e.py`) |

## Test plan

- `tests/unit/test_verify_release_readiness.py` — 18 passed
- `tests/e2e/test_release_readiness_e2e.py` — 5 passed
- `scripts/verify_release_readiness.sh` — runs end-to-end, all 5 checks PASS, exit 0
- Red-before confirmed: the dashboard checks fail (4 missing artifacts) when a
  project is generated **without** `--enable-live-dashboard`, and pass with it.
- Full suite via `./scripts/check-all.sh`: `1831 passed`, **coverage 94.53%**
  (>= 90% required), `Passed: 7 / Failed: 0`.
- `pre-commit run --all-files`: all hooks pass (black, ruff, mypy, radon/xenon,
  bandit, shellcheck, refurb, vulture, pytest, coverage).

The new e2e/verification code is offline and makes no network or Anthropic API
calls (uses the existing no-AI baseline generation path).

## Remaining manual checks (not automated, with rationale)

These #152 items are inherently manual or environment-dependent and are
intentionally left for a human pass before tagging v1.0.0:

- **Visual dashboard rendering** — opening `docs/dashboard.html` in a browser
  and confirming cards/styling render correctly (Part 1.3 "Dashboard opens in
  browser"). Structure is automated; pixel/visual correctness is not.
- **Interactive prompt UX** — `sgsg init` without `--no-interactive` (prompt
  wording, defaults, conflict resolution flow). Requires a TTY and human
  judgment.
- **`sgsg audit` with a real `ANTHROPIC_API_KEY`** (Part 1.4) — exercises the
  live Claude API; cannot run offline/deterministically in CI.
- **Running the generated `scripts/*.sh` to completion** (Part 2.1–2.6) —
  installing pre-commit, full toolchain, and running tests/lint/security inside
  a generated project depends on the host having every tool installed; existence
  + executability is automated, full execution is left manual.
- **Mutation testing >= 80%** (Part 8.3) — multi-minute periodic gate, not part
  of continuous CI per repo policy.
- **Package install from source / `pip install` round-trip** (Part 8.4) and
  **generation-speed/scale timing** (Part 7) — host/perf dependent.
- **Documentation build `./scripts/docs.sh`** (Part 6.2) — output location
  varies; left to manual verification.

### Note for maintainers (out of scope here)

The #152 checklist assumes `sgsg --version` works, but the CLI only implements
the `sgsg version` subcommand (`sgsg --version` errors with "No such option").
This is a CLI/docs discrepancy, not addressed in this PR to keep it scoped to
#152's automation; recommend a separate issue to either add a `--version` flag
or correct the docs.

Closes #152
