### PR TITLE
feat(metrics): add CI Status card to the dashboard (#159)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -31,6 +31,10 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Generate metrics.json via script mode
+        env:
+          # Enables the CI Status card's GitHub API path (Issue #159);
+          # without it, collection degrades to a static job count.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . .venv/bin/activate
           python scripts/collect_metrics.py \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1660
+        "line_number": 1669
       }
     ]
   },
-  "generated_at": "2026-06-10T05:17:44Z"
+  "generated_at": "2026-06-10T05:46:37Z"
 }

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -115,6 +115,18 @@
                 </div>
             </div>
 
+            <div class="metric-card" id="ci-status">
+                <div class="metric-name">CI Status</div>
+                <div class="metric-value" id="ci-value">--</div>
+                <div class="metric-threshold">
+                    Threshold:
+                    <span id="ci-threshold">10/10 Jobs</span>
+                </div>
+                <div class="metric-status status-pass" id="ci-status-badge">
+                    PASSING
+                </div>
+            </div>
+
             <div class="metric-card">
                 <div class="metric-name">Code Coverage</div>
                 <div class="metric-value" id="coverage-value">--</div>
@@ -231,6 +243,9 @@
 
             // Pre-Commit Status (index 0): green 100%, yellow 90-99%, red <90%
             updatePrecommitStatus(metrics.precommit_status);
