### PR TITLE
feat(dashboard): re-add mutation score and doc coverage tiles (#217)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,14 +35,18 @@ jobs:
           # Enables the CI Status card's GitHub API path (Issue #159);
           # without it, collection degrades to a static job count.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Script mode sources every metric from scripts/*.sh (Issue #217):
+        # - Documentation Coverage runs metrics-docs.sh (ruff D rules)
+        # - Mutation Score reads .mutmut-cache; absent in CI (mutmut is a
+        #   periodic gate), so it degrades to null and the dashboard
+        #   renders a gray N/A tile instead of failing.
         run: |
           . .venv/bin/activate
           python scripts/collect_metrics.py \
             --project-name start-green-stay-green \
             --output docs/metrics.json \
             --metrics-mode script \
-            --scripts-dir scripts/ \
-            --docs-file docs-report.txt
+            --scripts-dir scripts/
 
       - name: Regenerate dashboard.html from template
         run: |

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -148,6 +148,17 @@
             </div>
 
             <div class="metric-card">
+                <div class="metric-name">Mutation Score</div>
+                <div class="metric-value" id="mutation-value">--</div>
+                <div class="metric-threshold">
+                    Threshold: ≥80%
+                </div>
+                <div class="metric-status status-pass" id="mutation-status">
+                    PASSING
+                </div>
+            </div>
+
+            <div class="metric-card">
                 <div class="metric-name">Cyclomatic Complexity</div>
                 <div class="metric-value" id="complexity-value">--</div>
                 <div class="metric-threshold">
@@ -156,6 +167,15 @@
                 <div class="metric-status status-pass" id="complexity-status">
                     PASSING
                 </div>
+            </div>
+
+            <div class="metric-card">
+                <div class="metric-name">Documentation Coverage</div>
+                <div class="metric-value" id="docs-value">--</div>
+                <div class="metric-threshold">
+                    Threshold: ≥95%
+                </div>
+                <div class="metric-status status-pass" id="docs-status">PASSING</div>
             </div>
 
             <div class="metric-card">
@@ -269,6 +289,18 @@
                 }
             }
 
+            // Mutation Score (Issue #217): null (no .mutmut-cache in CI)
+            // renders the gray N/A treatment via updateStatus, never red.
+            if (metrics.mutation_score !== undefined) {
+                if (metrics.mutation_score === null) {
+                    document.getElementById('mutation-value').textContent = 'N/A';
+                    updateStatus('mutation', 'N/A', false);
+                } else {
+                    updateMetric('mutation', metrics.mutation_score, '%',
+                        metrics.mutation_score >= thresholds.mutation_score);
+                }
+            }
+
             // Complexity
             if (metrics.complexity_avg !== undefined) {
                 if (metrics.complexity_avg === null) {
@@ -277,6 +309,18 @@
                 } else {
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
+                }
+            }
+
+            // Documentation Coverage (Issue #217): sourced from
+            // metrics-docs.sh (ruff D rules); null renders gray N/A.
+            if (metrics.docs_coverage !== undefined) {
+                if (metrics.docs_coverage === null) {
+                    document.getElementById('docs-value').textContent = 'N/A';
+                    updateStatus('docs', 'N/A', false);
+                } else {
+                    updateMetric('docs', metrics.docs_coverage, '%',
+                        metrics.docs_coverage >= thresholds.docs_coverage);
                 }
             }
 

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -552,6 +552,33 @@ class MetricsCollector:
             issues, self.thresholds["security_issues"], higher_is_better=False
         )
 
