### PR TITLE
docs(polish): address Phase 6c review nits (#325)

### DIFF
--- a/start_green_stay_green/ai/batch_dispatch.py
+++ b/start_green_stay_green/ai/batch_dispatch.py
@@ -146,6 +146,10 @@ class BatchPersistenceContext:
     below the ``PLR0913`` threshold without splitting concerns. See
     issue #316.
 
+    Note: ``state`` is mutated (via ``clear_batch()``) on successful
+    reconciliation; ``frozen=True`` prevents reassignment of the field,
+    not mutation of the object it holds.
+
     Attributes:
         state: The :class:`EnhanceState` record. Cleared on
             successful reconciliation; left intact on

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -2838,12 +2838,9 @@ def _resume_subagent_batch_cli(
     _render_batch_resume_outcome(outcome)
 
 
-# Static-message statuses for :func:`_render_batch_resume_outcome`.
-# IN_PROGRESS and ENDED are deliberately absent — they need
-# ``outcome.poll`` / ``outcome.bundle`` data woven into the rendered
-# message, so they branch into ``_render_batch_in_progress`` /
-# ``_render_batch_ended`` instead. Adding them to this dict would
-# silently drop their dynamic data.
+# Message contents for the static-message branches of
+# :func:`_render_batch_resume_outcome`; IN_PROGRESS and ENDED have their
+# own ``case`` branches because their messages weave in dynamic data.
 _BATCH_OUTCOME_STATIC: dict[ResumeStatus, str] = {
     ResumeStatus.NO_BATCH: (
         "[yellow]No batch is in flight; nothing to resume.[/yellow]"

--- a/tests/unit/ai/test_batch_dispatch.py
+++ b/tests/unit/ai/test_batch_dispatch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import UTC
 from datetime import datetime
+from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -55,9 +56,11 @@ def _recent_submitted_at() -> str:
     the EXPIRED branch unintentionally. Re-anchoring on
     :func:`datetime.now` per-test makes the expiry guard test only
     when explicitly asserted (via ``patch.object`` of
-    ``is_potentially_expired`` itself).
+    ``is_potentially_expired`` itself). The one-hour future anchor
+    removes even the theoretical race where test wall time eats into
+    the SLA window.
     """
-    return datetime.now(UTC).isoformat()
+    return (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
 
 def _entry(agent_name: str, custom_id: str | None = None) -> SubagentBatchEntry:


### PR DESCRIPTION
## Summary

Rollup of the three polish items from the PR #324 round-1 review (issue #325), all comment/docstring-level with one test-helper tweak — no production behavior change:

- **Stale dict comment** — the `_BATCH_OUTCOME_STATIC` comment in `cli.py` described a pre-`match`-refactor "silent drop" risk that no longer exists; it now states what the dict is (content lookup for the static-message branches).
- **Mutable-state callout** — `BatchPersistenceContext`'s docstring now notes that `state` is mutated via `clear_batch()` on successful reconciliation and that `frozen=True` only prevents field reassignment.
- **Future-anchored test helper** — `_recent_submitted_at()` returns `now + 1h` so even a theoretical race between test wall time and the 24 h SLA window can't flap tests into the EXPIRED branch.

## Test plan

- `pytest tests/unit/ai/test_batch_dispatch.py`: 14 passed.
- `./scripts/check-all.sh`: all 7 checks pass.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