+
+            // CI Status (index 1): green 100%, yellow 85-99%, red <85%
+            updateCIStatus(metrics.ci_status);
 
             // Coverage
             if (metrics.coverage !== undefined) {
@@ -374,6 +389,52 @@
                 statusClass = 'status-pass';
                 statusText = 'PASSING';
             } else if (percentage >= 90) {
+                statusClass = 'status-warn';
+                statusText = 'WARNING';
+            } else {
+                statusClass = 'status-fail';
+                statusText = 'FAILING';
+            }
+            badgeElem.textContent = statusText;
+            badgeElem.className = 'metric-status ' + statusClass;
+        }
+
+        function updateCIStatus(ci) {
+            const valueElem = document.getElementById('ci-value');
+            const thresholdElem = document.getElementById('ci-threshold');
+            const badgeElem = document.getElementById('ci-status-badge');
+
+            // No-data guard (Issue #159): when there is no CI data, or the
+            // status is 'unknown' (static workflow count or API failure),
+            // render the gray N/A treatment BEFORE the percentage
+            // thresholds so a 0% unknown card does not fall through to red
+            // FAILING.
+            if (!ci || ci.status === 'unknown') {
+                valueElem.textContent = 'N/A';
+                thresholdElem.textContent = 'No data';
+                badgeElem.textContent = 'N/A';
+                badgeElem.className = 'metric-status status-unknown';
+                return;
+            }
+
+            const total = ci.total_jobs || 0;
+            const passing = ci.passing_jobs || 0;
+            const percentage = (ci.percentage !== undefined &&
+                ci.percentage !== null)
+                ? ci.percentage
+                : (total > 0 ? (passing / total) * 100 : 0);
+
+            valueElem.textContent = percentage.toFixed(0) + '%';
+            thresholdElem.textContent = passing + '/' + total + ' Jobs';
+
+            // Color coding per Issue #159:
+            // green (100%), yellow (85-99%), red (<85%)
+            let statusClass;
+            let statusText;
+            if (percentage >= 100) {
+                statusClass = 'status-pass';
+                statusText = 'PASSING';
+            } else if (percentage >= 85) {
                 statusClass = 'status-warn';
                 statusText = 'WARNING';
             } else {

--- a/docs/metrics.json
+++ b/docs/metrics.json
@@ -16,6 +16,12 @@
       "percentage": 100.0,
       "status": "passing"
     },
+    "ci_status": {
+      "total_jobs": 10,
+      "passing_jobs": 10,
+      "percentage": 100.0,
+      "status": "passing"
+    },
     "coverage": 92.62,
     "coverage_status": "pass",
     "branch_coverage": 90.26,

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import argparse
 from datetime import UTC
 from datetime import datetime
+from http import HTTPStatus
+import http.client
 import json
+import os
 from pathlib import Path
 import re
 import sqlite3
@@ -25,11 +28,146 @@ import sys
 from typing import Any
 from typing import TYPE_CHECKING
 
+from start_green_stay_green.generators.metrics import ci_status
+from start_green_stay_green.generators.metrics import count_ci_jobs
 from start_green_stay_green.generators.metrics import count_precommit_hooks
 from start_green_stay_green.generators.metrics import precommit_status
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+# GitHub REST API endpoint used by the hybrid CI Status collection
+# (Issue #159). HTTPS is enforced by construction via HTTPSConnection.
+GITHUB_API_HOST = "api.github.com"
+GITHUB_API_TIMEOUT_SECONDS = 10
+
+# ``owner/repo`` slug as provided by the GITHUB_REPOSITORY env var.
+GITHUB_REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+def _github_api_json(path: str, token: str) -> object | None:
+    """Fetch a JSON payload from the GitHub REST API over HTTPS.
+
+    Args:
+        path: Request path (e.g., ``/repos/owner/repo/actions/runs``).
+        token: GitHub token used as a Bearer credential.
+
+    Returns:
+        The decoded JSON payload, or ``None`` on any network, HTTP, or
+        decoding failure (callers fall back to static counting).
+    """
+    connection = http.client.HTTPSConnection(
+        GITHUB_API_HOST, timeout=GITHUB_API_TIMEOUT_SECONDS
+    )
+    try:
+        connection.request(
+            "GET",
+            path,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "start-green-stay-green-metrics",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        response = connection.getresponse()
+        if response.status != HTTPStatus.OK:
+            return None
+        payload: object = json.loads(response.read().decode("utf-8"))
+    except (OSError, ValueError, http.client.HTTPException):
+        return None
+    else:
+        return payload
+    finally:
+        connection.close()
+
+
+def _latest_main_run(runs_payload: object) -> dict[str, Any] | None:
+    """Extract the latest workflow run from a runs API payload.
+
+    Args:
+        runs_payload: Decoded JSON from the workflow-runs endpoint.
+
+    Returns:
+        The first (most recent) run mapping with an ``id``, or ``None``
+        when the payload is malformed or contains no runs.
+    """
+    if not isinstance(runs_payload, dict):
+        return None
+    runs = runs_payload.get("workflow_runs")
+    if not isinstance(runs, list) or not runs:
+        return None
+    run = runs[0]
+    if isinstance(run, dict) and "id" in run:
+        return run
+    return None
+
+
+def _job_conclusion_counts(jobs_payload: object) -> tuple[int, int] | None:
+    """Count total and successful jobs from a jobs API payload.
+
+    Args:
+        jobs_payload: Decoded JSON from the run-jobs endpoint.
+
+    Returns:
+        A ``(total_jobs, passing_jobs)`` tuple, or ``None`` when the
+        payload is malformed.
+    """
+    if not isinstance(jobs_payload, dict):
+        return None
+    jobs = jobs_payload.get("jobs")
+    if not isinstance(jobs, list):
+        return None
+    passing = sum(
+        1
+        for job in jobs
+        if isinstance(job, dict) and job.get("conclusion") == "success"
+    )
+    return (len(jobs), passing)
+
+
+def _fetch_ci_status_from_api(repo: str, token: str) -> dict[str, object] | None:
+    """Fetch CI job pass/fail counts for the latest main run via GitHub API.
+
+    Queries the most recent completed workflow run on ``main`` and counts
+    job conclusions (``success`` counts as passing). Any failure — invalid
+    repo slug, network error, non-200 response, malformed payload, or no
+    completed runs — returns ``None`` so the caller falls back to static
+    workflow counting. Never raises.
+
+    Args:
+        repo: ``owner/repo`` slug (from the GITHUB_REPOSITORY env var).
+        token: GitHub token (from the GITHUB_TOKEN env var).
+
+    Returns:
+        A ``ci_status`` mapping built by the canonical helper (including
+        ``run_url``), or ``None`` when the API path is unavailable.
+    """
+    if not GITHUB_REPOSITORY_PATTERN.match(repo):
+        return None
+
+    runs_payload = _github_api_json(
+        f"/repos/{repo}/actions/runs?branch=main&status=completed&per_page=1",
+        token,
+    )
+    run = _latest_main_run(runs_payload)
+    if run is None:
+        return None
+
+    jobs_payload = _github_api_json(
+        f"/repos/{repo}/actions/runs/{run['id']}/jobs?per_page=100", token
+    )
+    counts = _job_conclusion_counts(jobs_payload)
+    if counts is None:
+        return None
+
+    total_jobs, passing_jobs = counts
+    run_url = run.get("html_url")
+    return ci_status(
+        total_jobs,
+        passing_jobs,
+        run_url=run_url if isinstance(run_url, str) else None,
+    )
 
 
 class MetricsCollector:
@@ -194,6 +332,31 @@ class MetricsCollector:
         """
         total = count_precommit_hooks(config_path)
         self.metrics["precommit_status"] = precommit_status(total)
+
+    def collect_ci_status(self, workflows_dir: Path) -> None:
+        """Collect CI job status using the hybrid API/static strategy (#159).
+
+        When ``GITHUB_TOKEN`` and ``GITHUB_REPOSITORY`` are available
+        (GitHub Actions), the latest completed workflow run on ``main`` is
+        queried via the GitHub API and job conclusions are counted
+        (``success`` counts as passing), including the run URL. On any API
+        failure — or outside CI — this degrades to statically counting jobs
+        across ``.github/workflows/*.yml`` with ``unknown`` status (pass or
+        fail cannot be known statically). Never raises.
+
+        Args:
+            workflows_dir: Path to the ``.github/workflows`` directory used
+                for the static fallback count.
+        """
+        token = os.environ.get("GITHUB_TOKEN")
+        repo = os.environ.get("GITHUB_REPOSITORY")
+
+        status: dict[str, object] | None = None
+        if token and repo:
+            status = _fetch_ci_status_from_api(repo, token)
+        if status is None:
+            status = ci_status(count_ci_jobs(workflows_dir))
+        self.metrics["ci_status"] = status
 
     def add_mutation_score(self, score: float) -> None:
         """Add mutation testing score.
@@ -504,6 +667,9 @@ def _collect_script_mode(
     # Pre-Commit Status (Issue #154): derived from .pre-commit-config.yaml
     collector.collect_precommit_status(Path(".pre-commit-config.yaml"))
 
+    # CI Status (Issue #159): GitHub API when available, static otherwise
+    collector.collect_ci_status(Path(".github/workflows"))
+
 
 def _collect_file_mode(
     collector: MetricsCollector,
@@ -543,6 +709,9 @@ def _collect_file_mode(
 
     # Pre-Commit Status (Issue #154): derived from .pre-commit-config.yaml
     collector.collect_precommit_status(Path(".pre-commit-config.yaml"))
+
+    # CI Status (Issue #159): GitHub API when available, static otherwise
+    collector.collect_ci_status(Path(".github/workflows"))
 
     _collect_mutation(collector, args)
 

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -54,8 +54,14 @@ def _github_api_json(path: str, token: str) -> object | None:
 
     Returns:
         The decoded JSON payload, or ``None`` on any network, HTTP, or
-        decoding failure (callers fall back to static counting).
+        decoding failure (callers fall back to static counting). Tokens
+        containing interior whitespace are rejected outright —
+        ``http.client`` does not sanitize header values, so this closes
+        the header-injection path.
     """
+    token = token.strip()
+    if not token or re.search(r"\s", token):
+        return None
     connection = http.client.HTTPSConnection(
         GITHUB_API_HOST, timeout=GITHUB_API_TIMEOUT_SECONDS
     )
@@ -106,24 +112,29 @@ def _latest_main_run(runs_payload: object) -> dict[str, Any] | None:
 def _job_conclusion_counts(jobs_payload: object) -> tuple[int, int] | None:
     """Count total and successful jobs from a jobs API payload.
 
+    Conditionally-skipped jobs (``conclusion: "skipped"``) are excluded
+    from the denominator: a deploy job gated on a branch condition must
+    not drag an otherwise all-green run below 100%.
+
     Args:
         jobs_payload: Decoded JSON from the run-jobs endpoint.
 
     Returns:
-        A ``(total_jobs, passing_jobs)`` tuple, or ``None`` when the
-        payload is malformed.
+        A ``(total_jobs, passing_jobs)`` tuple counting only jobs that
+        actually ran, or ``None`` when the payload is malformed.
     """
     if not isinstance(jobs_payload, dict):
         return None
     jobs = jobs_payload.get("jobs")
     if not isinstance(jobs, list):
         return None
-    passing = sum(
-        1
+    ran_jobs = [
+        job
         for job in jobs
-        if isinstance(job, dict) and job.get("conclusion") == "success"
-    )
-    return (len(jobs), passing)
+        if isinstance(job, dict) and job.get("conclusion") != "skipped"
+    ]
+    passing = sum(1 for job in ran_jobs if job.get("conclusion") == "success")
+    return (len(ran_jobs), passing)
 
 
 def _fetch_ci_status_from_api(repo: str, token: str) -> dict[str, object] | None:
@@ -154,6 +165,8 @@ def _fetch_ci_status_from_api(repo: str, token: str) -> dict[str, object] | None
     if run is None:
         return None
 
+    # GitHub paginates this endpoint at 100 jobs per page; runs with more
+    # jobs than that would be silently under-counted here.
     jobs_payload = _github_api_json(
         f"/repos/{repo}/actions/runs/{run['id']}/jobs?per_page=100", token
     )

--- a/scripts/regenerate_dashboard.py
+++ b/scripts/regenerate_dashboard.py
@@ -18,6 +18,7 @@ import sys
 
 from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
+from start_green_stay_green.generators.metrics import count_ci_jobs
 
 
 def main() -> int:
@@ -39,10 +40,12 @@ def main() -> int:
     precommit_hooks_total = MetricsGenerator.count_precommit_hooks(
         Path(".pre-commit-config.yaml")
     )
+    ci_jobs_total = count_ci_jobs(Path(".github/workflows"))
     config = MetricsGenerationConfig(
         language="python",
         project_name=args.project_name,
         precommit_hooks_total=precommit_hooks_total,
+        ci_jobs_total=ci_jobs_total,
     )
     generator = MetricsGenerator(None, config)
     result = generator.write_dashboard(args.output_dir)

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -62,6 +62,8 @@ from start_green_stay_green.generators.github_actions import (
 )
 from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
+from start_green_stay_green.generators.metrics import ci_status
+from start_green_stay_green.generators.metrics import count_ci_jobs
 from start_green_stay_green.generators.metrics import precommit_status
 from start_green_stay_green.generators.precommit import GenerationConfig
 from start_green_stay_green.generators.precommit import PreCommitGenerator
@@ -1286,6 +1288,7 @@ def _generate_metrics_dashboard_step(
         precommit_hooks_total = MetricsGenerator.count_precommit_hooks(
             project_path / ".pre-commit-config.yaml"
         )
+        ci_jobs_total = count_ci_jobs(project_path / ".github" / "workflows")
         config = MetricsGenerationConfig(
             language=language,
             project_name=project_name,
@@ -1295,6 +1298,7 @@ def _generate_metrics_dashboard_step(
             complexity_threshold=10,
             doc_coverage_threshold=95,
             precommit_hooks_total=precommit_hooks_total,
+            ci_jobs_total=ci_jobs_total,
             enable_dashboard=True,
             enable_badges=True,
         )
@@ -1319,6 +1323,7 @@ def _generate_metrics_dashboard_step(
             },
             "metrics": {
                 "precommit_status": precommit_status(precommit_hooks_total),
+                "ci_status": ci_status(ci_jobs_total),
                 "coverage": 0.0,
                 "coverage_status": "fail",
                 "branch_coverage": 0.0,

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -148,6 +148,118 @@ def precommit_status(
     }
 
 
+def _workflow_job_count(workflow_path: Path) -> int:
+    """Return the number of jobs declared in a single workflow file.
+
+    Args:
+        workflow_path: Path to a GitHub Actions workflow YAML file.
+
+    Returns:
+        Number of entries in the workflow's ``jobs`` mapping, or ``0``
+        when the file is unreadable, malformed, or has no ``jobs`` mapping.
+    """
+    try:
+        data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return 0
+
+    jobs = data.get("jobs") if isinstance(data, dict) else None
+    return len(jobs) if isinstance(jobs, dict) else 0
+
+
+def count_ci_jobs(workflows_dir: Path) -> int:
+    """Count GitHub Actions jobs across all workflow files in a directory.
+
+    Canonical, public job-counting helper (Issue #159). Sums the ``jobs``
+    entries across every ``*.yml``/``*.yaml`` file in
+    ``.github/workflows/``. A missing directory, malformed YAML, or a
+    workflow without a ``jobs`` mapping degrades gracefully to ``0`` so
+    callers (the dashboard generator, ``start_green_stay_green.cli`` and
+    ``scripts/collect_metrics.py``) can still render a meaningful CI Status
+    card without duplicating this logic.
+
+    Args:
+        workflows_dir: Path to a ``.github/workflows`` directory.
+
+    Returns:
+        Total job count, or ``0`` when the directory is absent or contains
+        no parseable workflow jobs.
+    """
+    if not workflows_dir.is_dir():
+        return 0
+
+    workflow_files = sorted(
+        [*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")]
+    )
+    return sum(_workflow_job_count(path) for path in workflow_files)
+
+
+def _ci_status_label(total_jobs: int, passing_jobs: int | None) -> str:
+    """Derive the CI status label from job counts.
+
+    Args:
+        total_jobs: Total CI jobs counted.
+        passing_jobs: Successful jobs, or ``None`` when pass/fail data is
+            unavailable (static workflow counting).
+
+    Returns:
+        ``"unknown"`` when there is no pass/fail data or no jobs,
+        ``"passing"`` when every job succeeded, ``"failing"`` otherwise.
+    """
+    if passing_jobs is None or total_jobs <= 0:
+        return "unknown"
+    return "passing" if passing_jobs >= total_jobs else "failing"
+
+
+def ci_status(
+    total_jobs: int,
+    passing_jobs: int | None = None,
+    *,
+    run_url: str | None = None,
+) -> dict[str, object]:
+    """Build the canonical CI Status dict for the metrics dashboard.
+
+    Single source of truth (Issue #159) for the ``ci_status`` mapping
+    consumed by the dashboard's CI Status card. Both
+    ``start_green_stay_green.cli`` and ``scripts/collect_metrics.py``
+    delegate here instead of rebuilding the
+    ``total_jobs``/``passing_jobs``/``percentage``/``status`` fields.
+
+    When ``passing_jobs`` is ``None`` (jobs were counted statically from
+    workflow files, so pass/fail data is unavailable) or ``total_jobs`` is
+    ``0`` (no workflows found, or the GitHub API was unreachable), the
+    status is ``"unknown"`` so the dashboard renders the gray "N/A" no-data
+    treatment instead of a red FAILING card. Otherwise the status is
+    ``"passing"`` when every job succeeded and ``"failing"`` when any job
+    did not.
+
+    Args:
+        total_jobs: Total CI jobs counted (statically or from the API).
+        passing_jobs: Jobs whose conclusion was ``success``, or ``None``
+            when pass/fail data is unavailable (static counting).
+        run_url: HTML URL of the workflow run the counts came from, when
+            the GitHub API supplied one. Omitted from the result if
+            ``None``.
+
+    Returns:
+        A ``ci_status`` mapping with ``total_jobs``, ``passing_jobs``,
+        ``percentage`` and ``status`` keys, plus ``run_url`` when provided.
+    """
+    status = _ci_status_label(total_jobs, passing_jobs)
+    resolved_passing = passing_jobs if passing_jobs is not None else 0
+    percentage = (resolved_passing / total_jobs * 100) if total_jobs > 0 else 0.0
+
+    result: dict[str, object] = {
+        "total_jobs": total_jobs,
+        "passing_jobs": resolved_passing,
+        "percentage": percentage,
+        "status": status,
+    }
+    if run_url is not None:
+        result["run_url"] = run_url
+    return result
+
+
 @dataclass(frozen=True)
 class MetricConfig:
     """Configuration for a single quality metric.
@@ -189,6 +301,10 @@ class MetricsGenerationConfig:
             (derived from ``.pre-commit-config.yaml``). Rendered as the
             denominator of the Pre-Commit Status card's ``X/Y Hooks``
             threshold. Defaults to 0 when no config is available.
+        ci_jobs_total: Total number of CI jobs configured (derived from
+            ``.github/workflows/*.yml``). Rendered as the denominator of
+            the CI Status card's ``X/Y Jobs`` threshold. Defaults to 0
+            when no workflows are available.
         enable_sonarqube: Whether to generate SonarQube config.
         enable_badges: Whether to generate GitHub badges.
         enable_dashboard: Whether to generate dashboard template.
@@ -206,6 +322,7 @@ class MetricsGenerationConfig:
     doc_coverage_threshold: int = 95
     dependency_freshness_days: int = 30
     precommit_hooks_total: int = 0
+    ci_jobs_total: int = 0
     enable_sonarqube: bool = False
     enable_badges: bool = True
     enable_dashboard: bool = True
@@ -523,6 +640,7 @@ class MetricsGenerator(BaseGenerator):
         self._validate_non_negative(
             self.config.precommit_hooks_total, "Pre-commit hooks total"
         )
+        self._validate_non_negative(self.config.ci_jobs_total, "CI jobs total")
 
     @staticmethod
     def count_precommit_hooks(config_path: Path) -> int:
@@ -737,6 +855,12 @@ class MetricsGenerator(BaseGenerator):
         precommit_total = self.config.precommit_hooks_total
         precommit_threshold = f"{precommit_total}/{precommit_total} Hooks"
 
+        # CI Status baseline (Issue #159): render all configured jobs as the
+        # ``X/Y Jobs`` denominator. The JS later overrides this from
+        # metrics.json (or grays the card out when status is unknown).
+        ci_total = self.config.ci_jobs_total
+        ci_threshold = f"{ci_total}/{ci_total} Jobs"
+
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -850,6 +974,18 @@ class MetricsGenerator(BaseGenerator):
                     <span id="precommit-threshold">{precommit_threshold}</span>
                 </div>
                 <div class="metric-status status-pass" id="precommit-status-badge">
+                    PASSING
+                </div>
+            </div>
+
+            <div class="metric-card" id="ci-status">
+                <div class="metric-name">CI Status</div>
+                <div class="metric-value" id="ci-value">--</div>
+                <div class="metric-threshold">
+                    Threshold:
+                    <span id="ci-threshold">{ci_threshold}</span>
+                </div>
+                <div class="metric-status status-pass" id="ci-status-badge">
                     PASSING
                 </div>
             </div>
@@ -970,6 +1106,9 @@ class MetricsGenerator(BaseGenerator):
 
             // Pre-Commit Status (index 0): green 100%, yellow 90-99%, red <90%
             updatePrecommitStatus(metrics.precommit_status);
+
+            // CI Status (index 1): green 100%, yellow 85-99%, red <85%
+            updateCIStatus(metrics.ci_status);
 
             // Coverage
             if (metrics.coverage !== undefined) {{
@@ -1113,6 +1252,52 @@ class MetricsGenerator(BaseGenerator):
                 statusClass = 'status-pass';
                 statusText = 'PASSING';
             }} else if (percentage >= 90) {{
+                statusClass = 'status-warn';
+                statusText = 'WARNING';
+            }} else {{
+                statusClass = 'status-fail';
+                statusText = 'FAILING';
+            }}
+            badgeElem.textContent = statusText;
+            badgeElem.className = 'metric-status ' + statusClass;
+        }}
+
+        function updateCIStatus(ci) {{
+            const valueElem = document.getElementById('ci-value');
+            const thresholdElem = document.getElementById('ci-threshold');
+            const badgeElem = document.getElementById('ci-status-badge');
+
+            // No-data guard (Issue #159): when there is no CI data, or the
+            // status is 'unknown' (static workflow count or API failure),
+            // render the gray N/A treatment BEFORE the percentage
+            // thresholds so a 0% unknown card does not fall through to red
+            // FAILING.
+            if (!ci || ci.status === 'unknown') {{
+                valueElem.textContent = 'N/A';
+                thresholdElem.textContent = 'No data';
+                badgeElem.textContent = 'N/A';
+                badgeElem.className = 'metric-status status-unknown';
+                return;
+            }}
+
+            const total = ci.total_jobs || 0;
+            const passing = ci.passing_jobs || 0;
+            const percentage = (ci.percentage !== undefined &&
+                ci.percentage !== null)
+                ? ci.percentage
+                : (total > 0 ? (passing / total) * 100 : 0);
+
+            valueElem.textContent = percentage.toFixed(0) + '%';
+            thresholdElem.textContent = passing + '/' + total + ' Jobs';
+
+            // Color coding per Issue #159:
+            // green (100%), yellow (85-99%), red (<85%)
+            let statusClass;
+            let statusText;
+            if (percentage >= 100) {{
+                statusClass = 'status-pass';
+                statusText = 'PASSING';
+            }} else if (percentage >= 85) {{
                 statusClass = 'status-warn';
                 statusText = 'WARNING';
             }} else {{

--- a/tests/integration/generators/test_metrics_integration.py
+++ b/tests/integration/generators/test_metrics_integration.py
@@ -621,6 +621,25 @@ class TestDashboardSync:
                 "Run: python scripts/regenerate_dashboard.py"
             )
 
+    def test_deployed_has_ci_status_card(self) -> None:
+        """Verify docs/dashboard.html includes the CI Status card (Issue #159).
+
+        The deployed dashboard must carry the CI Status card's DOM ids and
+        the JS handler for the ``ci_status`` metrics.json key so the live
+        GitHub Pages dashboard renders CI job health.
+        """
+        deployed = self._get_deployed()
+
+        for expected in ('id="ci-value"', 'id="ci-threshold"', 'id="ci-status"'):
+            assert expected in deployed, (
+                f"docs/dashboard.html missing {expected}. "
+                "Run: python scripts/regenerate_dashboard.py"
+            )
+        assert "metrics.ci_status" in deployed, (
+            "docs/dashboard.html JS missing handler for metrics.ci_status. "
+            "Run: python scripts/regenerate_dashboard.py"
+        )
+
     def test_deployed_no_data_cards_render_gray_not_red(self) -> None:
         """Fresh dashboards must show the eight existing cards' no-data state gray.
 

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -17,6 +17,8 @@ from start_green_stay_green.generators.metrics import MetricConfig
 from start_green_stay_green.generators.metrics import MetricsGenerationConfig
 from start_green_stay_green.generators.metrics import MetricsGenerator
 from start_green_stay_green.generators.metrics import STANDARD_METRICS
+from start_green_stay_green.generators.metrics import ci_status
+from start_green_stay_green.generators.metrics import count_ci_jobs
 from start_green_stay_green.generators.metrics import count_precommit_hooks
 from start_green_stay_green.generators.metrics import precommit_status
 
@@ -1246,6 +1248,250 @@ class TestPrecommitStatusHelper:
         assert result["status"] == "passing"
 
 
+class TestCountCIJobs:
+    """Tests for the canonical ``count_ci_jobs`` helper (Issue #159)."""
+
+    def test_counts_jobs_across_workflow_files(self) -> None:
+        """Job count is the sum of jobs across every workflow file."""
+        with TemporaryDirectory() as tmp:
+            workflows = Path(tmp)
+            (workflows / "ci.yml").write_text(
+                yaml.dump({"jobs": {"lint": {}, "test": {}, "build": {}}}),
+                encoding="utf-8",
+            )
+            (workflows / "deploy.yml").write_text(
+                yaml.dump({"jobs": {"deploy": {}}}),
+                encoding="utf-8",
+            )
+
+            assert count_ci_jobs(workflows) == 4
+
+    def test_counts_yaml_extension_workflows(self) -> None:
+        """Workflows using the ``.yaml`` extension are counted too."""
+        with TemporaryDirectory() as tmp:
+            workflows = Path(tmp)
+            (workflows / "ci.yaml").write_text(
+                yaml.dump({"jobs": {"test": {}}}),
+                encoding="utf-8",
+            )
+
+            assert count_ci_jobs(workflows) == 1
+
+    def test_missing_directory_returns_zero(self) -> None:
+        """A missing workflows directory yields zero jobs (graceful)."""
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / ".github" / "workflows"
+
+            assert count_ci_jobs(missing) == 0
+
+    def test_malformed_yaml_contributes_zero(self) -> None:
+        """Malformed workflow YAML degrades to zero rather than raising."""
+        with TemporaryDirectory() as tmp:
+            workflows = Path(tmp)
+            (workflows / "broken.yml").write_text(
+                "jobs: [unterminated", encoding="utf-8"
+            )
+            (workflows / "ok.yml").write_text(
+                yaml.dump({"jobs": {"test": {}}}),
+                encoding="utf-8",
+            )
+
+            assert count_ci_jobs(workflows) == 1
+
+    def test_non_mapping_jobs_contributes_zero(self) -> None:
+        """A workflow whose ``jobs`` is not a mapping contributes zero."""
+        with TemporaryDirectory() as tmp:
+            workflows = Path(tmp)
+            (workflows / "list-jobs.yml").write_text(
+                yaml.dump({"jobs": ["not", "a", "mapping"]}),
+                encoding="utf-8",
+            )
+            (workflows / "no-jobs.yml").write_text(
+                yaml.dump({"name": "no jobs key"}),
+                encoding="utf-8",
+            )
+            (workflows / "scalar.yml").write_text("just a string", encoding="utf-8")
+
+            assert count_ci_jobs(workflows) == 0
+
+    def test_empty_directory_returns_zero(self) -> None:
+        """An empty workflows directory yields zero jobs."""
+        with TemporaryDirectory() as tmp:
+            assert count_ci_jobs(Path(tmp)) == 0
+
+
+class TestCIStatusHelper:
+    """Tests for the canonical ``ci_status`` dict-builder (Issue #159)."""
+
+    def test_all_jobs_passing_yields_passing_status(self) -> None:
+        """All jobs succeeding yields a 100% passing status."""
+        assert ci_status(7, 7) == {
+            "total_jobs": 7,
+            "passing_jobs": 7,
+            "percentage": 100.0,
+            "status": "passing",
+        }
+
+    def test_partial_passing_yields_failing_status(self) -> None:
+        """Any failing job yields a failing status with a partial percentage."""
+        result = ci_status(8, 6)
+        assert result["total_jobs"] == 8
+        assert result["passing_jobs"] == 6
+        assert result["percentage"] == 75.0
+        assert result["status"] == "failing"
+
+    def test_unknown_status_when_passing_jobs_omitted(self) -> None:
+        """Static counting (no pass/fail data) yields the unknown status."""
+        assert ci_status(7) == {
+            "total_jobs": 7,
+            "passing_jobs": 0,
+            "percentage": 0.0,
+            "status": "unknown",
+        }
+
+    def test_unknown_status_for_zero_jobs(self) -> None:
+        """Zero jobs (no workflows) yields the unknown/no-data status."""
+        assert ci_status(0, 0) == {
+            "total_jobs": 0,
+            "passing_jobs": 0,
+            "percentage": 0.0,
+            "status": "unknown",
+        }
+
+    def test_run_url_included_when_provided(self) -> None:
+        """``run_url`` is included in the dict when the API supplies one."""
+        result = ci_status(7, 7, run_url="https://github.com/o/r/actions/runs/1")
+        assert result["run_url"] == "https://github.com/o/r/actions/runs/1"
+
+    def test_run_url_omitted_when_not_provided(self) -> None:
+        """``run_url`` is absent when no workflow run URL is available."""
+        assert "run_url" not in ci_status(7, 7)
+
+
+class TestCIStatusCard:
+    """Test the CI Status metric card (Issue #159)."""
+
+    def test_ci_card_renders_between_precommit_and_coverage(self) -> None:
+        """CI Status card renders at index 1: after Pre-Commit, before Coverage."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=7,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "CI Status" in dashboard
+        assert dashboard.index("Pre-Commit Status") < dashboard.index("CI Status")
+        assert dashboard.index("CI Status") < dashboard.index("Code Coverage")
+
+    def test_ci_card_shows_total_jobs_threshold(self) -> None:
+        """Threshold shows ``X/Y Jobs`` using the configured total."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=7,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "7/7 Jobs" in dashboard
+
+    def test_ci_card_has_value_and_status_ids(self) -> None:
+        """Card exposes the DOM ids the JS uses to populate it."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=5,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert 'id="ci-value"' in dashboard
+        assert 'id="ci-threshold"' in dashboard
+        assert 'id="ci-status"' in dashboard
+        assert 'id="ci-status-badge"' in dashboard
+
+    def test_ci_js_color_codes_by_percentage(self) -> None:
+        """JS applies green/yellow/red classes per the issue thresholds."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=7,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        # 100% -> pass (green); 85-99% -> warn (yellow); <85% -> fail (red)
+        assert "metrics.ci_status" in dashboard
+        assert ">= 100" in dashboard
+        assert ">= 85" in dashboard
+
+    def test_ci_card_renders_with_zero_total(self) -> None:
+        """A zero job total renders ``0/0 Jobs`` without crashing."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=0,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "0/0 Jobs" in dashboard
+
+    def test_ci_js_grays_unknown_status_before_percentage(self) -> None:
+        """Unknown CI status maps to gray N/A, not red FAILING.
+
+        Mirrors the Issue #154 no-data guard: a ``status: 'unknown'``
+        ci_status entry (static fallback or no workflow data) has
+        ``percentage: 0.0`` which would fall through the percentage
+        thresholds and render red FAILING. ``updateCIStatus`` must branch on
+        the ``status`` field (and missing data) BEFORE the percentage
+        thresholds and apply the gray ``status-unknown`` treatment.
+        """
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            enable_dashboard=True,
+            ci_jobs_total=7,
+        )
+        generator = MetricsGenerator(None, config)
+
+        dashboard = generator._generate_dashboard_template()
+
+        assert dashboard is not None
+        assert "ci.status === 'unknown'" in dashboard
+        guard = dashboard.index("ci.status === 'unknown'")
+        threshold = dashboard.index("if (percentage >= 85)")
+        assert guard < threshold
+
+    def test_negative_ci_jobs_total_rejected(self) -> None:
+        """A negative ``ci_jobs_total`` fails config validation."""
+        config = MetricsGenerationConfig(
+            language="python",
+            project_name="test",
+            ci_jobs_total=-1,
+        )
+
+        with pytest.raises(ValueError, match="CI jobs total"):
+            MetricsGenerator(None, config)
+
+
 class TestCIIntegration:
     """Test CI integration configuration generation."""
 
@@ -1831,17 +2077,18 @@ class TestDashboardNewCards:
         assert "Test Count" in dashboard
         assert "tests-value" in dashboard
 
-    def test_dashboard_has_nine_metric_cards(self) -> None:
-        """Test dashboard has exactly 9 metric cards.
+    def test_dashboard_has_ten_metric_cards(self) -> None:
+        """Test dashboard has exactly 10 metric cards.
 
         Eight original quality cards plus the Pre-Commit Status card added
-        at index 0 (Issue #154).
+        at index 0 (Issue #154) and the CI Status card added at index 1
+        (Issue #159).
         """
         dashboard = self._get_dashboard()
 
         # Count metric-card div occurrences
         card_count = dashboard.count('class="metric-card"')
-        assert card_count == 9
+        assert card_count == 10
 
 
 class TestDashboardJavaScript:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -883,6 +883,15 @@ class TestMetricsDashboardGeneration:
         assert "thresholds" in metrics_data
         assert "metrics" in metrics_data
 
+        # Issue #159: fresh projects seed a ci_status entry. No workflows
+        # exist when the dashboard step counts jobs, so it degrades to the
+        # unknown/no-data status (rendered gray, not red).
+        ci_seed = metrics_data["metrics"]["ci_status"]
+        assert ci_seed["total_jobs"] == 0
+        assert ci_seed["passing_jobs"] == 0
+        assert ci_seed["percentage"] == 0.0
+        assert ci_seed["status"] == "unknown"
+
     @patch("start_green_stay_green.cli.shutil.copy")
     @patch("start_green_stay_green.cli.MetricsGenerator")
     def test_generate_metrics_dashboard_creates_workflows_dir(

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -19,6 +19,8 @@ import collect_metrics
 from collect_metrics import MetricsCollector
 from collect_metrics import main as collect_main
 
+from start_green_stay_green.generators.metrics import ci_status
+from start_green_stay_green.generators.metrics import count_ci_jobs
 from start_green_stay_green.generators.metrics import count_precommit_hooks
 from start_green_stay_green.generators.metrics import precommit_status
 
@@ -891,6 +893,239 @@ class TestCollectPrecommitStatus:
 
             spy.assert_called_once_with(13)
             assert collector.metrics["precommit_status"] == precommit_status(13)
+
+
+class TestCollectCIStatus:
+    """Tests for ``collect_ci_status`` on MetricsCollector (Issue #159)."""
+
+    def _write_workflow(self, path: Path, name: str, job_ids: list[str]) -> Path:
+        """Write a workflow file declaring the given job ids.
+
+        Args:
+            path: Directory to write the workflow into.
+            name: Workflow filename (e.g., ``ci.yml``).
+            job_ids: Job identifiers for the ``jobs`` mapping.
+
+        Returns:
+            Path to the written workflow file.
+        """
+        workflow_path = path / name
+        workflow_path.write_text(
+            yaml.dump({"jobs": {job_id: {} for job_id in job_ids}}),
+            encoding="utf-8",
+        )
+        return workflow_path
+
+    def _clear_github_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Remove GitHub Actions env vars so the static fallback is used.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    def test_static_fallback_counts_jobs_with_unknown_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without API env vars, jobs are counted statically as unknown."""
+        self._clear_github_env(monkeypatch)
+        with TemporaryDirectory() as tmpdir:
+            workflows = Path(tmpdir)
+            self._write_workflow(workflows, "ci.yml", ["lint", "test"])
+            self._write_workflow(workflows, "release.yml", ["publish"])
+            collector = MetricsCollector("test", {})
+
+            collector.collect_ci_status(workflows)
+
+            status = collector.metrics["ci_status"]
+            assert status["total_jobs"] == 3
+            assert status["passing_jobs"] == 0
+            assert status["percentage"] == 0.0
+            assert status["status"] == "unknown"
+            assert "run_url" not in status
+
+    def test_missing_workflows_dir_degrades_to_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing workflows directory yields total 0 and unknown status."""
+        self._clear_github_env(monkeypatch)
+        collector = MetricsCollector("test", {})
+
+        collector.collect_ci_status(Path("/nonexistent/.github/workflows"))
+
+        status = collector.metrics["ci_status"]
+        assert status["total_jobs"] == 0
+        assert status["status"] == "unknown"
+
+    def test_malformed_workflow_yaml_never_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed workflow YAML degrades gracefully instead of raising."""
+        self._clear_github_env(monkeypatch)
+        with TemporaryDirectory() as tmpdir:
+            workflows = Path(tmpdir)
+            (workflows / "broken.yml").write_text(
+                "jobs: [unterminated", encoding="utf-8"
+            )
+            collector = MetricsCollector("test", {})
+
+            collector.collect_ci_status(workflows)
+
+            status = collector.metrics["ci_status"]
+            assert status["total_jobs"] == 0
+            assert status["status"] == "unknown"
+
+    def test_api_path_counts_job_conclusions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With API env vars, job conclusions from the latest run are counted."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        payloads = {
+            "/repos/owner/repo/actions/runs"
+            "?branch=main&status=completed&per_page=1": {
+                "workflow_runs": [
+                    {
+                        "id": 42,
+                        "html_url": "https://github.com/owner/repo/actions/runs/42",
+                    }
+                ]
+            },
+            "/repos/owner/repo/actions/runs/42/jobs?per_page=100": {
+                "jobs": [
+                    {"conclusion": "success"},
+                    {"conclusion": "success"},
+                    {"conclusion": "failure"},
+                ]
+            },
+        }
+
+        with patch.object(
+            collect_metrics,
+            "_github_api_json",
+            side_effect=lambda path, _token: payloads[path],
+        ):
+            collector = MetricsCollector("test", {})
+            collector.collect_ci_status(Path("/nonexistent"))
+
+        status = collector.metrics["ci_status"]
+        assert status["total_jobs"] == 3
+        assert status["passing_jobs"] == 2
+        assert status["percentage"] == pytest.approx(66.67, abs=0.01)
+        assert status["status"] == "failing"
+        assert status["run_url"] == "https://github.com/owner/repo/actions/runs/42"
+
+    def test_api_all_passing_yields_passing_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All-success job conclusions yield a 100% passing status."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        def fake_api(path: str, _token: str) -> dict[str, object]:
+            if "/jobs" in path:
+                return {"jobs": [{"conclusion": "success"}] * 7}
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 7,
+                        "html_url": "https://github.com/owner/repo/actions/runs/7",
+                    }
+                ]
+            }
+
+        with patch.object(collect_metrics, "_github_api_json", side_effect=fake_api):
+            collector = MetricsCollector("test", {})
+            collector.collect_ci_status(Path("/nonexistent"))
+
+        status = collector.metrics["ci_status"]
+        assert status["total_jobs"] == 7
+        assert status["passing_jobs"] == 7
+        assert status["percentage"] == 100.0
+        assert status["status"] == "passing"
+
+    def test_api_failure_falls_back_to_static_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An API error falls back to the static workflow count, never raising."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        with TemporaryDirectory() as tmpdir:
+            workflows = Path(tmpdir)
+            self._write_workflow(workflows, "ci.yml", ["lint", "test"])
+
+            with patch.object(collect_metrics, "_github_api_json", return_value=None):
+                collector = MetricsCollector("test", {})
+                collector.collect_ci_status(workflows)
+
+            status = collector.metrics["ci_status"]
+            assert status["total_jobs"] == 2
+            assert status["status"] == "unknown"
+
+    def test_api_empty_runs_falls_back_to_static_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No completed runs on main falls back to the static count."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        with TemporaryDirectory() as tmpdir:
+            workflows = Path(tmpdir)
+            self._write_workflow(workflows, "ci.yml", ["lint"])
+
+            with patch.object(
+                collect_metrics,
+                "_github_api_json",
+                return_value={"workflow_runs": []},
+            ):
+                collector = MetricsCollector("test", {})
+                collector.collect_ci_status(workflows)
+
+            status = collector.metrics["ci_status"]
+            assert status["total_jobs"] == 1
+            assert status["status"] == "unknown"
+
+    def test_invalid_repository_env_falls_back_to_static(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed GITHUB_REPOSITORY skips the API path entirely."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "not a repo slug!")
+
+        with patch.object(collect_metrics, "_github_api_json") as mock_api:
+            collector = MetricsCollector("test", {})
+            collector.collect_ci_status(Path("/nonexistent"))
+
+        mock_api.assert_not_called()
+        assert collector.metrics["ci_status"]["status"] == "unknown"
+
+    def test_uses_canonical_package_job_counter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """collect_metrics imports the canonical CI helpers (no duplication).
+
+        Issue #159 DRY: the job-counting and status-building helpers live
+        only in ``start_green_stay_green.generators.metrics``;
+        ``collect_metrics`` reuses the same objects instead of redefining
+        them.
+        """
+        assert collect_metrics.__dict__["count_ci_jobs"] is count_ci_jobs
+        assert collect_metrics.__dict__["ci_status"] is ci_status
+
+        self._clear_github_env(monkeypatch)
+        with TemporaryDirectory() as tmpdir:
+            workflows = Path(tmpdir)
+            self._write_workflow(workflows, "ci.yml", ["a", "b", "c"])
+            collector = MetricsCollector("test", {})
+
+            collector.collect_ci_status(workflows)
+
+            assert collector.metrics["ci_status"]["total_jobs"] == (
+                count_ci_jobs(workflows)
+            )
 
 
 class TestMainScriptMode:

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -9,6 +9,7 @@ import sqlite3
 # Import the module we're testing
 import sys
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
@@ -1045,6 +1046,94 @@ class TestCollectCIStatus:
         assert status["passing_jobs"] == 7
         assert status["percentage"] == 100.0
         assert status["status"] == "passing"
+
+    def test_api_skipped_jobs_excluded_from_denominator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Skipped jobs do not count against the passing percentage.
+
+        A conditionally-skipped job (e.g. a deploy gated on a branch
+        condition) must not drag an otherwise all-green run below 100%.
+        """
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        def fake_api(path: str, _token: str) -> dict[str, object]:
+            if "/jobs" in path:
+                return {
+                    "jobs": [
+                        {"conclusion": "success"},
+                        {"conclusion": "success"},
+                        {"conclusion": "skipped"},
+                    ]
+                }
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 9,
+                        "html_url": "https://github.com/owner/repo/actions/runs/9",
+                    }
+                ]
+            }
+
+        with patch.object(collect_metrics, "_github_api_json", side_effect=fake_api):
+            collector = MetricsCollector("test", {})
+            collector.collect_ci_status(Path("/nonexistent"))
+
+        status = collector.metrics["ci_status"]
+        assert status["total_jobs"] == 2
+        assert status["passing_jobs"] == 2
+        assert status["percentage"] == 100.0
+        assert status["status"] == "passing"
+
+    def test_api_all_jobs_skipped_degrades_to_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run where every job was skipped yields an unknown status."""
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+
+        def fake_api(path: str, _token: str) -> dict[str, object]:
+            if "/jobs" in path:
+                return {"jobs": [{"conclusion": "skipped"}] * 2}
+            return {"workflow_runs": [{"id": 9}]}
+
+        with patch.object(collect_metrics, "_github_api_json", side_effect=fake_api):
+            collector = MetricsCollector("test", {})
+            collector.collect_ci_status(Path("/nonexistent"))
+
+        status = collector.metrics["ci_status"]
+        assert status["total_jobs"] == 0
+        assert status["status"] == "unknown"
+
+    def test_token_with_embedded_whitespace_is_rejected(self) -> None:
+        """A token containing whitespace never reaches the HTTP layer.
+
+        ``http.client`` does not sanitize header values; rejecting
+        whitespace-bearing tokens closes the header-injection path.
+        """
+        with patch("http.client.HTTPSConnection") as mock_connection:
+            result = collect_metrics._github_api_json(
+                "/repos/owner/repo/actions/runs", "bad\ntoken: injected"
+            )
+
+        assert result is None
+        mock_connection.assert_not_called()
+
+    def test_token_surrounding_whitespace_is_stripped(self) -> None:
+        """Leading/trailing whitespace on the token is stripped, not fatal."""
+        response = Mock()
+        response.status = 200
+        response.read.return_value = b'{"ok": true}'
+        connection = Mock()
+        connection.getresponse.return_value = response
+
+        with patch("http.client.HTTPSConnection", return_value=connection):
+            result = collect_metrics._github_api_json("/path", "  good-token\n")
+
+        assert result == {"ok": True}
+        headers = connection.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer good-token"
 
     def test_api_failure_falls_back_to_static_count(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- Adds a **CI Status** card at index 1 of the quality metrics dashboard (after Pre-Commit Status, before Coverage), showing passing/total CI jobs as a percentage with green (100%) / yellow (85–99%) / red (<85%) thresholds and a gray N/A unknown state.
- Hybrid collection per the issue: `MetricsCollector.collect_ci_status()` queries the GitHub API for the latest main-branch workflow run when `GITHUB_TOKEN`/`GITHUB_REPOSITORY` are available (stdlib `http.client`, 10s timeout, no new dependencies), and falls back to statically counting jobs across `.github/workflows/*.yml|*.yaml` with status `unknown`. Collection never raises.
- DRY via canonical module-level helpers `count_ci_jobs` and `ci_status` in `generators/metrics.py` — `cli.py`, `collect_metrics.py`, and `regenerate_dashboard.py` call them directly (no delegation wrappers, per the #403 review). Applies to both the SGSG repo dashboard and generated projects.

## Test plan

- TDD Red→Green: 26+ new tests across `test_metrics.py` (count/status helpers, card at index 1, JS gray-guard ordering), `test_collect_metrics.py` (API path, static fallback, DRY canonical-import checks), `test_cli_mocked.py` (fresh metrics.json seeds `ci_status`), and `test_metrics_integration.py` (deployed HTML has the card). Nine-cards assertion updated to ten.
- `./scripts/check-all.sh`: all 7 checks pass — 1885 unit tests, coverage **94.62%** (≥90% gate), xenon grade A, bandit/pip-audit clean.
- `.venv/bin/pre-commit run --all-files`: all 31 hooks pass.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
