### PR TITLE
refactor(tests): parametrize all-language setup instruction tests (#283)

### DIFF
--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -2,7 +2,13 @@
 
 from pathlib import Path
 
+import pytest
+
 from start_green_stay_green.cli import _get_setup_instructions
+
+# Languages exercised by the per-language common-tail tests; "java" covers
+# the unknown-language default path.
+ALL_LANGUAGES = ("python", "typescript", "go", "rust", "java")
 
 
 class TestGetSetupInstructions:
@@ -86,21 +92,17 @@ class TestGetSetupInstructions:
         assert "pre-commit install" in instructions
         assert "./scripts/check-all.sh" in instructions
 
-    def test_all_languages_end_with_check_all(self) -> None:
+    @pytest.mark.parametrize("lang", ALL_LANGUAGES)
+    def test_language_ends_with_check_all(self, lang: str) -> None:
         """Every language's instructions should end with check-all."""
-        for lang in ("python", "typescript", "go", "rust", "java"):
-            instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
-            assert (
-                instructions[-1] == "./scripts/check-all.sh"
-            ), f"{lang} should end with check-all"
+        instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
+        assert instructions[-1] == "./scripts/check-all.sh"
 
-    def test_all_languages_include_precommit(self) -> None:
+    @pytest.mark.parametrize("lang", ALL_LANGUAGES)
+    def test_language_includes_precommit(self, lang: str) -> None:
         """Every language's instructions should include pre-commit install."""
-        for lang in ("python", "typescript", "go", "rust", "java"):
-            instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
-            assert (
-                "pre-commit install" in instructions
-            ), f"{lang} should include pre-commit install"
+        instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
+        assert "pre-commit install" in instructions
 
     def test_returns_list_of_strings(self) -> None:
         """Instructions should be a list of strings."""


### PR DESCRIPTION
## Summary

- Converts the two loop-based tests in `tests/unit/test_cli_setup_instructions.py` (`test_all_languages_end_with_check_all`, `test_all_languages_include_precommit`) to `@pytest.mark.parametrize` over a shared `ALL_LANGUAGES` tuple, exactly as proposed in the issue.
- Failures now report the broken language in the test ID (e.g. `test_language_ends_with_check_all[rust]`) instead of hiding it in a custom assertion message. The file collects 32 tests (was 24): each loop became 5 explicit cases.

## Test plan

- `pytest tests/unit/test_cli_setup_instructions.py`: 32 passed.
- `./scripts/check-all.sh`: all 7 checks pass.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