+    def collect_docs_metrics(self, scripts_dir: Path, docs_file: Path) -> None:
+        """Collect documentation coverage via metrics-docs.sh --metrics (#217).
+
+        Runs the canonical docstring-coverage script (ruff D rules over an
+        AST item count) and recomputes status from the ``docs_coverage``
+        threshold (Issue #206). When the script yields no usable payload,
+        falls back to parsing a pre-generated report file; if that also
+        fails, the metric degrades to ``None``/``unknown``.
+
+        Args:
+            scripts_dir: Directory containing quality scripts
+            docs_file: Fallback docs report file (e.g., docs-report.txt)
+        """
+        data = self.collect_from_script("metrics-docs.sh", scripts_dir)
+        pct = data.get("docs_coverage_pct") if data is not None else None
+        if pct is None and docs_file.exists():
+            try:
+                self.collect_docs_coverage(docs_file)
+            except ValueError:
+                pct = None
+            else:
+                return
+        self.metrics["docs_coverage"] = pct
+        self.metrics["docs_status"] = self._compute_status(
+            pct, self.thresholds["docs_coverage"]
+        )
+
     def collect_coverage_metrics(self, scripts_dir: Path) -> None:
         """Collect coverage metrics via coverage.sh --metrics.
 
@@ -683,13 +710,8 @@ def _collect_script_mode(
     # Complexity + Maintainability via script
     collector.collect_complexity_from_script(scripts_dir)
 
-    # Docs coverage via file
-    try:
-        collector.collect_docs_coverage(args.docs_file)
-    except (FileNotFoundError, ValueError) as e:
-        print(f"Warning: Could not parse docs coverage ({type(e).__name__}): {e}")
-        collector.metrics["docs_coverage"] = None
-        collector.metrics["docs_status"] = "unknown"
+    # Docs coverage via script (Issue #217), report-file fallback
+    collector.collect_docs_metrics(scripts_dir, args.docs_file)
 
     # Security via script
     collector.collect_security_metrics(scripts_dir)

--- a/scripts/metrics-docs.sh
+++ b/scripts/metrics-docs.sh
@@ -1,19 +1,56 @@
 #!/usr/bin/env bash
 # scripts/metrics-docs.sh - Output documentation coverage metrics for dashboard
-# Usage: ./scripts/metrics-docs.sh
+# Usage: ./scripts/metrics-docs.sh [--metrics] [--help]
 #
 # Computes docstring coverage percentage using ruff D rules and AST item count.
-# Outputs in format expected by scripts/collect_metrics.py: "RESULT: XX.X%"
+# Default output format (consumed as docs-report.txt): "RESULT: XX.X%"
+# With --metrics, emits machine-readable JSON for collect_metrics.py:
+#   {"docs_coverage_pct": XX.X}
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+METRICS_OUTPUT=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --metrics)
+            METRICS_OUTPUT=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Compute docstring coverage from ruff D rules and an AST item count.
+
+OPTIONS:
+    --metrics   Output machine-readable JSON metrics to stdout
+    --help      Display this help message
+
+EXIT CODES:
+    0           Coverage computed successfully
+    2           Error computing coverage
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
 cd "$PROJECT_ROOT"
 
-# Count ruff D violations (missing/malformed docstrings)
-violations=$(ruff check --select D start_green_stay_green/ --output-format json 2>/dev/null | python3 -c "import sys, json; print(len(json.load(sys.stdin)))")
+# Count ruff D violations (missing/malformed docstrings).
+# ruff exits non-zero when violations exist; that is expected input here,
+# not an error, so capture output without tripping set -e/pipefail.
+ruff_json=$(ruff check --select D start_green_stay_green/ --output-format json 2>/dev/null) || true
+violations=$(printf '%s' "$ruff_json" | python3 -c "import sys, json; print(len(json.load(sys.stdin)))")
 
 # Count total docstring-eligible items (modules, classes, public functions/methods)
 total=$(python3 -c "
@@ -37,4 +74,8 @@ else
     coverage=$(python3 -c "print(round(($total - $violations) / $total * 100, 1))")
 fi
 
-echo "RESULT: ${coverage}%"
+if $METRICS_OUTPUT; then
+    echo "{\"docs_coverage_pct\": ${coverage}}"
+else
+    echo "RESULT: ${coverage}%"
+fi

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -1011,6 +1011,17 @@ class MetricsGenerator(BaseGenerator):
             </div>
 
             <div class="metric-card">
+                <div class="metric-name">Mutation Score</div>
+                <div class="metric-value" id="mutation-value">--</div>
+                <div class="metric-threshold">
+                    Threshold: ≥{self.config.mutation_threshold}%
+                </div>
+                <div class="metric-status status-pass" id="mutation-status">
+                    PASSING
+                </div>
+            </div>
+
+            <div class="metric-card">
                 <div class="metric-name">Cyclomatic Complexity</div>
                 <div class="metric-value" id="complexity-value">--</div>
                 <div class="metric-threshold">
@@ -1019,6 +1030,15 @@ class MetricsGenerator(BaseGenerator):
                 <div class="metric-status status-pass" id="complexity-status">
                     PASSING
                 </div>
+            </div>
+
+            <div class="metric-card">
+                <div class="metric-name">Documentation Coverage</div>
+                <div class="metric-value" id="docs-value">--</div>
+                <div class="metric-threshold">
+                    Threshold: ≥{self.config.doc_coverage_threshold}%
+                </div>
+                <div class="metric-status status-pass" id="docs-status">PASSING</div>
             </div>
 
             <div class="metric-card">
@@ -1132,6 +1152,18 @@ class MetricsGenerator(BaseGenerator):
                 }}
             }}
 
+            // Mutation Score (Issue #217): null (no .mutmut-cache in CI)
+            // renders the gray N/A treatment via updateStatus, never red.
+            if (metrics.mutation_score !== undefined) {{
+                if (metrics.mutation_score === null) {{
+                    document.getElementById('mutation-value').textContent = 'N/A';
+                    updateStatus('mutation', 'N/A', false);
+                }} else {{
+                    updateMetric('mutation', metrics.mutation_score, '%',
+                        metrics.mutation_score >= thresholds.mutation_score);
+                }}
+            }}
+
             // Complexity
             if (metrics.complexity_avg !== undefined) {{
                 if (metrics.complexity_avg === null) {{
@@ -1140,6 +1172,18 @@ class MetricsGenerator(BaseGenerator):
                 }} else {{
                     updateMetric('complexity', metrics.complexity_avg, '',
                         metrics.complexity_avg <= thresholds.complexity);
+                }}
+            }}
+
+            // Documentation Coverage (Issue #217): sourced from
+            // metrics-docs.sh (ruff D rules); null renders gray N/A.
+            if (metrics.docs_coverage !== undefined) {{
+                if (metrics.docs_coverage === null) {{
+                    document.getElementById('docs-value').textContent = 'N/A';
+                    updateStatus('docs', 'N/A', false);
+                }} else {{
+                    updateMetric('docs', metrics.docs_coverage, '%',
+                        metrics.docs_coverage >= thresholds.docs_coverage);
                 }}
             }}
 

--- a/tests/integration/generators/test_metrics_integration.py
+++ b/tests/integration/generators/test_metrics_integration.py
@@ -134,10 +134,12 @@ class TestMetricsGeneratorIntegration:
             )
 
             # Check dashboard includes thresholds
-            # (mutation ≥75% and docs ≥92% removed — tiles deferred)
+            # (mutation ≥75% and docs ≥92% re-added — Issue #217)
             dashboard_content = artifacts["dashboard"].read_text()
             assert "≥85%" in dashboard_content
             assert "≥80%" in dashboard_content
+            assert "≥75%" in dashboard_content
+            assert "≥92%" in dashboard_content
 
     def test_ci_integration_config_completeness(self) -> None:
         """Test that CI integration config is complete and usable."""
@@ -517,7 +519,9 @@ class TestDashboardSync:
     EXPECTED_VALUE_IDS: ClassVar[list[str]] = [
         "coverage-value",
         "branch-value",
+        "mutation-value",
         "complexity-value",
+        "docs-value",
         "security-value",
         "maintainability-value",
         "lint-value",
@@ -528,7 +532,9 @@ class TestDashboardSync:
     EXPECTED_STATUS_IDS: ClassVar[list[str]] = [
         "coverage-status",
         "branch-status",
+        "mutation-status",
         "complexity-status",
+        "docs-status",
         "security-status",
         "maintainability-status",
         "lint-status",
@@ -608,7 +614,9 @@ class TestDashboardSync:
         expected_js_keys = [
             "metrics.coverage",
             "metrics.branch_coverage",
+            "metrics.mutation_score",
             "metrics.complexity_avg",
+            "metrics.docs_coverage",
             "metrics.security_issues",
             "metrics.maintainability_avg",
             "metrics.lint_violations",
@@ -641,10 +649,10 @@ class TestDashboardSync:
         )
 
     def test_deployed_no_data_cards_render_gray_not_red(self) -> None:
-        """Fresh dashboards must show the eight existing cards' no-data state gray.
+        """Fresh dashboards must show the simple cards' no-data state gray.
 
         Regression guard for Issue #154: a brand-new project has no
-        ``metrics.json`` values, so the eight pre-existing cards fall into
+        ``metrics.json`` values, so the simple value cards fall into
         their ``null`` branch and call ``updateStatus(name, 'N/A', false)``.
         ``updateStatus`` must map the ``'N/A'`` text to the gray
         ``status-unknown`` state (not red ``status-fail``) so a fresh project

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -942,6 +942,7 @@ class TestDashboardGeneration:
         assert dashboard is not None
         assert "≥85%" in dashboard  # coverage
         assert "≥80%" in dashboard  # branch coverage
+        assert "≥75%" in dashboard  # mutation (re-added in #217)
 
     def test_dashboard_has_metric_cards(self) -> None:
         """Test that dashboard has metric card structure."""
@@ -2008,14 +2009,16 @@ class TestDashboardNewCards:
         assert dashboard is not None
         return dashboard
 
-    def test_all_eight_card_ids_exist(self) -> None:
-        """Test that all 8 metric card IDs exist in generated HTML."""
+    def test_all_ten_card_ids_exist(self) -> None:
+        """Test that all 10 metric card IDs exist in generated HTML."""
         dashboard = self._get_dashboard()
 
         expected_ids = [
             "coverage-value",
             "branch-value",
+            "mutation-value",
             "complexity-value",
+            "docs-value",
             "security-value",
             "maintainability-value",
             "lint-value",
@@ -2025,14 +2028,16 @@ class TestDashboardNewCards:
         for card_id in expected_ids:
             assert card_id in dashboard, f"Missing card ID: {card_id}"
 
-    def test_all_eight_status_ids_exist(self) -> None:
-        """Test that all 8 status element IDs exist in generated HTML."""
+    def test_all_ten_status_ids_exist(self) -> None:
+        """Test that all 10 status element IDs exist in generated HTML."""
         dashboard = self._get_dashboard()
 
         expected_ids = [
             "coverage-status",
             "branch-status",
+            "mutation-status",
             "complexity-status",
+            "docs-status",
             "security-status",
             "maintainability-status",
             "lint-status",
@@ -2077,18 +2082,33 @@ class TestDashboardNewCards:
         assert "Test Count" in dashboard
         assert "tests-value" in dashboard
 
-    def test_dashboard_has_ten_metric_cards(self) -> None:
-        """Test dashboard has exactly 10 metric cards.
+    def test_mutation_card_exists(self) -> None:
+        """Test mutation score card exists in dashboard (Issue #217)."""
+        dashboard = self._get_dashboard()
+
+        assert "Mutation Score" in dashboard
+        assert "mutation-value" in dashboard
+
+    def test_docs_card_exists(self) -> None:
+        """Test documentation coverage card exists in dashboard (Issue #217)."""
+        dashboard = self._get_dashboard()
+
+        assert "Documentation Coverage" in dashboard
+        assert "docs-value" in dashboard
+
+    def test_dashboard_has_twelve_metric_cards(self) -> None:
+        """Test dashboard has exactly 12 metric cards.
 
         Eight original quality cards plus the Pre-Commit Status card added
-        at index 0 (Issue #154) and the CI Status card added at index 1
-        (Issue #159).
+        at index 0 (Issue #154), the CI Status card added at index 1
+        (Issue #159), and the re-added Mutation Score and Documentation
+        Coverage cards (Issue #217).
         """
         dashboard = self._get_dashboard()
 
         # Count metric-card div occurrences
         card_count = dashboard.count('class="metric-card"')
