### PR TITLE
perf(ci): drop coverage HTML render and cold venv install in Coverage Report job (#256)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,13 +264,30 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
+      # Cache the whole virtualenv so ensure_venv() in scripts/common.sh
+      # activates a prebuilt .venv instead of creating a temporary venv
+      # and reinstalling every dependency from scratch on each run.
+      - name: Restore cached virtualenv
+        id: venv-cache
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt', 'pyproject.toml') }}
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          if [ "${{ steps.venv-cache.outputs.cache-hit }}" != "true" ]; then
+            python -m venv .venv
+            .venv/bin/pip install --upgrade pip
+            .venv/bin/pip install -e . -r requirements-dev.txt
+          fi
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
+      # No --html: the metrics below come from `coverage report` terminal
+      # output, so rendering every source file to HTML is wasted work in CI.
+      # The flag remains available for local use.
       - name: Generate coverage report
-        run: ./scripts/coverage.sh --html
+        run: ./scripts/coverage.sh
 
       - name: Extract coverage metrics
         id: coverage
@@ -324,13 +341,6 @@ jobs:
           echo "Badge files generated:"
           ls -la badges/
 
-      - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: htmlcov/
-          retention-days: 30
-
       - name: Upload badge artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -365,7 +375,7 @@ jobs:
             | Threshold | ${threshold}% |
             | Status | ${status} |
 
-            [View detailed HTML report](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
+            [View workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
 
             // Find existing coverage comment
             const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary

- Drops `--html` from the Coverage Report CI job's `coverage.sh` invocation — the job extracts its percentage from `coverage report` terminal output, so rendering every source file to HTML was pure waste. The now-empty `htmlcov/` artifact upload step is removed and the PR-comment link relabeled; `--html` remains fully functional for local use.
- Eliminates the cold dependency reinstall: the job now caches the whole `.venv` via `actions/cache@v5` keyed on OS + Python version + `hashFiles(requirements*.txt, pyproject.toml)`, installing only on a cache miss and prepending `.venv/bin` to `GITHUB_PATH`. A real `.venv` triggers the existing activate-fast-path in `ensure_venv()`, so `scripts/common.sh` is untouched and local flows plus every other job behave exactly as before.
- Single file changed: `.github/workflows/ci.yml`.

## Known follow-up (out of scope)

The quality and security jobs have the same cold-temp-venv waste; the `.venv` cache approach here can be lifted to them in a follow-up under epic #250.

## Test plan

- No Python tests assert real `ci.yml` content (existing tests use synthetic workflow fixtures), so coverage is via the YAML/shellcheck hooks per repo pattern; workflow verified parseable and the job's step list coherent.
- `./scripts/check-all.sh`: all 7 checks pass.
- `.venv/bin/pre-commit run --all-files`: all hooks pass (check-yaml, shellcheck included).

Closes #256
Refs #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
