### PR TITLE
refactor(metrics): unify threshold computation convention (#206)

### DIFF
--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -8,6 +8,11 @@ This script aggregates metrics from:
 - bandit security scanning (security-report.json)
 - quality scripts via --metrics flag (script mode)
 
+Threshold convention (Issue #206): pass/fail status is ALWAYS recomputed in
+Python from the thresholds dict (see ``_default_thresholds``). Quality
+scripts emit raw numbers; any ``status`` field they include is ignored so
+threshold ownership lives in exactly one place.
+
 Output: metrics.json in the specified output directory
 """
 
@@ -219,8 +224,8 @@ class MetricsCollector:
         cov_data = json.loads(coverage_file.read_text())
         total_cov = cov_data["totals"]["percent_covered"]
         self.metrics["coverage"] = round(total_cov, 2)
-        self.metrics["coverage_status"] = (
-            "pass" if total_cov >= self.thresholds["coverage"] else "fail"
+        self.metrics["coverage_status"] = self._compute_status(
+            total_cov, self.thresholds["coverage"]
         )
 
         # Branch coverage
@@ -229,8 +234,8 @@ class MetricsCollector:
         if num_branches > 0:
             branch_cov = (covered_branches / num_branches) * 100
             self.metrics["branch_coverage"] = round(branch_cov, 2)
-            self.metrics["branch_coverage_status"] = (
-                "pass" if branch_cov >= self.thresholds["branch_coverage"] else "fail"
+            self.metrics["branch_coverage_status"] = self._compute_status(
+                branch_cov, self.thresholds["branch_coverage"]
             )
 
     def collect_complexity(self, complexity_file: Path) -> None:
@@ -266,8 +271,8 @@ class MetricsCollector:
             raise ValueError(msg)
 
         self.metrics["complexity_avg"] = round(comp, 2)
-        self.metrics["complexity_status"] = (
-            "pass" if comp <= self.thresholds["complexity"] else "fail"
+        self.metrics["complexity_status"] = self._compute_status(
+            comp, self.thresholds["complexity"], higher_is_better=False
         )
 
     def collect_docs_coverage(self, docs_file: Path) -> None:
@@ -304,8 +309,8 @@ class MetricsCollector:
             raise ValueError(msg)
 
         self.metrics["docs_coverage"] = round(docs, 2)
-        self.metrics["docs_status"] = (
-            "pass" if docs >= self.thresholds["docs_coverage"] else "fail"
+        self.metrics["docs_status"] = self._compute_status(
+            docs, self.thresholds["docs_coverage"]
         )
 
     def collect_security(self, security_file: Path) -> None:
@@ -326,8 +331,8 @@ class MetricsCollector:
         security_data = json.loads(security_file.read_text())
         issues = len(security_data["results"])
         self.metrics["security_issues"] = issues
-        self.metrics["security_status"] = (
-            "pass" if issues == self.thresholds["security_issues"] else "fail"
+        self.metrics["security_status"] = self._compute_status(
+            issues, self.thresholds["security_issues"], higher_is_better=False
         )
 
     def collect_precommit_status(self, config_path: Path) -> None:
@@ -378,8 +383,8 @@ class MetricsCollector:
             score: Mutation score (0-100)
         """
         self.metrics["mutation_score"] = score
-        self.metrics["mutation_status"] = (
-            "pass" if score >= self.thresholds["mutation_score"] else "fail"
+        self.metrics["mutation_status"] = self._compute_status(
+            score, self.thresholds["mutation_score"]
         )
 
     def _set_mutation_unknown(self) -> None:
@@ -458,8 +463,8 @@ class MetricsCollector:
         if total > 0:
             score = round((killed / total) * 100, 1)
             self.metrics["mutation_score"] = score
-            self.metrics["mutation_status"] = (
-                "pass" if score >= self.thresholds["mutation_score"] else "fail"
+            self.metrics["mutation_status"] = self._compute_status(
+                score, self.thresholds["mutation_score"]
             )
         else:
             self._set_mutation_unknown()
@@ -501,52 +506,98 @@ class MetricsCollector:
     def collect_lint_metrics(self, scripts_dir: Path) -> None:
         """Collect lint metrics via lint.sh --metrics.
 
+        Status is recomputed from the ``lint_violations`` threshold; any
+        ``status`` field emitted by the script is ignored (Issue #206).
+
         Args:
             scripts_dir: Directory containing quality scripts
         """
         data = self.collect_from_script("lint.sh", scripts_dir)
-        if data is not None:
-            self.metrics["lint_violations"] = data.get("violations", 0)
-            self.metrics["lint_status"] = data.get("status", "unknown")
-        else:
-            self.metrics["lint_violations"] = None
-            self.metrics["lint_status"] = "unknown"
+        violations = data.get("violations") if data is not None else None
+        self.metrics["lint_violations"] = violations
+        self.metrics["lint_status"] = self._compute_status(
+            violations, self.thresholds["lint_violations"], higher_is_better=False
+        )
 
     def collect_typecheck_metrics(self, scripts_dir: Path) -> None:
         """Collect type checking metrics via typecheck.sh --metrics.
+
+        Status is recomputed from the ``type_errors`` threshold; any
+        ``status`` field emitted by the script is ignored (Issue #206).
 
         Args:
             scripts_dir: Directory containing quality scripts
         """
         data = self.collect_from_script("typecheck.sh", scripts_dir)
-        if data is not None:
-            self.metrics["type_errors"] = data.get("errors", 0)
-            self.metrics["typecheck_status"] = data.get("status", "unknown")
-        else:
-            self.metrics["type_errors"] = None
-            self.metrics["typecheck_status"] = "unknown"
+        errors = data.get("errors") if data is not None else None
+        self.metrics["type_errors"] = errors
+        self.metrics["typecheck_status"] = self._compute_status(
+            errors, self.thresholds["type_errors"], higher_is_better=False
+        )
+
+    def collect_security_metrics(self, scripts_dir: Path) -> None:
+        """Collect security metrics via security.sh --metrics.
+
+        Status is recomputed from the ``security_issues`` threshold; any
+        ``status`` field emitted by the script is ignored (Issue #206). A
+        null ``bandit_issues`` value (scan failed) yields ``unknown``.
+
+        Args:
+            scripts_dir: Directory containing quality scripts
+        """
+        data = self.collect_from_script("security.sh", scripts_dir)
+        issues = data.get("bandit_issues") if data is not None else None
+        self.metrics["security_issues"] = issues
+        self.metrics["security_status"] = self._compute_status(
+            issues, self.thresholds["security_issues"], higher_is_better=False
+        )
+
+    def collect_coverage_metrics(self, scripts_dir: Path) -> None:
+        """Collect coverage metrics via coverage.sh --metrics.
+
+        Status is recomputed from the ``coverage`` and ``branch_coverage``
+        thresholds; any ``status`` field emitted by the script is ignored
+        (Issue #206). Missing raw percentages yield ``unknown``.
+
+        Args:
+            scripts_dir: Directory containing quality scripts
+        """
+        data = self.collect_from_script("coverage.sh", scripts_dir)
+        cov_pct = data.get("coverage_pct") if data is not None else None
+        branch_pct = data.get("branch_coverage_pct") if data is not None else None
+        self.metrics["coverage"] = cov_pct
+        self.metrics["coverage_status"] = self._compute_status(
+            cov_pct, self.thresholds["coverage"]
+        )
+        self.metrics["branch_coverage"] = branch_pct
+        self.metrics["branch_coverage_status"] = self._compute_status(
+            branch_pct, self.thresholds["branch_coverage"]
+        )
 
     def collect_test_metrics(self, scripts_dir: Path) -> None:
         """Collect test count metrics via test.sh --metrics.
+
+        Status is recomputed from raw counts; any ``status`` field emitted
+        by the script is ignored (Issue #206). Tests have no tunable
+        threshold: any failed test is a failure, and zero collected tests
+        (a broken suite) or missing counts yield ``unknown``.
 
         Args:
             scripts_dir: Directory containing quality scripts
         """
         data = self.collect_from_script("test.sh", scripts_dir)
-        if data is not None:
-            self.metrics["tests_total"] = data.get("tests_total", 0)
-            self.metrics["tests_passed"] = data.get("tests_passed", 0)
-            self.metrics["tests_failed"] = data.get("tests_failed", 0)
-            self.metrics["tests_skipped"] = data.get("tests_skipped", 0)
-            self.metrics["tests_status"] = data.get(
-                "status", "pass" if data.get("tests_failed", 0) == 0 else "fail"
-            )
-        else:
-            self.metrics["tests_total"] = None
-            self.metrics["tests_passed"] = None
-            self.metrics["tests_failed"] = None
-            self.metrics["tests_skipped"] = None
+        if data is None:
+            data = {}
+        total = data.get("tests_total")
+        failed = data.get("tests_failed")
+        self.metrics["tests_total"] = total
+        self.metrics["tests_passed"] = data.get("tests_passed")
+        self.metrics["tests_failed"] = failed
+        self.metrics["tests_skipped"] = data.get("tests_skipped")
+        if not total or failed is None:
             self.metrics["tests_status"] = "unknown"
+        else:
+            self.metrics["tests_status"] = "pass" if failed == 0 else "fail"
 
     def collect_complexity_from_script(self, scripts_dir: Path) -> None:
         """Collect complexity metrics via complexity.sh --metrics.
@@ -565,7 +616,7 @@ class MetricsCollector:
             )
             self.metrics["maintainability_avg"] = mi_avg
             self.metrics["maintainability_status"] = self._compute_status(
-                mi_avg, self.thresholds.get("maintainability", 20)
+                mi_avg, self.thresholds["maintainability"]
             )
         else:
             self.metrics["complexity_avg"] = None
@@ -592,7 +643,15 @@ class MetricsCollector:
 
 
 def _default_thresholds() -> dict[str, int | float]:
-    """Return default quality thresholds aligned with SGSG standards."""
+    """Return default quality thresholds aligned with SGSG standards.
+
+    This is the single source of truth for pass/fail thresholds
+    (Issue #206): every status in metrics.json is computed from these
+    values, never from a quality script's own hardcoded threshold.
+
+    Returns:
+        Mapping of metric name to its pass/fail threshold.
+    """
     return {
         "coverage": 90,
         "branch_coverage": 85,
@@ -603,50 +662,23 @@ def _default_thresholds() -> dict[str, int | float]:
         "maintainability": 20,
         "lint_violations": 0,
         "type_errors": 0,
-        "tests_total": 0,
     }
 
 
 def _collect_script_mode(
     collector: MetricsCollector,
     args: argparse.Namespace,
-    thresholds: dict[str, int | float],
 ) -> None:
     """Collect metrics using script mode (--metrics flag on each script).
 
     Args:
         collector: MetricsCollector instance
         args: Parsed CLI arguments
-        thresholds: Quality thresholds
     """
     scripts_dir = args.scripts_dir
 
     # Coverage via script
-    cov_data = collector.collect_from_script("coverage.sh", scripts_dir)
-    if cov_data is not None:
-        cov_pct = cov_data.get("coverage_pct")
-        if cov_pct is not None:
-            collector.metrics["coverage"] = cov_pct
-            collector.metrics["coverage_status"] = (
-                "pass" if cov_pct >= thresholds["coverage"] else "fail"
-            )
-        else:
-            collector.metrics["coverage"] = None
-            collector.metrics["coverage_status"] = "unknown"
-        branch_pct = cov_data.get("branch_coverage_pct")
-        if branch_pct is not None:
-            collector.metrics["branch_coverage"] = branch_pct
-            collector.metrics["branch_coverage_status"] = (
-                "pass" if branch_pct >= thresholds["branch_coverage"] else "fail"
-            )
-        else:
-            collector.metrics["branch_coverage"] = None
-            collector.metrics["branch_coverage_status"] = "unknown"
-    else:
-        collector.metrics["coverage"] = None
-        collector.metrics["coverage_status"] = "unknown"
-        collector.metrics["branch_coverage"] = None
-        collector.metrics["branch_coverage_status"] = "unknown"
+    collector.collect_coverage_metrics(scripts_dir)
 
     # Complexity + Maintainability via script
     collector.collect_complexity_from_script(scripts_dir)
@@ -660,13 +692,7 @@ def _collect_script_mode(
         collector.metrics["docs_status"] = "unknown"
 
     # Security via script
-    sec_data = collector.collect_from_script("security.sh", scripts_dir)
-    if sec_data is not None:
-        collector.metrics["security_issues"] = sec_data.get("bandit_issues", 0)
-        collector.metrics["security_status"] = sec_data.get("status", "unknown")
-    else:
-        collector.metrics["security_issues"] = None
-        collector.metrics["security_status"] = "unknown"
+    collector.collect_security_metrics(scripts_dir)
 
     # Mutation score: read SQLite cache directly (not mutation.sh --metrics)
     # because running mutmut is expensive; the cache already has results.
@@ -816,7 +842,7 @@ def main() -> int:
     collector = MetricsCollector(args.project_name, thresholds)
 
     if args.metrics_mode == "script":
-        _collect_script_mode(collector, args, thresholds)
+        _collect_script_mode(collector, args)
     else:
         _collect_file_mode(collector, args)
 

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -750,6 +750,271 @@ class TestNewMetricMethods:
         assert collector.metrics["maintainability_status"] == "unknown"
 
 
+class TestUnifiedThresholdConvention:
+    """Issue #206: Python owns status computation via the thresholds dict.
+
+    Shell scripts emit raw numbers (and a legacy ``status`` field); the
+    collector must ignore any script-provided status and recompute pass/fail
+    from ``self.thresholds`` so threshold changes propagate everywhere.
+    """
+
+    def test_lint_status_ignores_script_status_field(self) -> None:
+        """Lint status comes from the threshold, not the script's status."""
+        collector = MetricsCollector("test", {"lint_violations": 5})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"violations": 3, "status": "fail"},
+        ):
+            collector.collect_lint_metrics(Path("/scripts"))
+
+        assert collector.metrics["lint_violations"] == 3
+        assert collector.metrics["lint_status"] == "pass"
+
+    @pytest.mark.parametrize(
+        ("threshold", "expected"),
+        [(0, "fail"), (2, "fail"), (3, "pass"), (10, "pass")],
+    )
+    def test_lint_threshold_change_flips_status(
+        self, threshold: int, expected: str
+    ) -> None:
+        """Changing the lint threshold changes the computed status."""
+        collector = MetricsCollector("test", {"lint_violations": threshold})
+
+        with patch.object(
+            collector, "collect_from_script", return_value={"violations": 3}
+        ):
+            collector.collect_lint_metrics(Path("/scripts"))
+
+        assert collector.metrics["lint_status"] == expected
+
+    def test_lint_missing_raw_value_is_unknown(self) -> None:
+        """A payload without a raw count yields unknown, not a trusted pass."""
+        collector = MetricsCollector("test", {"lint_violations": 0})
+
+        with patch.object(
+            collector, "collect_from_script", return_value={"status": "pass"}
+        ):
+            collector.collect_lint_metrics(Path("/scripts"))
+
+        assert collector.metrics["lint_violations"] is None
+        assert collector.metrics["lint_status"] == "unknown"
+
+    def test_typecheck_status_ignores_script_status_field(self) -> None:
+        """Typecheck status comes from the threshold, not the script."""
+        collector = MetricsCollector("test", {"type_errors": 10})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"errors": 5, "status": "fail"},
+        ):
+            collector.collect_typecheck_metrics(Path("/scripts"))
+
+        assert collector.metrics["type_errors"] == 5
+        assert collector.metrics["typecheck_status"] == "pass"
+
+    @pytest.mark.parametrize(
+        ("threshold", "expected"),
+        [(0, "fail"), (5, "pass")],
+    )
+    def test_typecheck_threshold_change_flips_status(
+        self, threshold: int, expected: str
+    ) -> None:
+        """Changing the type-error threshold changes the computed status."""
+        collector = MetricsCollector("test", {"type_errors": threshold})
+
+        with patch.object(collector, "collect_from_script", return_value={"errors": 5}):
+            collector.collect_typecheck_metrics(Path("/scripts"))
+
+        assert collector.metrics["typecheck_status"] == expected
+
+    def test_typecheck_missing_raw_value_is_unknown(self) -> None:
+        """A payload without a raw count yields unknown, not a trusted pass."""
+        collector = MetricsCollector("test", {"type_errors": 0})
+
+        with patch.object(
+            collector, "collect_from_script", return_value={"status": "pass"}
+        ):
+            collector.collect_typecheck_metrics(Path("/scripts"))
+
+        assert collector.metrics["type_errors"] is None
+        assert collector.metrics["typecheck_status"] == "unknown"
+
+    def test_security_metrics_ignores_script_status_field(self) -> None:
+        """Security status comes from the threshold, not the script."""
+        collector = MetricsCollector("test", {"security_issues": 5})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"bandit_issues": 3, "status": "fail"},
+        ):
+            collector.collect_security_metrics(Path("/scripts"))
+
+        assert collector.metrics["security_issues"] == 3
+        assert collector.metrics["security_status"] == "pass"
+
+    @pytest.mark.parametrize(
+        ("threshold", "expected"),
+        [(0, "fail"), (2, "pass")],
+    )
+    def test_security_threshold_change_flips_status(
+        self, threshold: int, expected: str
+    ) -> None:
+        """Changing the security threshold changes the computed status."""
+        collector = MetricsCollector("test", {"security_issues": threshold})
+
+        with patch.object(
+            collector, "collect_from_script", return_value={"bandit_issues": 2}
+        ):
+            collector.collect_security_metrics(Path("/scripts"))
+
+        assert collector.metrics["security_status"] == expected
+
+    def test_security_metrics_null_issues_is_unknown(self) -> None:
+        """A null bandit_issues payload (scan failed) yields unknown."""
+        collector = MetricsCollector("test", {"security_issues": 0})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"bandit_issues": None, "status": "unknown"},
+        ):
+            collector.collect_security_metrics(Path("/scripts"))
+
+        assert collector.metrics["security_issues"] is None
+        assert collector.metrics["security_status"] == "unknown"
+
+    def test_security_metrics_script_failure_is_unknown(self) -> None:
+        """A failed security script run yields unknown status."""
+        collector = MetricsCollector("test", {"security_issues": 0})
+
+        with patch.object(collector, "collect_from_script", return_value=None):
+            collector.collect_security_metrics(Path("/scripts"))
+
+        assert collector.metrics["security_issues"] is None
+        assert collector.metrics["security_status"] == "unknown"
+
+    def test_file_mode_security_threshold_propagates(self) -> None:
+        """File-mode security uses <= threshold, so raising it passes."""
+        with TemporaryDirectory() as tmpdir:
+            sec_file = Path(tmpdir) / "security.json"
+            sec_file.write_text(
+                json.dumps({"results": [{"issue": "a"}, {"issue": "b"}]})
+            )
+
+            collector = MetricsCollector("test", {"security_issues": 5})
+            collector.collect_security(sec_file)
+
+            assert collector.metrics["security_issues"] == 2
+            assert collector.metrics["security_status"] == "pass"
+
+    def test_tests_status_ignores_script_status_field(self) -> None:
+        """Test status is recomputed from raw counts, not trusted."""
+        collector = MetricsCollector("test", {})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={
+                "tests_total": 100,
+                "tests_passed": 97,
+                "tests_failed": 3,
+                "tests_skipped": 0,
+                "status": "pass",
+            },
+        ):
+            collector.collect_test_metrics(Path("/scripts"))
+
+        assert collector.metrics["tests_status"] == "fail"
+
+    def test_tests_zero_collected_is_unknown(self) -> None:
+        """Zero collected tests (broken suite) yields unknown, not pass."""
+        collector = MetricsCollector("test", {})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={
+                "tests_total": 0,
+                "tests_passed": 0,
+                "tests_failed": 0,
+                "tests_skipped": 0,
+            },
+        ):
+            collector.collect_test_metrics(Path("/scripts"))
+
+        assert collector.metrics["tests_status"] == "unknown"
+
+    def test_tests_missing_raw_counts_is_unknown(self) -> None:
+        """A payload without raw counts yields unknown status."""
+        collector = MetricsCollector("test", {})
+
+        with patch.object(
+            collector, "collect_from_script", return_value={"status": "pass"}
+        ):
+            collector.collect_test_metrics(Path("/scripts"))
+
+        assert collector.metrics["tests_total"] is None
+        assert collector.metrics["tests_status"] == "unknown"
+
+    def test_coverage_metrics_threshold_propagates(self) -> None:
+        """Script-mode coverage status follows the thresholds dict."""
+        collector = MetricsCollector("test", {"coverage": 80, "branch_coverage": 95})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"coverage_pct": 85.0, "branch_coverage_pct": 90.0},
+        ):
+            collector.collect_coverage_metrics(Path("/scripts"))
+
+        assert collector.metrics["coverage"] == 85.0
+        assert collector.metrics["coverage_status"] == "pass"
+        assert collector.metrics["branch_coverage"] == 90.0
+        assert collector.metrics["branch_coverage_status"] == "fail"
+
+    def test_coverage_metrics_null_values_are_unknown(self) -> None:
+        """Missing coverage numbers yield unknown statuses."""
+        collector = MetricsCollector("test", {"coverage": 90, "branch_coverage": 85})
+
+        with patch.object(collector, "collect_from_script", return_value={}):
+            collector.collect_coverage_metrics(Path("/scripts"))
+
+        assert collector.metrics["coverage"] is None
+        assert collector.metrics["coverage_status"] == "unknown"
+        assert collector.metrics["branch_coverage"] is None
+        assert collector.metrics["branch_coverage_status"] == "unknown"
+
+    def test_coverage_metrics_script_failure_is_unknown(self) -> None:
+        """A failed coverage script run yields unknown statuses."""
+        collector = MetricsCollector("test", {"coverage": 90, "branch_coverage": 85})
+
+        with patch.object(collector, "collect_from_script", return_value=None):
+            collector.collect_coverage_metrics(Path("/scripts"))
+
+        assert collector.metrics["coverage"] is None
+        assert collector.metrics["coverage_status"] == "unknown"
+
+    def test_default_thresholds_contains_only_active_keys(self) -> None:
+        """Every default threshold key drives at least one status."""
+        thresholds = collect_metrics._default_thresholds()
+
+        assert set(thresholds) == {
+            "coverage",
+            "branch_coverage",
+            "mutation_score",
+            "complexity",
+            "docs_coverage",
+            "security_issues",
+            "maintainability",
+            "lint_violations",
+            "type_errors",
+        }
+
+
 class TestCollectPrecommitStatus:
     """Tests for pre-commit status collection (Issue #154)."""
 