-        assert card_count == 10
+        assert card_count == 12
 
 
 class TestDashboardJavaScript:
@@ -2144,6 +2164,26 @@ class TestDashboardJavaScript:
         """Test JavaScript has null check for branch coverage (#212)."""
         dashboard = self._get_dashboard()
         assert "metrics.branch_coverage === null" in dashboard
+
+    def test_js_handles_null_mutation_score(self) -> None:
+        """Test JavaScript has null check for mutation score (#217).
+
+        The null branch must pass 'N/A' (not 'NO DATA') so updateStatus
+        maps it to the gray status-unknown state instead of red.
+        """
+        dashboard = self._get_dashboard()
+        assert "metrics.mutation_score === null" in dashboard
+        assert "updateStatus('mutation', 'N/A', false)" in dashboard
+
+    def test_js_handles_null_docs_coverage(self) -> None:
+        """Test JavaScript has null check for docs coverage (#217).
+
+        The null branch must pass 'N/A' (not 'NO DATA') so updateStatus
+        maps it to the gray status-unknown state instead of red.
+        """
+        dashboard = self._get_dashboard()
+        assert "metrics.docs_coverage === null" in dashboard
+        assert "updateStatus('docs', 'N/A', false)" in dashboard
 
     def test_js_handles_null_security_issues(self) -> None:
         """Test JavaScript has null check for security issues (#212)."""

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -750,6 +750,103 @@ class TestNewMetricMethods:
         assert collector.metrics["maintainability_status"] == "unknown"
 
 
