### PR TITLE
feat(metrics): add Pre-Commit Status card to the dashboard (#154)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1660
+        "line_number": 1688
       }
     ]
   },
-  "generated_at": "2026-06-10T04:08:26Z"
+  "generated_at": "2026-06-10T04:53:11Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1656
+        "line_number": 1660
       }
     ]
   },
-  "generated_at": "2026-06-10T02:55:53Z"
+  "generated_at": "2026-06-10T04:08:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1688
+        "line_number": 1660
       }
     ]
   },
-  "generated_at": "2026-06-10T04:53:11Z"
+  "generated_at": "2026-06-10T05:17:44Z"
 }

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -85,8 +85,8 @@
             color: #fff;
         }
         .status-unknown {
-            background: #484f58;
-            color: #c9d1d9;
+            background: #30363d;
+            color: #8b949e;
         }
         .footer {
             text-align: center;
@@ -344,10 +344,15 @@
             const badgeElem =
                 document.getElementById('precommit-status-badge');
 
-            if (!precommit) {
+            // No-data guard (Issue #154): when there is no precommit data, or
+            // the status is 'unknown' (no .pre-commit-config.yaml), render the
+            // gray N/A treatment BEFORE the percentage thresholds so a 0%
+            // unknown card does not fall through to red FAILING.
+            if (!precommit || precommit.status === 'unknown') {
                 valueElem.textContent = 'N/A';
-                badgeElem.textContent = 'NO DATA';
-                badgeElem.className = 'metric-status status-warn';
+                thresholdElem.textContent = 'No data';
+                badgeElem.textContent = 'N/A';
+                badgeElem.className = 'metric-status status-unknown';
                 return;
             }
 
@@ -389,6 +394,9 @@
             const elem = document.getElementById(`${name}-status`);
             if (!elem) return;
             elem.textContent = text;
+            // No-data cards pass 'N/A' (Issue #154): map to the gray
+            // status-unknown state so a fresh project does not surface
+            // alarming red "no data" badges.
             let statusClass;
             if (text === 'N/A') {
                 statusClass = 'status-unknown';

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -84,6 +84,10 @@
             background: #da3633;
             color: #fff;
         }
+        .status-unknown {
+            background: #484f58;
+            color: #c9d1d9;
+        }
         .footer {
             text-align: center;
             margin-top: 3rem;
@@ -232,7 +236,7 @@
             if (metrics.coverage !== undefined) {
                 if (metrics.coverage === null) {
                     document.getElementById('coverage-value').textContent = 'N/A';
-                    updateStatus('coverage', 'NO DATA', false);
+                    updateStatus('coverage', 'N/A', false);
                 } else {
                     updateMetric('coverage', metrics.coverage, '%',
                         metrics.coverage >= thresholds.coverage);
@@ -243,7 +247,7 @@
             if (metrics.branch_coverage !== undefined) {
                 if (metrics.branch_coverage === null) {
                     document.getElementById('branch-value').textContent = 'N/A';
-                    updateStatus('branch', 'NO DATA', false);
+                    updateStatus('branch', 'N/A', false);
                 } else {
                     updateMetric('branch', metrics.branch_coverage, '%',
                         metrics.branch_coverage >= thresholds.branch_coverage);
@@ -254,7 +258,7 @@
             if (metrics.complexity_avg !== undefined) {
                 if (metrics.complexity_avg === null) {
                     document.getElementById('complexity-value').textContent = 'N/A';
-                    updateStatus('complexity', 'NO DATA', false);
+                    updateStatus('complexity', 'N/A', false);
                 } else {
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
@@ -265,7 +269,7 @@
             if (metrics.security_issues !== undefined) {
                 if (metrics.security_issues === null) {
                     document.getElementById('security-value').textContent = 'N/A';
-                    updateStatus('security', 'NO DATA', false);
+                    updateStatus('security', 'N/A', false);
                 } else {
                     const elem = document.getElementById('security-value');
                     elem.textContent = metrics.security_issues;
@@ -280,7 +284,7 @@
                 if (metrics.maintainability_avg === null) {
                     const mv = document.getElementById('maintainability-value');
                     mv.textContent = 'N/A';
-                    updateStatus('maintainability', 'NO DATA', false);
+                    updateStatus('maintainability', 'N/A', false);
                 } else {
                     const t = thresholds.maintainability || 20;
                     updateMetric('maintainability',
@@ -293,7 +297,7 @@
             if (metrics.lint_violations !== undefined) {
                 if (metrics.lint_violations === null) {
                     document.getElementById('lint-value').textContent = 'N/A';
-                    updateStatus('lint', 'NO DATA', false);
+                    updateStatus('lint', 'N/A', false);
                 } else {
                     const elem = document.getElementById('lint-value');
                     elem.textContent = metrics.lint_violations;
@@ -307,7 +311,7 @@
             if (metrics.type_errors !== undefined) {
                 if (metrics.type_errors === null) {
                     document.getElementById('typecheck-value').textContent = 'N/A';
-                    updateStatus('typecheck', 'NO DATA', false);
+                    updateStatus('typecheck', 'N/A', false);
                 } else {
                     const elem = document.getElementById('typecheck-value');
                     elem.textContent = metrics.type_errors;
@@ -321,7 +325,7 @@
             if (metrics.tests_total !== undefined) {
                 if (metrics.tests_total === null) {
                     document.getElementById('tests-value').textContent = 'N/A';
-                    updateStatus('tests', 'NO DATA', false);
+                    updateStatus('tests', 'N/A', false);
                 } else {
                     const elem = document.getElementById('tests-value');
                     const failed = metrics.tests_failed || 0;
@@ -383,8 +387,14 @@
 
         function updateStatus(name, text, passing) {
             const elem = document.getElementById(`${name}-status`);
+            if (!elem) return;
             elem.textContent = text;
-            const statusClass = passing ? 'status-pass' : 'status-fail';
+            let statusClass;
+            if (text === 'N/A') {
+                statusClass = 'status-unknown';
+            } else {
+                statusClass = passing ? 'status-pass' : 'status-fail';
+            }
             elem.className = 'metric-status ' + statusClass;
         }
 

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -84,10 +84,6 @@
             background: #da3633;
             color: #fff;
         }
-        .status-unknown {
-            background: #484f58;
-            color: #c9d1d9;
-        }
         .footer {
             text-align: center;
             margin-top: 3rem;
@@ -103,6 +99,18 @@
         <p class="subtitle">Quality Metrics Dashboard</p>
 
         <div class="metrics-grid">
+            <div class="metric-card" id="precommit-status">
+                <div class="metric-name">Pre-Commit Status</div>
+                <div class="metric-value" id="precommit-value">--</div>
+                <div class="metric-threshold">
+                    Threshold:
+                    <span id="precommit-threshold">31/31 Hooks</span>
+                </div>
+                <div class="metric-status status-pass" id="precommit-status-badge">
+                    PASSING
+                </div>
+            </div>
+
             <div class="metric-card">
                 <div class="metric-name">Code Coverage</div>
                 <div class="metric-value" id="coverage-value">--</div>
@@ -217,11 +225,14 @@
             document.getElementById('last-updated').textContent =
                 new Date(data.timestamp).toLocaleString();
 
+            // Pre-Commit Status (index 0): green 100%, yellow 90-99%, red <90%
+            updatePrecommitStatus(metrics.precommit_status);
+
             // Coverage
             if (metrics.coverage !== undefined) {
                 if (metrics.coverage === null) {
                     document.getElementById('coverage-value').textContent = 'N/A';
-                    updateStatus('coverage', 'N/A', false);
+                    updateStatus('coverage', 'NO DATA', false);
                 } else {
                     updateMetric('coverage', metrics.coverage, '%',
                         metrics.coverage >= thresholds.coverage);
@@ -232,7 +243,7 @@
             if (metrics.branch_coverage !== undefined) {
                 if (metrics.branch_coverage === null) {
                     document.getElementById('branch-value').textContent = 'N/A';
-                    updateStatus('branch', 'N/A', false);
+                    updateStatus('branch', 'NO DATA', false);
                 } else {
                     updateMetric('branch', metrics.branch_coverage, '%',
                         metrics.branch_coverage >= thresholds.branch_coverage);
@@ -243,7 +254,7 @@
             if (metrics.complexity_avg !== undefined) {
                 if (metrics.complexity_avg === null) {
                     document.getElementById('complexity-value').textContent = 'N/A';
-                    updateStatus('complexity', 'N/A', false);
+                    updateStatus('complexity', 'NO DATA', false);
                 } else {
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
@@ -254,7 +265,7 @@
             if (metrics.security_issues !== undefined) {
                 if (metrics.security_issues === null) {
                     document.getElementById('security-value').textContent = 'N/A';
-                    updateStatus('security', 'N/A', false);
+                    updateStatus('security', 'NO DATA', false);
                 } else {
                     const elem = document.getElementById('security-value');
                     elem.textContent = metrics.security_issues;
@@ -269,7 +280,7 @@
                 if (metrics.maintainability_avg === null) {
                     const mv = document.getElementById('maintainability-value');
                     mv.textContent = 'N/A';
-                    updateStatus('maintainability', 'N/A', false);
+                    updateStatus('maintainability', 'NO DATA', false);
                 } else {
                     const t = thresholds.maintainability || 20;
                     updateMetric('maintainability',
@@ -282,7 +293,7 @@
             if (metrics.lint_violations !== undefined) {
                 if (metrics.lint_violations === null) {
                     document.getElementById('lint-value').textContent = 'N/A';
-                    updateStatus('lint', 'N/A', false);
+                    updateStatus('lint', 'NO DATA', false);
                 } else {
                     const elem = document.getElementById('lint-value');
                     elem.textContent = metrics.lint_violations;
@@ -296,7 +307,7 @@
             if (metrics.type_errors !== undefined) {
                 if (metrics.type_errors === null) {
                     document.getElementById('typecheck-value').textContent = 'N/A';
-                    updateStatus('typecheck', 'N/A', false);
+                    updateStatus('typecheck', 'NO DATA', false);
                 } else {
                     const elem = document.getElementById('typecheck-value');
                     elem.textContent = metrics.type_errors;
@@ -310,7 +321,7 @@
             if (metrics.tests_total !== undefined) {
                 if (metrics.tests_total === null) {
                     document.getElementById('tests-value').textContent = 'N/A';
-                    updateStatus('tests', 'N/A', false);
+                    updateStatus('tests', 'NO DATA', false);
                 } else {
                     const elem = document.getElementById('tests-value');
                     const failed = metrics.tests_failed || 0;
@@ -323,6 +334,47 @@
             }
         }
 
+        function updatePrecommitStatus(precommit) {
+            const valueElem = document.getElementById('precommit-value');
+            const thresholdElem = document.getElementById('precommit-threshold');
+            const badgeElem =
+                document.getElementById('precommit-status-badge');
+
+            if (!precommit) {
+                valueElem.textContent = 'N/A';
+                badgeElem.textContent = 'NO DATA';
+                badgeElem.className = 'metric-status status-warn';
+                return;
+            }
+
+            const total = precommit.total_hooks || 0;
+            const passing = precommit.passing_hooks || 0;
+            const percentage = (precommit.percentage !== undefined &&
+                precommit.percentage !== null)
+                ? precommit.percentage
+                : (total > 0 ? (passing / total) * 100 : 0);
+
+            valueElem.textContent = percentage.toFixed(0) + '%';
+            thresholdElem.textContent = passing + '/' + total + ' Hooks';
+
+            // Color coding per Issue #154:
+            // green (100%), yellow (90-99%), red (<90%)
+            let statusClass;
+            let statusText;
+            if (percentage >= 100) {
+                statusClass = 'status-pass';
+                statusText = 'PASSING';
+            } else if (percentage >= 90) {
+                statusClass = 'status-warn';
+                statusText = 'WARNING';
+            } else {
+                statusClass = 'status-fail';
+                statusText = 'FAILING';
+            }
+            badgeElem.textContent = statusText;
+            badgeElem.className = 'metric-status ' + statusClass;
+        }
+
         function updateMetric(name, value, suffix, passing) {
             const elem = document.getElementById(`${name}-value`);
             elem.textContent = value.toFixed(2) + suffix;
@@ -331,14 +383,8 @@
 
         function updateStatus(name, text, passing) {
             const elem = document.getElementById(`${name}-status`);
-            if (!elem) return;
             elem.textContent = text;
-            let statusClass;
-            if (text === 'N/A') {
-                statusClass = 'status-unknown';
-            } else {
-                statusClass = passing ? 'status-pass' : 'status-fail';
-            }
+            const statusClass = passing ? 'status-pass' : 'status-fail';
             elem.className = 'metric-status ' + statusClass;
         }
 

--- a/docs/metrics.json
+++ b/docs/metrics.json
@@ -10,6 +10,12 @@
     "security_issues": 0
   },
   "metrics": {
+    "precommit_status": {
+      "total_hooks": 31,
+      "passing_hooks": 31,
+      "percentage": 100.0,
+      "status": "passing"
+    },
     "coverage": 92.62,
     "coverage_status": "pass",
     "branch_coverage": 90.26,

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -26,6 +26,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from start_green_stay_green.generators.metrics import count_precommit_hooks
+from start_green_stay_green.generators.metrics import precommit_status
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -192,13 +193,7 @@ class MetricsCollector:
             config_path: Path to the ``.pre-commit-config.yaml`` file.
         """
         total = count_precommit_hooks(config_path)
-        has_hooks = total > 0
-        self.metrics["precommit_status"] = {
-            "total_hooks": total,
-            "passing_hooks": total,
-            "percentage": 100.0 if has_hooks else 0.0,
-            "status": "passing" if has_hooks else "unknown",
-        }
+        self.metrics["precommit_status"] = precommit_status(total)
 
     def add_mutation_score(self, score: float) -> None:
         """Add mutation testing score.

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -25,6 +25,8 @@ import sys
 from typing import Any
 from typing import TYPE_CHECKING
 
+import yaml
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -175,6 +177,28 @@ class MetricsCollector:
         self.metrics["security_status"] = (
             "pass" if issues == self.thresholds["security_issues"] else "fail"
         )
+
+    def collect_precommit_status(self, config_path: Path) -> None:
+        """Collect pre-commit hooks status from the config file (Issue #154).
+
+        Counts the total hooks configured in ``.pre-commit-config.yaml`` and
+        records a ``precommit_status`` entry with ``total_hooks``,
+        ``passing_hooks``, ``percentage`` and ``status``. Because running
+        ``pre-commit run --all-files`` is expensive and CI already gates on
+        it, this treats configured hooks as passing; a missing or empty
+        config degrades gracefully to zero hooks with ``unknown`` status.
+
+        Args:
+            config_path: Path to the ``.pre-commit-config.yaml`` file.
+        """
+        total = _count_precommit_hooks(config_path)
+        has_hooks = total > 0
+        self.metrics["precommit_status"] = {
+            "total_hooks": total,
+            "passing_hooks": total,
+            "percentage": 100.0 if has_hooks else 0.0,
+            "status": "passing" if has_hooks else "unknown",
+        }
 
     def add_mutation_score(self, score: float) -> None:
         """Add mutation testing score.
@@ -396,6 +420,56 @@ class MetricsCollector:
         print(f"✓ Generated {output_file}")
 
 
+def _load_precommit_repos(config_path: Path) -> list[object]:
+    """Load the ``repos`` list from a pre-commit config, degrading to ``[]``.
+
+    Args:
+        config_path: Path to a ``.pre-commit-config.yaml`` file.
+
+    Returns:
+        The ``repos`` list, or an empty list when the file is absent,
+        unreadable, or malformed.
+    """
+    if not config_path.is_file():
+        return []
+
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+
+    repos = data.get("repos") if isinstance(data, dict) else None
+    return repos if isinstance(repos, list) else []
+
+
+def _repo_hook_count(repo: object) -> int:
+    """Return the number of hooks declared by a single pre-commit repo entry.
+
+    Args:
+        repo: A single entry from the pre-commit ``repos`` list.
+
+    Returns:
+        Hook count for the entry, or ``0`` when it is malformed.
+    """
+    if not isinstance(repo, dict):
+        return 0
+    hooks = repo.get("hooks")
+    return len(hooks) if isinstance(hooks, list) else 0
+
+
+def _count_precommit_hooks(config_path: Path) -> int:
+    """Count total hooks across all repos in a pre-commit config.
+
+    Args:
+        config_path: Path to a ``.pre-commit-config.yaml`` file.
+
+    Returns:
+        Total hook count, or ``0`` when absent, empty, or malformed.
+    """
+    repos = _load_precommit_repos(config_path)
+    return sum(_repo_hook_count(repo) for repo in repos)
+
+
 def _default_thresholds() -> dict[str, int | float]:
     """Return default quality thresholds aligned with SGSG standards."""
     return {
@@ -482,6 +556,9 @@ def _collect_script_mode(
     collector.collect_typecheck_metrics(scripts_dir)
     collector.collect_test_metrics(scripts_dir)
 
+    # Pre-Commit Status (Issue #154): derived from .pre-commit-config.yaml
+    collector.collect_precommit_status(Path(".pre-commit-config.yaml"))
+
 
 def _collect_file_mode(
     collector: MetricsCollector,
@@ -518,6 +595,9 @@ def _collect_file_mode(
         print(f"Warning: Could not parse security ({type(e).__name__}): {e}")
         collector.metrics["security_issues"] = None
         collector.metrics["security_status"] = "unknown"
+
+    # Pre-Commit Status (Issue #154): derived from .pre-commit-config.yaml
+    collector.collect_precommit_status(Path(".pre-commit-config.yaml"))
 
     _collect_mutation(collector, args)
 

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -25,7 +25,7 @@ import sys
 from typing import Any
 from typing import TYPE_CHECKING
 
-import yaml
+from start_green_stay_green.generators.metrics import count_precommit_hooks
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -191,7 +191,7 @@ class MetricsCollector:
         Args:
             config_path: Path to the ``.pre-commit-config.yaml`` file.
         """
-        total = _count_precommit_hooks(config_path)
+        total = count_precommit_hooks(config_path)
         has_hooks = total > 0
         self.metrics["precommit_status"] = {
             "total_hooks": total,
@@ -418,56 +418,6 @@ class MetricsCollector:
         output_file.parent.mkdir(parents=True, exist_ok=True)
         output_file.write_text(json.dumps(metrics_data, indent=2))
         print(f"✓ Generated {output_file}")
-
-
-def _load_precommit_repos(config_path: Path) -> list[object]:
-    """Load the ``repos`` list from a pre-commit config, degrading to ``[]``.
-
-    Args:
-        config_path: Path to a ``.pre-commit-config.yaml`` file.
-
-    Returns:
-        The ``repos`` list, or an empty list when the file is absent,
-        unreadable, or malformed.
-    """
-    if not config_path.is_file():
-        return []
-
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
-        return []
-
-    repos = data.get("repos") if isinstance(data, dict) else None
-    return repos if isinstance(repos, list) else []
-
-
-def _repo_hook_count(repo: object) -> int:
-    """Return the number of hooks declared by a single pre-commit repo entry.
-
-    Args:
-        repo: A single entry from the pre-commit ``repos`` list.
-
-    Returns:
-        Hook count for the entry, or ``0`` when it is malformed.
-    """
-    if not isinstance(repo, dict):
-        return 0
-    hooks = repo.get("hooks")
-    return len(hooks) if isinstance(hooks, list) else 0
-
-
-def _count_precommit_hooks(config_path: Path) -> int:
-    """Count total hooks across all repos in a pre-commit config.
-
-    Args:
-        config_path: Path to a ``.pre-commit-config.yaml`` file.
-
-    Returns:
-        Total hook count, or ``0`` when absent, empty, or malformed.
-    """
-    repos = _load_precommit_repos(config_path)
-    return sum(_repo_hook_count(repo) for repo in repos)
 
 
 def _default_thresholds() -> dict[str, int | float]:

--- a/scripts/regenerate_dashboard.py
+++ b/scripts/regenerate_dashboard.py
@@ -36,9 +36,13 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    precommit_hooks_total = MetricsGenerator.count_precommit_hooks(
+        Path(".pre-commit-config.yaml")
+    )
     config = MetricsGenerationConfig(
         language="python",
         project_name=args.project_name,
+        precommit_hooks_total=precommit_hooks_total,
     )
     generator = MetricsGenerator(None, config)
     result = generator.write_dashboard(args.output_dir)

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1275,6 +1275,28 @@ def _generate_subagents_step(
     console.print("[green]✓[/green] Generated subagents")
 
 
+def _initial_precommit_status(total_hooks: int) -> dict[str, object]:
+    """Build the baseline Pre-Commit Status entry for a fresh metrics.json.
+
+    Configured hooks are treated as passing for the initial snapshot;
+    a zero count (no config found) yields an ``unknown`` status so the
+    dashboard can show a meaningful placeholder.
+
+    Args:
+        total_hooks: Number of hooks counted from ``.pre-commit-config.yaml``.
+
+    Returns:
+        A ``precommit_status`` mapping with total/passing/percentage/status.
+    """
+    has_hooks = total_hooks > 0
+    return {
+        "total_hooks": total_hooks,
+        "passing_hooks": total_hooks,
+        "percentage": 100.0 if has_hooks else 0.0,
+        "status": "passing" if has_hooks else "unknown",
+    }
+
+
 def _generate_metrics_dashboard_step(
     project_path: Path,
     project_name: str,
@@ -1282,6 +1304,9 @@ def _generate_metrics_dashboard_step(
 ) -> None:
     """Generate live metrics dashboard and workflow."""
     with step_timer("metrics"), console.status("Generating metrics dashboard..."):
+        precommit_hooks_total = MetricsGenerator.count_precommit_hooks(
+            project_path / ".pre-commit-config.yaml"
+        )
         config = MetricsGenerationConfig(
             language=language,
             project_name=project_name,
@@ -1290,6 +1315,7 @@ def _generate_metrics_dashboard_step(
             mutation_threshold=80,
             complexity_threshold=10,
             doc_coverage_threshold=95,
+            precommit_hooks_total=precommit_hooks_total,
             enable_dashboard=True,
             enable_badges=True,
         )
@@ -1313,6 +1339,7 @@ def _generate_metrics_dashboard_step(
                 "security_issues": 0,
             },
             "metrics": {
+                "precommit_status": _initial_precommit_status(precommit_hooks_total),
                 "coverage": 0.0,
                 "coverage_status": "fail",
                 "branch_coverage": 0.0,

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1276,22 +1276,6 @@ def _generate_subagents_step(
     console.print("[green]✓[/green] Generated subagents")
 
 
-def _initial_precommit_status(total_hooks: int) -> dict[str, object]:
-    """Build the baseline Pre-Commit Status entry for a fresh metrics.json.
-
-    Configured hooks are treated as passing for the initial snapshot;
-    a zero count (no config found) yields an ``unknown`` status so the
-    dashboard can show a meaningful placeholder.
-
-    Args:
-        total_hooks: Number of hooks counted from ``.pre-commit-config.yaml``.
-
-    Returns:
-        A ``precommit_status`` mapping with total/passing/percentage/status.
-    """
-    return precommit_status(total_hooks)
-
-
 def _generate_metrics_dashboard_step(
     project_path: Path,
     project_name: str,
@@ -1334,7 +1318,7 @@ def _generate_metrics_dashboard_step(
                 "security_issues": 0,
             },
             "metrics": {
-                "precommit_status": _initial_precommit_status(precommit_hooks_total),
+                "precommit_status": precommit_status(precommit_hooks_total),
                 "coverage": 0.0,
                 "coverage_status": "fail",
                 "branch_coverage": 0.0,

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -62,6 +62,7 @@ from start_green_stay_green.generators.github_actions import (
 )
 from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
+from start_green_stay_green.generators.metrics import precommit_status
 from start_green_stay_green.generators.precommit import GenerationConfig
 from start_green_stay_green.generators.precommit import PreCommitGenerator
 from start_green_stay_green.generators.readme import ReadmeConfig
@@ -1288,13 +1289,7 @@ def _initial_precommit_status(total_hooks: int) -> dict[str, object]:
     Returns:
         A ``precommit_status`` mapping with total/passing/percentage/status.
     """
-    has_hooks = total_hooks > 0
-    return {
-        "total_hooks": total_hooks,
-        "passing_hooks": total_hooks,
-        "percentage": 100.0 if has_hooks else 0.0,
-        "status": "passing" if has_hooks else "unknown",
-    }
+    return precommit_status(total_hooks)
 
 
 def _generate_metrics_dashboard_step(

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -91,6 +91,25 @@ def _repo_hook_count(repo: object) -> int:
     return len(hooks) if isinstance(hooks, list) else 0
 
 
+def count_precommit_hooks(config_path: Path) -> int:
+    """Count the total number of hooks in a pre-commit config file.
+
+    Canonical, public hook-counting helper. Sums the ``hooks`` entries
+    across every ``repos`` entry in a ``.pre-commit-config.yaml``. Missing,
+    empty, or malformed configs degrade gracefully to ``0`` so callers (the
+    dashboard generator and ``scripts/collect_metrics.py``) can still render
+    a meaningful Pre-Commit Status card without duplicating this logic.
+
+    Args:
+        config_path: Path to a ``.pre-commit-config.yaml`` file.
+
+    Returns:
+        Total hook count, or ``0`` when the file is absent or has no hooks.
+    """
+    repos = _load_precommit_repos(config_path)
+    return sum(_repo_hook_count(repo) for repo in repos)
+
+
 @dataclass(frozen=True)
 class MetricConfig:
     """Configuration for a single quality metric.
@@ -471,10 +490,9 @@ class MetricsGenerator(BaseGenerator):
     def count_precommit_hooks(config_path: Path) -> int:
         """Count the total number of hooks in a pre-commit config file.
 
-        Sums the ``hooks`` entries across every ``repos`` entry in a
-        ``.pre-commit-config.yaml``. Missing, empty, or malformed configs
-        degrade gracefully to ``0`` so the dashboard can still render a
-        meaningful Pre-Commit Status card.
+        Thin wrapper around the canonical module-level
+        :func:`count_precommit_hooks`, retained for callers that reach the
+        helper through the generator class. See that function for behavior.
 
         Args:
             config_path: Path to a ``.pre-commit-config.yaml`` file.
@@ -483,8 +501,7 @@ class MetricsGenerator(BaseGenerator):
             Total hook count, or ``0`` when the file is absent or has no
             hooks.
         """
-        repos = _load_precommit_repos(config_path)
-        return sum(_repo_hook_count(repo) for repo in repos)
+        return count_precommit_hooks(config_path)
 
     def _get_tool_for_language(self, metric_type: str) -> str:
         """Get appropriate tool for language and metric type.

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -54,6 +54,43 @@ DANGEROUS_PATHS = {
 }
 
 
+def _load_precommit_repos(config_path: Path) -> list[object]:
+    """Load the ``repos`` list from a pre-commit config, degrading to ``[]``.
+
+    Args:
+        config_path: Path to a ``.pre-commit-config.yaml`` file.
+
+    Returns:
+        The ``repos`` list, or an empty list when the file is absent,
+        unreadable, or malformed.
+    """
+    if not config_path.is_file():
+        return []
+
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+
+    repos = data.get("repos") if isinstance(data, dict) else None
+    return repos if isinstance(repos, list) else []
+
+
+def _repo_hook_count(repo: object) -> int:
+    """Return the number of hooks declared by a single pre-commit repo entry.
+
+    Args:
+        repo: A single entry from the pre-commit ``repos`` list.
+
+    Returns:
+        Hook count for the entry, or ``0`` when it is malformed.
+    """
+    if not isinstance(repo, dict):
+        return 0
+    hooks = repo.get("hooks")
+    return len(hooks) if isinstance(hooks, list) else 0
+
+
 @dataclass(frozen=True)
 class MetricConfig:
     """Configuration for a single quality metric.
@@ -91,6 +128,10 @@ class MetricsGenerationConfig:
         debt_ratio_threshold: Max technical debt ratio (0-100).
         doc_coverage_threshold: Documentation coverage threshold (0-100).
         dependency_freshness_days: Max dependency age in days.
+        precommit_hooks_total: Total number of pre-commit hooks configured
+            (derived from ``.pre-commit-config.yaml``). Rendered as the
+            denominator of the Pre-Commit Status card's ``X/Y Hooks``
+            threshold. Defaults to 0 when no config is available.
         enable_sonarqube: Whether to generate SonarQube config.
         enable_badges: Whether to generate GitHub badges.
         enable_dashboard: Whether to generate dashboard template.
@@ -107,6 +148,7 @@ class MetricsGenerationConfig:
     debt_ratio_threshold: int = 5
     doc_coverage_threshold: int = 95
     dependency_freshness_days: int = 30
+    precommit_hooks_total: int = 0
     enable_sonarqube: bool = False
     enable_badges: bool = True
     enable_dashboard: bool = True
@@ -421,6 +463,28 @@ class MetricsGenerator(BaseGenerator):
         self._validate_non_negative(
             self.config.dependency_freshness_days, "Dependency freshness days"
         )
+        self._validate_non_negative(
+            self.config.precommit_hooks_total, "Pre-commit hooks total"
+        )
+
+    @staticmethod
+    def count_precommit_hooks(config_path: Path) -> int:
+        """Count the total number of hooks in a pre-commit config file.
+
+        Sums the ``hooks`` entries across every ``repos`` entry in a
+        ``.pre-commit-config.yaml``. Missing, empty, or malformed configs
+        degrade gracefully to ``0`` so the dashboard can still render a
+        meaningful Pre-Commit Status card.
+
+        Args:
+            config_path: Path to a ``.pre-commit-config.yaml`` file.
+
+        Returns:
+            Total hook count, or ``0`` when the file is absent or has no
+            hooks.
+        """
+        repos = _load_precommit_repos(config_path)
+        return sum(_repo_hook_count(repo) for repo in repos)
 
     def _get_tool_for_language(self, metric_type: str) -> str:
         """Get appropriate tool for language and metric type.
@@ -613,6 +677,11 @@ class MetricsGenerator(BaseGenerator):
         # Security: HTML-escape project name to prevent XSS
         safe_project_name = html.escape(self.config.project_name)
 
+        # Pre-Commit Status baseline: render all configured hooks as passing
+        # (``X/Y Hooks``). The JS later overrides this from metrics.json.
+        precommit_total = self.config.precommit_hooks_total
+        precommit_threshold = f"{precommit_total}/{precommit_total} Hooks"
+
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -714,6 +783,18 @@ class MetricsGenerator(BaseGenerator):
         <p class="subtitle">Quality Metrics Dashboard</p>
 
         <div class="metrics-grid">
+            <div class="metric-card" id="precommit-status">
+                <div class="metric-name">Pre-Commit Status</div>
+                <div class="metric-value" id="precommit-value">--</div>
+                <div class="metric-threshold">
+                    Threshold:
+                    <span id="precommit-threshold">{precommit_threshold}</span>
+                </div>
+                <div class="metric-status status-pass" id="precommit-status-badge">
+                    PASSING
+                </div>
+            </div>
+
             <div class="metric-card">
                 <div class="metric-name">Code Coverage</div>
                 <div class="metric-value" id="coverage-value">--</div>
@@ -828,6 +909,9 @@ class MetricsGenerator(BaseGenerator):
             document.getElementById('last-updated').textContent =
                 new Date(data.timestamp).toLocaleString();
 
+            // Pre-Commit Status (index 0): green 100%, yellow 90-99%, red <90%
+            updatePrecommitStatus(metrics.precommit_status);
+
             // Coverage
             if (metrics.coverage !== undefined) {{
                 if (metrics.coverage === null) {{
@@ -932,6 +1016,47 @@ class MetricsGenerator(BaseGenerator):
                         failed === 0);
                 }}
             }}
+        }}
+
+        function updatePrecommitStatus(precommit) {{
+            const valueElem = document.getElementById('precommit-value');
+            const thresholdElem = document.getElementById('precommit-threshold');
+            const badgeElem =
+                document.getElementById('precommit-status-badge');
+
+            if (!precommit) {{
+                valueElem.textContent = 'N/A';
+                badgeElem.textContent = 'NO DATA';
+                badgeElem.className = 'metric-status status-warn';
+                return;
+            }}
+
+            const total = precommit.total_hooks || 0;
+            const passing = precommit.passing_hooks || 0;
+            const percentage = (precommit.percentage !== undefined &&
+                precommit.percentage !== null)
+                ? precommit.percentage
+                : (total > 0 ? (passing / total) * 100 : 0);
+
+            valueElem.textContent = percentage.toFixed(0) + '%';
+            thresholdElem.textContent = passing + '/' + total + ' Hooks';
+
+            // Color coding per Issue #154:
+            // green (100%), yellow (90-99%), red (<90%)
+            let statusClass;
+            let statusText;
+            if (percentage >= 100) {{
+                statusClass = 'status-pass';
+                statusText = 'PASSING';
+            }} else if (percentage >= 90) {{
+                statusClass = 'status-warn';
+                statusText = 'WARNING';
+            }} else {{
+                statusClass = 'status-fail';
+                statusText = 'FAILING';
+            }}
+            badgeElem.textContent = statusText;
+            badgeElem.className = 'metric-status ' + statusClass;
         }}
 
         function updateMetric(name, value, suffix, passing) {{

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -110,6 +110,44 @@ def count_precommit_hooks(config_path: Path) -> int:
     return sum(_repo_hook_count(repo) for repo in repos)
 
 
+def precommit_status(
+    total_hooks: int, passing_hooks: int | None = None
+) -> dict[str, object]:
+    """Build the canonical Pre-Commit Status dict for the metrics dashboard.
+
+    Single source of truth (Issue #154 DRY consolidation) for the
+    ``precommit_status`` mapping consumed by the dashboard's Pre-Commit
+    Status card. Both ``start_green_stay_green.cli._initial_precommit_status``
+    and ``scripts/collect_metrics.py`` delegate here instead of rebuilding the
+    ``total_hooks``/``passing_hooks``/``percentage``/``status`` fields
+    themselves.
+
+    When ``total_hooks`` is ``0`` (no ``.pre-commit-config.yaml`` found) the
+    status is ``"unknown"`` so the dashboard renders the gray "N/A" no-data
+    treatment instead of a red FAILING card. Otherwise the status is
+    ``"passing"`` and the percentage reflects ``passing_hooks / total_hooks``.
+
+    Args:
+        total_hooks: Total hooks counted from ``.pre-commit-config.yaml``.
+        passing_hooks: Hooks treated as passing. Defaults to ``total_hooks``
+            (configured hooks are assumed passing for the snapshot).
+
+    Returns:
+        A ``precommit_status`` mapping with ``total_hooks``,
+        ``passing_hooks``, ``percentage`` and ``status`` keys.
+    """
+    if passing_hooks is None:
+        passing_hooks = total_hooks
+    has_hooks = total_hooks > 0
+    percentage = (passing_hooks / total_hooks * 100) if has_hooks else 0.0
+    return {
+        "total_hooks": total_hooks,
+        "passing_hooks": passing_hooks,
+        "percentage": percentage,
+        "status": "passing" if has_hooks else "unknown",
+    }
+
+
 @dataclass(frozen=True)
 class MetricConfig:
     """Configuration for a single quality metric.
@@ -785,6 +823,10 @@ class MetricsGenerator(BaseGenerator):
             background: #da3633;
             color: #fff;
         }}
+        .status-unknown {{
+            background: #30363d;
+            color: #8b949e;
+        }}
         .footer {{
             text-align: center;
             margin-top: 3rem;
@@ -933,7 +975,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.coverage !== undefined) {{
                 if (metrics.coverage === null) {{
                     document.getElementById('coverage-value').textContent = 'N/A';
-                    updateStatus('coverage', 'NO DATA', false);
+                    updateStatus('coverage', 'N/A', false);
                 }} else {{
                     updateMetric('coverage', metrics.coverage, '%',
                         metrics.coverage >= thresholds.coverage);
@@ -944,7 +986,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.branch_coverage !== undefined) {{
                 if (metrics.branch_coverage === null) {{
                     document.getElementById('branch-value').textContent = 'N/A';
-                    updateStatus('branch', 'NO DATA', false);
+                    updateStatus('branch', 'N/A', false);
                 }} else {{
                     updateMetric('branch', metrics.branch_coverage, '%',
                         metrics.branch_coverage >= thresholds.branch_coverage);
@@ -955,7 +997,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.complexity_avg !== undefined) {{
                 if (metrics.complexity_avg === null) {{
                     document.getElementById('complexity-value').textContent = 'N/A';
-                    updateStatus('complexity', 'NO DATA', false);
+                    updateStatus('complexity', 'N/A', false);
                 }} else {{
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
@@ -966,7 +1008,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.security_issues !== undefined) {{
                 if (metrics.security_issues === null) {{
                     document.getElementById('security-value').textContent = 'N/A';
-                    updateStatus('security', 'NO DATA', false);
+                    updateStatus('security', 'N/A', false);
                 }} else {{
                     const elem = document.getElementById('security-value');
                     elem.textContent = metrics.security_issues;
@@ -981,7 +1023,7 @@ class MetricsGenerator(BaseGenerator):
                 if (metrics.maintainability_avg === null) {{
                     const mv = document.getElementById('maintainability-value');
                     mv.textContent = 'N/A';
-                    updateStatus('maintainability', 'NO DATA', false);
+                    updateStatus('maintainability', 'N/A', false);
                 }} else {{
                     const t = thresholds.maintainability || 20;
                     updateMetric('maintainability',
@@ -994,7 +1036,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.lint_violations !== undefined) {{
                 if (metrics.lint_violations === null) {{
                     document.getElementById('lint-value').textContent = 'N/A';
-                    updateStatus('lint', 'NO DATA', false);
+                    updateStatus('lint', 'N/A', false);
                 }} else {{
                     const elem = document.getElementById('lint-value');
                     elem.textContent = metrics.lint_violations;
@@ -1008,7 +1050,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.type_errors !== undefined) {{
                 if (metrics.type_errors === null) {{
                     document.getElementById('typecheck-value').textContent = 'N/A';
-                    updateStatus('typecheck', 'NO DATA', false);
+                    updateStatus('typecheck', 'N/A', false);
                 }} else {{
                     const elem = document.getElementById('typecheck-value');
                     elem.textContent = metrics.type_errors;
@@ -1022,7 +1064,7 @@ class MetricsGenerator(BaseGenerator):
             if (metrics.tests_total !== undefined) {{
                 if (metrics.tests_total === null) {{
                     document.getElementById('tests-value').textContent = 'N/A';
-                    updateStatus('tests', 'NO DATA', false);
+                    updateStatus('tests', 'N/A', false);
                 }} else {{
                     const elem = document.getElementById('tests-value');
                     const failed = metrics.tests_failed || 0;
@@ -1041,10 +1083,15 @@ class MetricsGenerator(BaseGenerator):
             const badgeElem =
                 document.getElementById('precommit-status-badge');
 
-            if (!precommit) {{
+            // No-data guard (Issue #154): when there is no precommit data, or
+            // the status is 'unknown' (no .pre-commit-config.yaml), render the
+            // gray N/A treatment BEFORE the percentage thresholds so a 0%
+            // unknown card does not fall through to red FAILING.
+            if (!precommit || precommit.status === 'unknown') {{
                 valueElem.textContent = 'N/A';
-                badgeElem.textContent = 'NO DATA';
-                badgeElem.className = 'metric-status status-warn';
+                thresholdElem.textContent = 'No data';
+                badgeElem.textContent = 'N/A';
+                badgeElem.className = 'metric-status status-unknown';
                 return;
             }}
 
@@ -1084,8 +1131,17 @@ class MetricsGenerator(BaseGenerator):
 
         function updateStatus(name, text, passing) {{
             const elem = document.getElementById(`${{name}}-status`);
+            if (!elem) return;
             elem.textContent = text;
-            const statusClass = passing ? 'status-pass' : 'status-fail';
+            // No-data cards pass 'N/A' (Issue #154): map to the gray
+            // status-unknown state so a fresh project does not surface
+            // alarming red "no data" badges.
+            let statusClass;
+            if (text === 'N/A') {{
+                statusClass = 'status-unknown';
+            }} else {{
+                statusClass = passing ? 'status-pass' : 'status-fail';
+            }}
             elem.className = 'metric-status ' + statusClass;
         }}
 

--- a/tests/integration/generators/test_metrics_integration.py
+++ b/tests/integration/generators/test_metrics_integration.py
@@ -620,3 +620,29 @@ class TestDashboardSync:
                 f"docs/dashboard.html JS missing handler for {key}. "
                 "Run: python scripts/regenerate_dashboard.py"
             )
+
+    def test_deployed_no_data_cards_render_gray_not_red(self) -> None:
+        """Fresh dashboards must show the eight existing cards' no-data state gray.
+
+        Regression guard for Issue #154: a brand-new project has no
+        ``metrics.json`` values, so the eight pre-existing cards fall into
+        their ``null`` branch and call ``updateStatus(name, 'N/A', false)``.
+        ``updateStatus`` must map the ``'N/A'`` text to the gray
+        ``status-unknown`` state (not red ``status-fail``) so a fresh project
+        does not surface alarming red "no data" badges. This asserts the
+        deployed ``docs/dashboard.html`` keeps the gray no-data behavior.
+        """
+        deployed = self._get_deployed()
+
+        assert ".status-unknown {" in deployed, (
+            "docs/dashboard.html dropped the gray status-unknown CSS state. "
+            "Fresh no-data cards would render red instead of gray."
+        )
+        assert "if (text === 'N/A') {" in deployed, (
+            "docs/dashboard.html updateStatus no longer maps 'N/A' text to "
+            "the gray status-unknown state; fresh no-data cards render red."
+        )
+        assert "statusClass = 'status-unknown';" in deployed, (
+            "docs/dashboard.html updateStatus no longer assigns "
+            "status-unknown for the no-data ('N/A') case."
+        )

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -973,6 +973,173 @@ class TestDashboardGeneration:
         assert "grid" in dashboard  # CSS grid layout
 
 
+class TestPrecommitStatusCard:
+    """Test the Pre-Commit Status metric card (Issue #154)."""
+
+    def _write_config(self, path: Path, *, hook_count: int) -> Path:
+        """Write a minimal .pre-commit-config.yaml with ``hook_count`` hooks."""
+        repos = [
+            {
+                "repo": "local",
+                "hooks": [{"id": f"hook-{i}"} for i in range(hook_count)],
+            }
+        ]
+        config_path = path / ".pre-commit-config.yaml"
+        config_path.write_text(yaml.dump({"repos": repos}), encoding="utf-8")
+        return config_path
+
+    def test_count_precommit_hooks_counts_all_hooks(self) -> None:
+        """Hook count is the sum of hooks across every repo entry."""
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / ".pre-commit-config.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "repos": [
+                            {"repo": "a", "hooks": [{"id": "x"}, {"id": "y"}]},
+                            {"repo": "b", "hooks": [{"id": "z"}]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            assert MetricsGenerator.count_precommit_hooks(config_path) == 3
+
+    def test_count_precommit_hooks_missing_file_returns_zero(self) -> None:
+        """A missing config file yields zero hooks (graceful degradation)."""
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / ".pre-commit-config.yaml"
+
+            assert MetricsGenerator.count_precommit_hooks(missing) == 0
+
+    def test_count_precommit_hooks_empty_config_returns_zero(self) -> None:
+        """An empty or repo-less config yields zero hooks."""
+        with TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / ".pre-commit-config.yaml"
+            config_path.write_text("", encoding="utf-8")
+
+            assert MetricsGenerator.count_precommit_hooks(config_path) == 0
+
+    def test_count_precommit_hooks_malformed_yaml_returns_zero(self) -> None:
+        """Malformed YAML degrades to zero hooks rather than raising."""
+        with TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / ".pre-commit-config.yaml"
+            config_path.write_text("repos: [unterminated", encoding="utf-8")
+
+            assert MetricsGenerator.count_precommit_hooks(config_path) == 0
+
+    def test_count_precommit_hooks_non_mapping_top_level_returns_zero(self) -> None:
+        """A top-level list (not a mapping) yields zero hooks."""
+        with TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / ".pre-commit-config.yaml"
+            config_path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+            assert MetricsGenerator.count_precommit_hooks(config_path) == 0
+
+    def test_count_precommit_hooks_ignores_malformed_repo_entries(self) -> None:
+        """Non-dict repo entries and hookless repos contribute zero hooks."""
+        with TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / ".pre-commit-config.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "repos": [
+                            "not-a-mapping",
+                            {"repo": "no-hooks-key"},
+                            {"repo": "string-hooks", "hooks": "oops"},
+                            {"repo": "valid", "hooks": [{"id": "a"}, {"id": "b"}]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            assert MetricsGenerator.count_precommit_hooks(config_path) == 2
+
+    def test_precommit_card_is_first_card(self) -> None:
+        """Pre-Commit Status card renders before the Code Coverage card."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=32,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "Pre-Commit Status" in dashboard
+        assert dashboard.index("Pre-Commit Status") < dashboard.index("Code Coverage")
+
+    def test_precommit_card_shows_total_hooks_threshold(self) -> None:
+        """Threshold shows ``X/Y Hooks`` using the configured total."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=32,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "32/32 Hooks" in dashboard
+
+    def test_precommit_card_has_value_and_status_ids(self) -> None:
+        """Card exposes the DOM ids the JS uses to populate it."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=10,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert 'id="precommit-value"' in dashboard
+        assert 'id="precommit-threshold"' in dashboard
+        assert 'id="precommit-status"' in dashboard
+
+    def test_precommit_js_color_codes_by_percentage(self) -> None:
+        """JS applies green/yellow/red classes per the issue thresholds."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=32,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        # 100% -> pass (green); 90-99% -> warn (yellow); <90% -> fail (red)
+        assert "precommit_status" in dashboard
+        assert ">= 100" in dashboard
+        assert ">= 90" in dashboard
+
+    def test_precommit_card_renders_with_zero_total(self) -> None:
+        """A zero hook total renders ``0/0 Hooks`` without crashing."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=0,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "0/0 Hooks" in dashboard
+
+
 class TestCIIntegration:
     """Test CI integration configuration generation."""
 
@@ -1558,13 +1725,17 @@ class TestDashboardNewCards:
         assert "Test Count" in dashboard
         assert "tests-value" in dashboard
 
-    def test_dashboard_has_eight_metric_cards(self) -> None:
-        """Test dashboard has exactly 8 metric cards."""
+    def test_dashboard_has_nine_metric_cards(self) -> None:
+        """Test dashboard has exactly 9 metric cards.
+
+        Eight original quality cards plus the Pre-Commit Status card added
+        at index 0 (Issue #154).
+        """
         dashboard = self._get_dashboard()
 
         # Count metric-card div occurrences
         card_count = dashboard.count('class="metric-card"')
-        assert card_count == 8
+        assert card_count == 9
 
 
 class TestDashboardJavaScript:

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -17,6 +17,7 @@ from start_green_stay_green.generators.metrics import MetricConfig
 from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
 from start_green_stay_green.generators.metrics import STANDARD_METRICS
+from start_green_stay_green.generators.metrics import count_precommit_hooks
 
 
 class TestMetricConfig:
@@ -1057,6 +1058,33 @@ class TestPrecommitStatusCard:
             )
 
             assert MetricsGenerator.count_precommit_hooks(config_path) == 2
+
+    def test_module_level_count_precommit_hooks_is_canonical(self) -> None:
+        """The public module-level helper counts hooks and the staticmethod delegates.
+
+        ``count_precommit_hooks`` is the single canonical implementation
+        (Issue #154 DRY consolidation); ``scripts/collect_metrics.py`` imports
+        it instead of duplicating the logic. The generator staticmethod must
+        return the same result for the same config.
+        """
+        with TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / ".pre-commit-config.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "repos": [
+                            {"repo": "a", "hooks": [{"id": "x"}, {"id": "y"}]},
+                            {"repo": "b", "hooks": [{"id": "z"}]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            assert count_precommit_hooks(config_path) == 3
+            assert count_precommit_hooks(config_path) == (
+                MetricsGenerator.count_precommit_hooks(config_path)
+            )
 
     def test_precommit_card_is_first_card(self) -> None:
         """Pre-Commit Status card renders before the Code Coverage card."""

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -18,6 +18,7 @@ from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
 from start_green_stay_green.generators.metrics import STANDARD_METRICS
 from start_green_stay_green.generators.metrics import count_precommit_hooks
+from start_green_stay_green.generators.metrics import precommit_status
 
 
 class TestMetricConfig:
@@ -1166,6 +1167,83 @@ class TestPrecommitStatusCard:
 
         assert dashboard is not None
         assert "0/0 Hooks" in dashboard
+
+    def test_precommit_js_grays_unknown_status_before_percentage(self) -> None:
+        """Zero-hooks/``unknown`` status maps to gray, not red FAILING.
+
+        Regression for the no-data UX bug (Issue #154): a
+        ``status: 'unknown'`` precommit card has ``percentage: 0.0`` which
+        would fall through the ``>= 100``/``>= 90`` guards and render red
+        FAILING. ``updatePrecommitStatus`` must branch on the ``status``
+        field (and missing data) BEFORE the percentage thresholds and apply
+        the gray ``status-unknown`` treatment, mirroring the other cards.
+        """
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            precommit_hooks_total=32,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        # The unknown/no-data guard must short-circuit before the percentage
+        # colour thresholds and use the gray status-unknown class.
+        assert "precommit.status === 'unknown'" in dashboard
+        assert "status-unknown" in dashboard
+        guard = dashboard.index("precommit.status === 'unknown'")
+        threshold = dashboard.index("if (percentage >= 100)")
+        assert guard < threshold
+
+    def test_dashboard_defines_status_unknown_css(self) -> None:
+        """The gray ``status-unknown`` badge class is defined in the CSS."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert ".status-unknown {" in dashboard
+
+
+class TestPrecommitStatusHelper:
+    """Tests for the canonical ``precommit_status`` dict-builder (Issue #154)."""
+
+    def test_passing_status_for_configured_hooks(self) -> None:
+        """A positive hook count yields a 100% passing status."""
+        assert precommit_status(32) == {
+            "total_hooks": 32,
+            "passing_hooks": 32,
+            "percentage": 100.0,
+            "status": "passing",
+        }
+
+    def test_unknown_status_for_zero_hooks(self) -> None:
+        """Zero hooks (no config) yields the unknown/no-data status."""
+        assert precommit_status(0) == {
+            "total_hooks": 0,
+            "passing_hooks": 0,
+            "percentage": 0.0,
+            "status": "unknown",
+        }
+
+    def test_passing_hooks_defaults_to_total(self) -> None:
+        """``passing_hooks`` defaults to ``total_hooks`` when omitted."""
+        result = precommit_status(10)
+        assert result["passing_hooks"] == 10
+
+    def test_partial_passing_yields_proportional_percentage(self) -> None:
+        """An explicit passing count below total yields a partial percentage."""
+        result = precommit_status(10, passing_hooks=9)
+        assert result["passing_hooks"] == 9
+        assert result["percentage"] == 90.0
+        assert result["status"] == "passing"
 
 
 class TestCIIntegration:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -45,7 +45,6 @@ from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
-from start_green_stay_green.generators.metrics import precommit_status
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 from start_green_stay_green.utils.enhance_state import BatchProgress
 from start_green_stay_green.utils.enhance_state import EnhanceState
@@ -976,33 +975,6 @@ class TestMetricsDashboardGeneration:
             content = workflow_file.read_text()
             assert "my-new-project" in content
             assert "start-green-stay-green" not in content
-
-
-class TestInitialPrecommitStatus:
-    """Tests for cli._initial_precommit_status (Issue #154 DRY)."""
-
-    def test_passing_status_for_configured_hooks(self) -> None:
-        """A positive hook count yields the 100% passing status dict."""
-        assert cli._initial_precommit_status(31) == precommit_status(31)
-        assert cli._initial_precommit_status(31)["status"] == "passing"
-
-    def test_unknown_status_for_zero_hooks(self) -> None:
-        """Zero hooks yields the unknown/no-data status dict."""
-        assert cli._initial_precommit_status(0) == precommit_status(0)
-        assert cli._initial_precommit_status(0)["status"] == "unknown"
-
-    def test_delegates_to_shared_builder(self) -> None:
-        """The dict is built by the canonical ``precommit_status`` helper.
-
-        Issue #154 DRY consolidation: ``_initial_precommit_status`` must not
-        re-derive the status fields; it must delegate to the shared
-        ``precommit_status`` builder.
-        """
-        with patch.object(cli, "precommit_status", wraps=precommit_status) as spy:
-            result = cli._initial_precommit_status(7)
-
-        spy.assert_called_once_with(7)
-        assert result == precommit_status(7)
 
 
 class TestShowDryRunPreview:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -45,6 +45,7 @@ from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
+from start_green_stay_green.generators.metrics import precommit_status
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
 from start_green_stay_green.utils.enhance_state import BatchProgress
 from start_green_stay_green.utils.enhance_state import EnhanceState
@@ -975,6 +976,33 @@ class TestMetricsDashboardGeneration:
             content = workflow_file.read_text()
             assert "my-new-project" in content
             assert "start-green-stay-green" not in content
+
+
+class TestInitialPrecommitStatus:
+    """Tests for cli._initial_precommit_status (Issue #154 DRY)."""
+
+    def test_passing_status_for_configured_hooks(self) -> None:
+        """A positive hook count yields the 100% passing status dict."""
+        assert cli._initial_precommit_status(31) == precommit_status(31)
+        assert cli._initial_precommit_status(31)["status"] == "passing"
+
+    def test_unknown_status_for_zero_hooks(self) -> None:
+        """Zero hooks yields the unknown/no-data status dict."""
+        assert cli._initial_precommit_status(0) == precommit_status(0)
+        assert cli._initial_precommit_status(0)["status"] == "unknown"
+
+    def test_delegates_to_shared_builder(self) -> None:
+        """The dict is built by the canonical ``precommit_status`` helper.
+
+        Issue #154 DRY consolidation: ``_initial_precommit_status`` must not
+        re-derive the status fields; it must delegate to the shared
+        ``precommit_status`` builder.
+        """
+        with patch.object(cli, "precommit_status", wraps=precommit_status) as spy:
+            result = cli._initial_precommit_status(7)
+
+        spy.assert_called_once_with(7)
+        assert result == precommit_status(7)
 
 
 class TestShowDryRunPreview:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -842,6 +842,7 @@ class TestMetricsDashboardGeneration:
         # Setup mock generator
         mock_generator = Mock()
         mock_generator_class.return_value = mock_generator
+        mock_generator_class.count_precommit_hooks.return_value = 31
 
         # Mock shutil.copy to create a dummy workflow file when called
         def copy_side_effect(_src: Path, dst: Path) -> None:
@@ -890,6 +891,7 @@ class TestMetricsDashboardGeneration:
         """Test _generate_metrics_dashboard_step creates .github/workflows."""
         # Setup mock generator to avoid instantiation errors
         mock_generator_class.return_value = Mock()
+        mock_generator_class.count_precommit_hooks.return_value = 31
 
         # Mock shutil.copy to create files
         def copy_side_effect(_src: Path, dst: Path) -> None:
@@ -922,6 +924,7 @@ class TestMetricsDashboardGeneration:
         """Test _generate_metrics_dashboard_step warns when workflow missing."""
         # Setup mock generator
         mock_generator_class.return_value = Mock()
+        mock_generator_class.count_precommit_hooks.return_value = 31
         # Setup mock copy (not used but required by patch decorator order)
         mock_shutil_copy.return_value = None
 
@@ -948,6 +951,7 @@ class TestMetricsDashboardGeneration:
         """Test _generate_metrics_dashboard_step replaces project name in workflow."""
         # Setup mock generator
         mock_generator_class.return_value = Mock()
+        mock_generator_class.count_precommit_hooks.return_value = 31
 
         # Create source workflow with SGSG project name
         workflow_content = "project: start-green-stay-green\nname: Metrics"

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -15,8 +15,11 @@ import pytest
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import collect_metrics
 from collect_metrics import MetricsCollector
 from collect_metrics import main as collect_main
+
+from start_green_stay_green.generators.metrics import count_precommit_hooks
 
 
 class TestMetricsCollector:
@@ -837,6 +840,34 @@ class TestCollectPrecommitStatus:
             collector.collect_precommit_status(config_path)
 
             assert collector.metrics["precommit_status"]["total_hooks"] == 0
+
+    def test_uses_canonical_package_hook_counter(self) -> None:
+        """collect_metrics imports the canonical hook counter (no duplication).
+
+        Issue #154 DRY consolidation: the hook-counting helpers must live only
+        in ``start_green_stay_green.generators.metrics``. ``collect_metrics``
+        must import and reuse that canonical ``count_precommit_hooks`` rather
+        than redefining its own ``_load_precommit_repos`` / ``_repo_hook_count``
+        / ``_count_precommit_hooks`` copies.
+        """
+        # The duplicated private helpers must be gone from the script module.
+        assert not hasattr(collect_metrics, "_load_precommit_repos")
+        assert not hasattr(collect_metrics, "_repo_hook_count")
+        assert not hasattr(collect_metrics, "_count_precommit_hooks")
+        # The script re-exports the canonical helper (same object), so
+        # collected status matches the canonical count for the same config.
+        assert collect_metrics.__dict__["count_precommit_hooks"] is (
+            count_precommit_hooks
+        )
+        with TemporaryDirectory() as tmpdir:
+            config_path = self._write_config(Path(tmpdir), 7)
+            collector = MetricsCollector("test", {})
+
+            collector.collect_precommit_status(config_path)
+
+            assert collector.metrics["precommit_status"]["total_hooks"] == (
+                count_precommit_hooks(config_path)
+            )
 
 
 class TestMainScriptMode:

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -12,6 +12,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 from collect_metrics import MetricsCollector
@@ -740,6 +741,102 @@ class TestNewMetricMethods:
         assert collector.metrics["complexity_status"] == "unknown"
         assert collector.metrics["maintainability_avg"] is None
         assert collector.metrics["maintainability_status"] == "unknown"
+
+
+class TestCollectPrecommitStatus:
+    """Tests for pre-commit status collection (Issue #154)."""
+
+    def _write_config(self, path: Path, hook_count: int) -> Path:
+        """Write a .pre-commit-config.yaml with ``hook_count`` hooks."""
+        config_path = path / ".pre-commit-config.yaml"
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "repos": [
+                        {
+                            "repo": "local",
+                            "hooks": [{"id": f"hook-{i}"} for i in range(hook_count)],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return config_path
+
+    def test_collect_precommit_status_counts_hooks(self) -> None:
+        """Pre-commit status records total/passing/percentage from config."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = self._write_config(Path(tmpdir), 32)
+            collector = MetricsCollector("test", {})
+
+            collector.collect_precommit_status(config_path)
+
+            status = collector.metrics["precommit_status"]
+            assert status["total_hooks"] == 32
+            assert status["passing_hooks"] == 32
+            assert status["percentage"] == 100.0
+            assert status["status"] == "passing"
+
+    def test_collect_precommit_status_missing_config(self) -> None:
+        """Missing config degrades to zero hooks and unknown status."""
+        collector = MetricsCollector("test", {})
+
+        collector.collect_precommit_status(Path("/nonexistent/.pre-commit-config.yaml"))
+
+        status = collector.metrics["precommit_status"]
+        assert status["total_hooks"] == 0
+        assert status["passing_hooks"] == 0
+        assert status["percentage"] == 0.0
+        assert status["status"] == "unknown"
+
+    def test_collect_precommit_status_malformed_yaml(self) -> None:
+        """Malformed YAML degrades to unknown status without raising."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".pre-commit-config.yaml"
+            config_path.write_text("repos: [unterminated", encoding="utf-8")
+            collector = MetricsCollector("test", {})
+
+            collector.collect_precommit_status(config_path)
+
+            status = collector.metrics["precommit_status"]
+            assert status["total_hooks"] == 0
+            assert status["status"] == "unknown"
+
+    def test_collect_precommit_status_ignores_malformed_repos(self) -> None:
+        """Non-dict repos and hookless repos contribute zero hooks."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".pre-commit-config.yaml"
+            config_path.write_text(
+                yaml.dump(
+                    {
+                        "repos": [
+                            "not-a-mapping",
+                            {"repo": "no-hooks"},
+                            {"repo": "valid", "hooks": [{"id": "a"}, {"id": "b"}]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            collector = MetricsCollector("test", {})
+
+            collector.collect_precommit_status(config_path)
+
+            status = collector.metrics["precommit_status"]
+            assert status["total_hooks"] == 2
+            assert status["status"] == "passing"
+
+    def test_collect_precommit_status_non_mapping_top_level(self) -> None:
+        """A top-level YAML list yields zero hooks and unknown status."""
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / ".pre-commit-config.yaml"
+            config_path.write_text("- a\n- b\n", encoding="utf-8")
+            collector = MetricsCollector("test", {})
+
+            collector.collect_precommit_status(config_path)
+
+            assert collector.metrics["precommit_status"]["total_hooks"] == 0
 
 
 class TestMainScriptMode:

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -20,6 +20,7 @@ from collect_metrics import MetricsCollector
 from collect_metrics import main as collect_main
 
 from start_green_stay_green.generators.metrics import count_precommit_hooks
+from start_green_stay_green.generators.metrics import precommit_status
 
 
 class TestMetricsCollector:
@@ -868,6 +869,28 @@ class TestCollectPrecommitStatus:
             assert collector.metrics["precommit_status"]["total_hooks"] == (
                 count_precommit_hooks(config_path)
             )
+
+    def test_collect_precommit_status_delegates_to_shared_builder(self) -> None:
+        """The status dict is built by the canonical ``precommit_status`` helper.
+
+        Issue #154 DRY consolidation: ``collect_precommit_status`` must not
+        re-derive ``has_hooks``/``passing_hooks``/``percentage``/``status``;
+        it must delegate dict construction to the shared
+        ``precommit_status`` builder in the metrics generator module.
+        """
+        with TemporaryDirectory() as tmpdir:
+            config_path = self._write_config(Path(tmpdir), 13)
+            collector = MetricsCollector("test", {})
+
+            with patch.object(
+                collect_metrics,
+                "precommit_status",
+                wraps=precommit_status,
+            ) as spy:
+                collector.collect_precommit_status(config_path)
+
+            spy.assert_called_once_with(13)
+            assert collector.metrics["precommit_status"] == precommit_status(13)
 
 
 class TestMainScriptMode:


### PR DESCRIPTION
## Summary

Adds a **Pre-Commit Status** metric card to the generated quality-metrics
dashboard, positioned as the **first card (index 0)** ahead of Code Coverage,
mirroring the visual pattern of the existing Coverage and Mutation Score cards.

The card displays the share of pre-commit hooks passing as a percentage with
the issue's color-coding thresholds and an `X/Y Hooks` threshold line:

- **Green** (100%): all hooks passing
- **Yellow** (90–99%): most hooks passing
- **Red** (<90%): some hooks failing

### What changed

- **`MetricsGenerator.count_precommit_hooks()`** — derives the total hook count
  from `.pre-commit-config.yaml` (sum of `hooks` across all `repos`), degrading
  gracefully to `0` for missing / empty / malformed configs.
- **`MetricsGenerationConfig.precommit_hooks_total`** — new field feeding the
  card's `X/Y Hooks` threshold at generation time.
- **Dashboard HTML** — Pre-Commit Status card rendered at index 0 with the
  `precommit-value` / `precommit-threshold` / `precommit-status-badge` ids, plus
  `updatePrecommitStatus()` JS that populates the card from
  `metrics.precommit_status` (`total_hooks` / `passing_hooks` / `percentage` /
  `status`) and applies the green/yellow/red status classes.
- **CLI** (`_generate_metrics_dashboard_step`) — seeds `docs/metrics.json` with a
  `precommit_status` entry derived from the project's `.pre-commit-config.yaml`.
- **`scripts/collect_metrics.py`** — new `collect_precommit_status()` so the
  CI-refreshed `metrics.json` includes the field.
- **`scripts/regenerate_dashboard.py`** and the SGSG repo's own
  `docs/dashboard.html` + `docs/metrics.json` regenerated to show `31/31 Hooks`.

## Test plan

Strict TDD (Red → Green). New tests:

- `tests/unit/generators/test_metrics.py::TestPrecommitStatusCard` — hook
  counting (valid / missing / empty / malformed YAML / non-mapping top level /
  malformed repo entries), card is first, `X/Y Hooks` threshold, DOM ids,
  JS color-coding thresholds, zero-total rendering.
- `tests/unit/test_collect_metrics.py::TestCollectPrecommitStatus` — status
  collection for valid / missing / malformed / non-mapping configs.
- Updated existing card-count assertion (8 → 9) and the four CLI mocked
  dashboard tests to account for the new card.

Gates (run from the worktree venv):

- `./scripts/check-all.sh` — **all 7 checks passed**, total coverage **94.48%**.
- `pre-commit run --all-files` — **all hooks passed**.
- New/changed code in `metrics.py` fully covered (module at 98.11%, remaining
  misses are pre-existing lines unrelated to this change).

No quality bypasses were used. The pip-audit advisory on the bundled `pip`
(an environment artifact, not a project dependency) was remediated by upgrading
pip to 26.1.2 rather than suppressed.

Closes #154