### PR DESCRIPTION
## Summary

- Adopts the issue's preferred **Option 1**: Python recomputes every metric status; shell scripts' `--metrics` JSON `status` fields are now ignored. Thresholds live in exactly one place — `_default_thresholds()` in `scripts/collect_metrics.py` — so changing a threshold there now actually propagates to security/lint/typecheck statuses (previously dead config).
- All collectors (file-mode coverage/branch/complexity/docs/security/mutation and script-mode lint/typecheck/security/coverage/tests) route through a single `MetricsCollector._compute_status()`. Missing/null raw values degrade to `unknown` instead of a fake `pass`; file-mode security pass condition fixed from `issues == threshold` to `issues <= threshold`; dead `tests_total` threshold key removed.
- No shell script output changes — smallest blast radius; scripts keep emitting raw numbers plus their legacy `status` field, which the collector simply no longer trusts.

## Known follow-up (out of scope)

The dashboard JS template in `generators/metrics.py` (~lines 1147–1215) hardcodes `=== 0` for security/lint/typecheck badge colors instead of reading `data.thresholds` as the coverage/complexity badges do, so a non-zero threshold passes in Python but renders red in the dashboard. Deliberately not addressed here to keep this PR scoped to the collection-side convention; needs its own issue.

## Test plan

- TDD Red→Green: new `TestUnifiedThresholdConvention` class (21 tests) proves script `status` fields are ignored, threshold changes flip computed status for lint/typecheck/security/coverage (parametrized), null/missing raw values degrade to `unknown`, and `_default_thresholds()` contains only active keys.
- `./scripts/check-all.sh`: all 7 checks pass — 1912 unit tests, coverage **94.62%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