+class TestCollectDocsMetrics:
+    """Issue #217: docs coverage in script mode via metrics-docs.sh."""
+
+    def test_collect_docs_metrics_success(self) -> None:
+        """Docs coverage from the script payload computes a pass status."""
+        collector = MetricsCollector("test", {"docs_coverage": 95})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"docs_coverage_pct": 96.5},
+        ) as mock_script:
+            collector.collect_docs_metrics(Path("/scripts"), Path("/missing.txt"))
+
+        mock_script.assert_called_once_with("metrics-docs.sh", Path("/scripts"))
+        assert collector.metrics["docs_coverage"] == 96.5
+        assert collector.metrics["docs_status"] == "pass"
+
+    def test_collect_docs_metrics_below_threshold(self) -> None:
+        """Docs coverage below the threshold computes a fail status."""
+        collector = MetricsCollector("test", {"docs_coverage": 95})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"docs_coverage_pct": 92.0},
+        ):
+            collector.collect_docs_metrics(Path("/scripts"), Path("/missing.txt"))
+
+        assert collector.metrics["docs_coverage"] == 92.0
+        assert collector.metrics["docs_status"] == "fail"
+
+    def test_collect_docs_metrics_script_failure_no_file(self) -> None:
+        """Script failure with no report file degrades to unknown."""
+        collector = MetricsCollector("test", {"docs_coverage": 95})
+
+        with patch.object(collector, "collect_from_script", return_value=None):
+            collector.collect_docs_metrics(Path("/scripts"), Path("/missing.txt"))
+
+        assert collector.metrics["docs_coverage"] is None
+        assert collector.metrics["docs_status"] == "unknown"
+
+    def test_collect_docs_metrics_missing_pct_key_is_unknown(self) -> None:
+        """A payload without docs_coverage_pct yields unknown, not pass."""
+        collector = MetricsCollector("test", {"docs_coverage": 95})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"status": "pass"},
+        ):
+            collector.collect_docs_metrics(Path("/scripts"), Path("/missing.txt"))
+
+        assert collector.metrics["docs_coverage"] is None
+        assert collector.metrics["docs_status"] == "unknown"
+
+    def test_collect_docs_metrics_falls_back_to_report_file(self) -> None:
+        """Script failure falls back to a pre-generated docs report file."""
+        with TemporaryDirectory() as tmpdir:
+            docs_file = Path(tmpdir) / "docs-report.txt"
+            docs_file.write_text("RESULT: 97.5%")
+            collector = MetricsCollector("test", {"docs_coverage": 95})
+
+            with patch.object(collector, "collect_from_script", return_value=None):
+                collector.collect_docs_metrics(Path("/scripts"), docs_file)
+
+            assert collector.metrics["docs_coverage"] == 97.5
+            assert collector.metrics["docs_status"] == "pass"
+
+    def test_collect_docs_metrics_fallback_unparseable_file_is_unknown(self) -> None:
+        """Script failure plus an unparseable report file yields unknown."""
+        with TemporaryDirectory() as tmpdir:
+            docs_file = Path(tmpdir) / "docs-report.txt"
+            docs_file.write_text("no coverage data here")
+            collector = MetricsCollector("test", {"docs_coverage": 95})
+
+            with patch.object(collector, "collect_from_script", return_value=None):
+                collector.collect_docs_metrics(Path("/scripts"), docs_file)
+
+            assert collector.metrics["docs_coverage"] is None
+            assert collector.metrics["docs_status"] == "unknown"
+
+    def test_collect_docs_metrics_threshold_boundary(self) -> None:
+        """Coverage exactly at the threshold passes (>= comparison)."""
+        collector = MetricsCollector("test", {"docs_coverage": 95})
+
+        with patch.object(
+            collector,
+            "collect_from_script",
+            return_value={"docs_coverage_pct": 95.0},
+        ):
+            collector.collect_docs_metrics(Path("/scripts"), Path("/missing.txt"))
+
+        assert collector.metrics["docs_coverage"] == 95.0
+        assert collector.metrics["docs_status"] == "pass"
+
+
 class TestUnifiedThresholdConvention:
     """Issue #206: Python owns status computation via the thresholds dict.
 
@@ -1523,6 +1620,10 @@ class TestMainScriptMode:
             # Security failure should report "unknown", not "pass"
             assert data["metrics"]["security_status"] == "unknown"
             assert data["metrics"]["security_issues"] is None
+            # Docs coverage falls back to the report file when the
+            # metrics-docs.sh script yields no data (Issue #217)
+            assert data["metrics"]["docs_coverage"] == 96.5
+            assert data["metrics"]["docs_status"] == "pass"
 
     def test_main_file_mode_backward_compat(self) -> None:
         """Test that file mode remains backward compatible."""


### PR DESCRIPTION
## Summary

- Re-adds the **Mutation Score** and **Documentation Coverage** dashboard tiles removed in PR #216, now with reliable data sourcing: doc coverage comes from `scripts/metrics-docs.sh --metrics` (ruff D rules — interrogate was removed from the project, so no `interrogate.sh` per the issue text), invoked directly in script mode; mutation score reads `.mutmut-cache` when a periodic local run has populated it and degrades to gray N/A in CI.
- Both tiles follow the #154/#159 unknown-status pattern (gray `status-unknown`, never red) and the #206 convention (status recomputed in Python from `_default_thresholds()`). The pre-#216 template's `'NO DATA'` text would render red under current JS, so null paths use `'N/A'`.
- Fixes the original root cause: the metrics workflow referenced a `docs-report.txt` that was never generated (stale arg dropped), and `metrics-docs.sh` had a latent pipefail bug where ruff's expected non-zero exit on violations killed the script.
- Dashboard card count is now **12** (the issue's "back to 10" predates the Pre-Commit #154 and CI Status #159 cards). `docs/dashboard.html` regenerated; sync tests green.

## Test plan

- TDD Red→Green: 7 new `TestCollectDocsMetrics` unit tests (pass/fail/boundary/unknown/file-fallback), generator tests for both cards and both JS null-guards asserting the gray-N/A path, card-count and dashboard-sync tests updated 10→12.
- `./scripts/check-all.sh`: all 7 checks pass — 1923 unit tests, coverage **94.62%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass (shellcheck included for the script changes).

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
