### PR TITLE
feat(swift): wire quality tooling across precommit/scripts/metrics/architecture (#352)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1688
+        "line_number": 1703
       }
     ]
   },
-  "generated_at": "2026-06-10T09:49:20Z"
+  "generated_at": "2026-06-10T10:36:46Z"
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Start Green Stay Green is a meta-tool that scaffolds new software projects with 
 - **Enterprise-Grade Quality**: 90%+ code coverage, mutation testing, comprehensive linting
 - **AI Integration**: Pre-configured AI subagent profiles and code review workflows
 - **Multi-Language Support**: Python, TypeScript, Go, Rust, and more
-- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), and cargo-deny (Rust)
+- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), and SwiftLint custom rules (Swift)
 - **Complete CI/CD**: GitHub Actions workflows with quality gates
 - **Additive Init**: Safe to re-run in existing directories — preserves your files
 - **Developer Experience**: Rich console output, interactive prompts, dry-run mode
@@ -429,6 +429,7 @@ Project names must follow these rules:
 - **TypeScript**: jest, eslint, prettier, typescript
 - **Go**: go test, golangci-lint, gofmt
 - **Rust**: cargo test, clippy, rustfmt
+- **Swift**: swift test (≥90% coverage via llvm-cov), SwiftLint, swift-format, Periphery
 
 (More languages coming soon)
 

--- a/docs/GENERATOR_GUIDE.md
+++ b/docs/GENERATOR_GUIDE.md
@@ -83,7 +83,7 @@ output_path.write_text(yaml_content)
 
 **Configuration Options**:
 - `project_name`: Name of the project
-- `language`: python, typescript, go, or rust
+- `language`: python, typescript, go, rust, or swift
 - `language_config`: Language-specific settings (dict)
 
 **Output**: `.pre-commit-config.yaml` with hooks for:
@@ -138,7 +138,7 @@ scripts = generator.generate()
 - `complexity.sh` - Code complexity analysis
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust
+- `language`: python, typescript, go, rust, swift
 - `package_name`: Python package name (snake_case)
 
 ### CIGenerator (AI-powered)
@@ -372,6 +372,7 @@ generator.generate(language="python", project_name="my-app")
 - TypeScript: dependency-cruiser
 - Go: go-arch-lint
 - Rust: cargo-deny
+- Swift: SwiftLint custom rules
 
 ### GitHubActionsReviewGenerator (AI-powered)
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1207,18 +1207,18 @@ def _generate_architecture_step(
 
     Architecture configuration is fully deterministic (import-linter for
     Python, dependency-cruiser for TypeScript, go-arch-lint for Go,
-    cargo-deny for Rust). Runs regardless of API key availability; only
-    Python, TypeScript, Go, and Rust projects produce output. The previous
-    ``orchestrator`` argument was unused and has been removed from this
-    private helper.
+    cargo-deny for Rust, SwiftLint custom rules for Swift). Runs regardless
+    of API key availability; only Python, TypeScript, Go, Rust, and Swift
+    projects produce output. The previous ``orchestrator`` argument was
+    unused and has been removed from this private helper.
     """
-    if language not in {"python", "typescript", "go", "rust"}:
+    if language not in {"python", "typescript", "go", "rust", "swift"}:
         # The generator only supports these languages; surface a dim info
         # line so users understand why no architecture rules were generated
-        # for, e.g., a Swift project rather than seeing silence.
+        # for, e.g., a Java project rather than seeing silence.
         console.print(
             f"[dim]Architecture rules unavailable for {language} "
-            "(supported: python, typescript, go, rust)[/dim]"
+            "(supported: python, typescript, go, rust, swift)[/dim]"
         )
         return
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -1,7 +1,8 @@
 """Architecture enforcement generator.
 
 Generates architecture validation configuration for import-linter (Python),
-dependency-cruiser (TypeScript), go-arch-lint (Go), and cargo-deny (Rust).
+dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), and
+SwiftLint custom rules (Swift).
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ class ArchitectureResult:
     Attributes:
         output_dir: Directory containing generated files.
         files_created: List of files created.
-        language: Target language (python, typescript, go, rust).
+        language: Target language (python, typescript, go, rust, swift).
     """
 
     output_dir: Path
@@ -97,6 +98,17 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         docs_url="https://embarkstudios.github.io/cargo-deny/",
         display_name="Rust",
     ),
+    "swift": _LanguageTooling(
+        # No native Swift layer linter exists (unlike import-linter or
+        # go-arch-lint), so layer rules are expressed as SwiftLint custom
+        # regex rules; the generated config documents that gap.
+        tool="SwiftLint custom rules",
+        config_file=".swiftlint-architecture.yml",
+        install_cmd="brew install swiftlint",
+        run_cmd="swiftlint lint --config {config_file}",
+        docs_url="https://realm.github.io/SwiftLint/custom_rules.html",
+        display_name="Swift",
+    ),
 }
 
 
@@ -104,9 +116,9 @@ class ArchitectureEnforcementGenerator:
     """Generates architecture enforcement configuration.
 
     Generates import-linter config for Python, dependency-cruiser
-    config for TypeScript, go-arch-lint config for Go, and cargo-deny
-    config for Rust to enforce layer separation and prevent circular
-    dependencies.
+    config for TypeScript, go-arch-lint config for Go, cargo-deny
+    config for Rust, and SwiftLint custom rules for Swift to enforce
+    layer separation and prevent circular dependencies.
 
     Attributes:
         orchestrator: AI orchestrator for content generation.
@@ -153,7 +165,7 @@ class ArchitectureEnforcementGenerator:
         """Generate architecture enforcement configuration.
 
         Args:
-            language: Target language (python, typescript, go, rust).
+            language: Target language (python, typescript, go, rust, swift).
             project_name: Name of the project.
 
         Returns:
@@ -177,6 +189,7 @@ class ArchitectureEnforcementGenerator:
             "typescript": partial(self._generate_typescript_config, project_name),
             "go": partial(self._generate_go_config, project_name),
             "rust": self._generate_rust_config,
+            "swift": self._generate_swift_config,
         }
         files_created = config_builders[language]()
 
@@ -477,6 +490,93 @@ unknown-git = "deny"
         config_path.write_text(config_content)
         return [config_path]
 
+    # Like the Rust config, the Swift config is project-name agnostic: the
+    # custom rules reference the per-layer SPM module names, which are fixed
+    # by convention, so no project_name parameter is needed here.
+    def _generate_swift_config(self) -> list[Path]:
+        """Generate SwiftLint custom-rules configuration for Swift.
+
+        No native Swift architecture linter exists (unlike import-linter,
+        dependency-cruiser, go-arch-lint, or cargo-deny), so layer rules
+        are expressed as SwiftLint custom regex rules over ``import``
+        statements. The generated config documents that enforcement gap
+        explicitly, mirroring how the Rust ``deny.toml`` documents what
+        cargo-deny cannot restrict. The dependency matrix mirrors the Go
+        config: presentation -> application -> domain, with infrastructure
+        allowed to depend on domain only.
+
+        Returns:
+            List of files created.
+        """
+        config_path = self.output_dir / ".swiftlint-architecture.yml"
+
+        # Raw string: the regexes below must reach the YAML file with their
+        # backslashes intact (single-quoted YAML scalars keep them literal).
+        config_content = r"""# SwiftLint custom rules enforcing layered architecture.
+#
+# No native Swift layer linter exists (unlike import-linter for Python,
+# dependency-cruiser for TypeScript, go-arch-lint for Go, or cargo-deny
+# for Rust), so layer rules are expressed as SwiftLint custom regex rules
+# over `import` statements.
+#
+# Enforcement limits (documented, not hidden):
+#   - Custom rules are regex matches over source text,
+#     not a resolved dependency graph. They only catch explicit `import`
+#     statements of layer modules; they cannot see transitive dependencies.
+#   - Layers must be modeled as separate SPM targets/modules named
+#     Presentation, Application, Domain, and Infrastructure. References
+#     within a single module never need an `import` and are NOT caught.
+#   - No cycle rule is needed here:
+#     Swift Package Manager itself rejects circular target dependencies
+#     at build time.
+#
+# Dependency matrix (mirrors the Go go-arch-lint config):
+#   presentation -> application, domain
+#   application  -> domain
+#   infrastructure -> domain
+#   domain       -> (nothing)
+#
+# Run with:
+#   swiftlint lint --config .swiftlint-architecture.yml
+
+# Run only the custom architecture rules from this config so this check
+# stays orthogonal to the general lint pass (.swiftlint.yml).
+only_rules:
+  - custom_rules
+
+included:
+  - Sources
+
+custom_rules:
+  domain_layer_purity:
+    name: 'Domain layer purity'
+    included: 'Sources/Domain/.*\.swift'
+    regex: '^\s*(@testable\s+)?import\s+(Presentation|Application|Infrastructure)\b'
+    message: 'Domain must not import Presentation, Application, or Infrastructure.'
+    severity: error
+  application_layer_boundary:
+    name: 'Application layer boundary'
+    included: 'Sources/Application/.*\.swift'
+    regex: '^\s*(@testable\s+)?import\s+(Presentation|Infrastructure)\b'
+    message: 'Application may only depend on Domain, never on outer layers.'
+    severity: error
+  infrastructure_layer_boundary:
+    name: 'Infrastructure layer boundary'
+    included: 'Sources/Infrastructure/.*\.swift'
+    regex: '^\s*(@testable\s+)?import\s+(Presentation|Application)\b'
+    message: 'Infrastructure may only depend on Domain.'
+    severity: error
+  presentation_layer_boundary:
+    name: 'Presentation layer boundary'
+    included: 'Sources/Presentation/.*\.swift'
+    regex: '^\s*(@testable\s+)?import\s+Infrastructure\b'
+    message: 'Presentation may depend on Application and Domain only.'
+    severity: error
+"""
+
+        config_path.write_text(config_content)
+        return [config_path]
+
     def _generate_readme(self, language: str, project_name: str) -> Path:
         """Generate README with usage instructions.
 
@@ -561,12 +661,14 @@ Edit the configuration file:
 - TypeScript: `.dependency-cruiser.js`
 - Go: `.go-arch-lint.yml`
 - Rust: `deny.toml`
+- Swift: `.swiftlint-architecture.yml`
 
 See documentation:
 - Python: https://import-linter.readthedocs.io/
 - TypeScript: https://github.com/sverweij/dependency-cruiser
 - Go: https://github.com/fe3dback/go-arch-lint
 - Rust: https://embarkstudios.github.io/cargo-deny/
+- Swift: https://realm.github.io/SwiftLint/custom_rules.html
 
 ## Integration
 

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -464,6 +464,14 @@ LANGUAGE_TOOLS: dict[str, dict[str, str]] = {
         "security": "cargo-audit",
         "dependency_check": "cargo-outdated",
     },
+    "swift": {
+        "coverage": "swift test --enable-code-coverage + llvm-cov",
+        "mutation": "muter",
+        "complexity": "swiftlint (cyclomatic_complexity)",
+        "documentation": "swift-docc",
+        "security": "swiftlint + periphery",
+        "dependency_check": "swift package update --dry-run",
+    },
 }
 
 

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -25,7 +25,7 @@ class GenerationConfig:
 
     Attributes:
         project_name: Name of the project.
-        language: Programming language (python, typescript, go, rust).
+        language: Programming language (python, typescript, go, rust, swift).
         language_config: Additional language-specific configuration.
     """
 
@@ -350,6 +350,82 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         ],
         "default_language_version": {},
     },
+    "swift": {
+        "hooks": [
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v4.5.0",
+                "hooks": [
+                    {"id": "trailing-whitespace"},
+                    {"id": "end-of-file-fixer"},
+                    {"id": "check-yaml"},
+                    {"id": "check-json"},
+                    {"id": "check-added-large-files", "args": ["--maxkb=500"]},
+                    {"id": "check-case-conflict"},
+                    {"id": "check-merge-conflict"},
+                    {"id": "check-symlinks"},
+                    {"id": "detect-private-key"},
+                    {"id": "fix-byte-order-marker"},
+                    {"id": "mixed-line-ending", "args": ["--fix=lf"]},
+                    {"id": "no-commit-to-branch", "args": ["--branch", "main"]},
+                ],
+            },
+            # swift-format and SwiftLint run as `repo: local` system hooks
+            # (mirroring how the Rust hooks invoke the cargo toolchain):
+            # apple/swift-format ships no .pre-commit-hooks.yaml, and
+            # realm/SwiftLint's remote hook builds SwiftLint from source via
+            # SPM on first run (a multi-minute build). Install both with:
+            # `brew install swift-format swiftlint`.
+            {
+                "repo": "local",
+                "hooks": [
+                    {
+                        "id": "swift-format",
+                        "name": "swift-format",
+                        "entry": "swift-format format --in-place",
+                        "language": "system",
+                        "types": ["swift"],
+                    },
+                    {
+                        "id": "swiftlint",
+                        "name": "SwiftLint",
+                        # --strict promotes warnings to errors; reads the
+                        # generated .swiftlint.yml (cyclomatic_complexity
+                        # <=10 plus the crash-safety/security opt-in rules).
+                        "entry": "swiftlint lint --strict",
+                        "language": "system",
+                        "types": ["swift"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                ],
+            },
+            {
+                "repo": "https://github.com/gitleaks/gitleaks",
+                "rev": "v8.18.4",
+                "hooks": [
+                    {"id": "gitleaks"},
+                ],
+            },
+            {
+                "repo": "https://github.com/shellcheck-py/shellcheck-py",
+                "rev": "v0.9.0.6",
+                "hooks": [
+                    {"id": "shellcheck"},
+                ],
+            },
+            {
+                "repo": "https://github.com/Yelp/detect-secrets",
+                "rev": "v1.4.0",
+                "hooks": [
+                    {
+                        "id": "detect-secrets",
+                        "args": ["--baseline", ".secrets.baseline"],
+                    },
+                ],
+            },
+        ],
+        "default_language_version": {},
+    },
 }
 
 
@@ -359,7 +435,7 @@ class PreCommitGenerator(BaseGenerator):
     Customizes pre-commit hooks based on project language and requirements.
     Includes formatting, linting, security, and general file quality checks.
 
-    Supports: Python, TypeScript, Go, Rust, and other languages.
+    Supports: Python, TypeScript, Go, Rust, Swift, and other languages.
 
     Attributes:
         orchestrator: Optional AI orchestrator for enhanced generation.

--- a/start_green_stay_green/generators/readme.py
+++ b/start_green_stay_green/generators/readme.py
@@ -1238,12 +1238,17 @@ Start Green Stay Green.
 
 ## Description
 
-This Swift scaffold is the foundation of a quality-controlled watchOS
-project. The following are generated today:
+This Swift scaffold is a quality-controlled watchOS project. The following
+are generated today:
 
 - ✅ Apple Watch (watchOS) app target built with SwiftUI
 - ✅ Swift Package Manager manifest (Package.swift)
 - ✅ XCTest test target
+- ✅ Code quality tools (SwiftLint + swift-format, configured in .swiftlint.yml)
+- ✅ Pre-commit hooks (format, lint, secret scanning via gitleaks)
+- ✅ Quality scripts (./scripts/check-all.sh with a 90%+ coverage gate)
+- ✅ Security & dead-code scanning (Periphery via ./scripts/security.sh)
+- ✅ Architecture enforcement (SwiftLint custom rules)
 - ✅ This README
 
 ### Planned / coming soon
@@ -1252,11 +1257,7 @@ These quality features are part of the Start Green Stay Green roadmap for
 Swift but are **not yet generated** by this scaffold — do not assume they
 are configured:
 
-- Code quality tools (SwiftLint, swift-format)
-- Security scanning (Swift Package audit)
-- Pre-commit hooks (quality checks)
 - CI/CD pipeline (GitHub Actions)
-- Enforced 90%+ test coverage gate
 
 ## Installation
 
@@ -1267,6 +1268,12 @@ cd {self.config.project_name}
 
 # Resolve package dependencies
 swift package resolve
+
+# Install the quality toolchain (Homebrew)
+brew install swiftlint swift-format periphery
+
+# Install the pre-commit hooks
+pre-commit install
 ```
 
 ## Usage
@@ -1302,10 +1309,12 @@ swift test
 
 # Run tests with code coverage
 swift test --enable-code-coverage
+
+# Run every quality gate (format, lint, tests + coverage, security)
+./scripts/check-all.sh
 ```
 
-> **Note:** Linting (SwiftLint), formatting (swift-format), security
-> scanning, pre-commit hooks, and CI are on the roadmap but not yet
+> **Note:** A CI pipeline (GitHub Actions) is on the roadmap but not yet
 > configured by this scaffold. See *Planned / coming soon* above.
 
 ### Quality Tools
@@ -1314,6 +1323,11 @@ This scaffold currently includes:
 
 - **XCTest**: Built-in testing framework
 - **Swift Package Manager**: Dependency management and build tooling
+- **SwiftLint**: Linting with cyclomatic complexity ≤10 (.swiftlint.yml)
+- **swift-format**: Code formatting (./scripts/format.sh)
+- **Periphery**: Dead-code detection (./scripts/security.sh)
+- **Pre-commit hooks**: swift-format, SwiftLint, gitleaks, detect-secrets
+- **Architecture rules**: SwiftLint custom rules (plans/architecture/)
 
 ### Project Structure
 
@@ -1342,14 +1356,17 @@ swift test --filter TestName
 
 ### Code Quality
 
-This scaffold is the foundation for a MAXIMUM QUALITY Swift project. Today it
-provides:
+This scaffold is a MAXIMUM QUALITY Swift project. Today it provides:
 
 - **Type Safety**: 100% compile-time type checking (inherent to Swift)
 - **XCTest test target**: ready for you to add tests
+- **Coverage gate**: ./scripts/test.sh --coverage enforces ≥90% line coverage
+- **Complexity gate**: SwiftLint errors on cyclomatic complexity >10
+- **Formatting & linting**: swift-format and SwiftLint, locally and in
+  pre-commit
 
-Enforced coverage gates, linting, and formatting are planned (see *Planned /
-coming soon* above) and are not yet wired into this scaffold.
+A CI pipeline is planned (see *Planned / coming soon* above) and is not yet
+wired into this scaffold.
 
 ## License
 

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -1,7 +1,8 @@
 """Scripts directory generator.
 
 Generates quality control scripts adapted to target project languages and structure.
-Supports Python, TypeScript, Go, Rust, and other languages with appropriate tooling.
+Supports Python, TypeScript, Go, Rust, Swift, and other languages with
+appropriate tooling.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from start_green_stay_green.utils.file_writer import FileWriter
 
 
@@ -20,7 +23,7 @@ class ScriptConfig:
     """Configuration for script generation.
 
     Attributes:
-        language: Programming language (python, typescript, go, rust, etc.)
+        language: Programming language (python, typescript, go, rust, swift, etc.)
         package_name: Name of the main package/module
         supports_pytest: Whether project uses pytest for testing
         supports_coverage: Whether project uses coverage reporting
@@ -115,20 +118,21 @@ class ScriptsGenerator:
         Raises:
             OSError: If script files cannot be written
         """
-        scripts: dict[str, Path] = {}
-
-        # Generate language-specific scripts
-        if self.config.language == "python":
-            scripts.update(self._generate_python_scripts())
-        elif self.config.language in ("typescript", "ts", "javascript", "js"):
-            scripts.update(self._generate_typescript_scripts())
-        elif self.config.language == "go":
-            scripts.update(self._generate_go_scripts())
-        elif self.config.language == "rust":
-            scripts.update(self._generate_rust_scripts())
-        else:
-            # Fallback to Python scripts for unknown languages
-            scripts.update(self._generate_python_scripts())
+        # Dispatch table keeps generate() flat as languages are added:
+        # each entry is a zero-argument builder returning the scripts dict.
+        builders: dict[str, Callable[[], dict[str, Path]]] = {
+            "python": self._generate_python_scripts,
+            "typescript": self._generate_typescript_scripts,
+            "ts": self._generate_typescript_scripts,
+            "javascript": self._generate_typescript_scripts,
+            "js": self._generate_typescript_scripts,
+            "go": self._generate_go_scripts,
+            "rust": self._generate_rust_scripts,
+            "swift": self._generate_swift_scripts,
+        }
+        # Fallback to Python scripts for unknown languages.
+        builder = builders.get(self.config.language, self._generate_python_scripts)
+        scripts: dict[str, Path] = builder()
 
         # Language-agnostic scripts
         scripts["pr-status.sh"] = self._write_script(
@@ -282,6 +286,45 @@ class ScriptsGenerator:
             "test.sh",
             self._rust_test_script(),
         )
+
+        return scripts
+
+    def _generate_swift_scripts(self) -> dict[str, Path]:
+        """Generate Swift-specific quality control scripts.
+
+        Emits check/format/lint/test/security scripts plus a companion
+        ``.swiftlint.yml`` at the project root (complexity gate and
+        crash-safety/security opt-in rules) so the lint script and the
+        pre-commit SwiftLint hook share one configuration.
+
+        Returns:
+            Dictionary mapping script names to file paths
+        """
+        scripts: dict[str, Path] = {}
+
+        scripts["check-all.sh"] = self._write_script(
+            "check-all.sh",
+            self._swift_check_all_script(),
+        )
+        scripts["format.sh"] = self._write_script(
+            "format.sh",
+            self._swift_format_script(),
+        )
+        scripts["lint.sh"] = self._write_script(
+            "lint.sh",
+            self._swift_lint_script(),
+        )
+        scripts["test.sh"] = self._write_script(
+            "test.sh",
+            self._swift_test_script(),
+        )
+        scripts["security.sh"] = self._write_script(
+            "security.sh",
+            self._swift_security_script(),
+        )
+        # Companion SwiftLint config — written at the project root, not
+        # added to the scripts dict (it isn't an executable).
+        self._write_swiftlint_config_template()
 
         return scripts
 
@@ -2690,6 +2733,456 @@ fi
 echo "✓ Tests passed"
 exit 0
 """
+
+    # Swift script generators
+
+    def _swift_check_all_script(self) -> str:
+        """Generate Swift check-all.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Format check (swift-format)
+  2. Linting + complexity <=10 (SwiftLint)
+  3. Tests + coverage >=90% (swift test + llvm-cov)
+  4. Security & dead code (Periphery)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+
+    echo "Running: $check_name"
+    if "$SCRIPT_DIR/$script" "${@}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+run_check "Format" "format.sh"
+run_check "Linting" "lint.sh"
+run_check "Tests" "test.sh" --coverage
+run_check "Security" "security.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    exit 1
+else
+    echo "✓ All quality checks passed!"
+    exit 0
+fi
+"""
+
+    def _swift_format_script(self) -> str:
+        """Generate Swift format.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/format.sh - Format Swift code
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format Swift code using swift-format (install: brew install swift-format).
+
+OPTIONS:
+    --fix       Apply formatting (default, writes in place)
+    --check     Check only, fail if formatting needed
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Formatting (swift-format) ==="
+
+if $CHECK; then
+    swift-format lint --strict --recursive Sources Tests || \\
+        { echo "✗ Format check failed" >&2; exit 1; }
+    echo "✓ Code formatting check passed"
+else
+    swift-format format --in-place --recursive Sources Tests || \\
+        { echo "✗ Formatting failed" >&2; exit 1; }
+    echo "✓ Code formatted successfully"
+fi
+exit 0
+"""
+
+    def _swift_lint_script(self) -> str:
+        """Generate Swift lint.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/lint.sh - Run linting with SwiftLint
+# Usage: ./scripts/lint.sh [--fix] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+FIX=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run linting using SwiftLint (install: brew install swiftlint).
+
+Reads .swiftlint.yml at the project root, which enforces
+cyclomatic_complexity <= 10 and the crash-safety/security opt-in rules.
+
+OPTIONS:
+    --fix       Auto-fix linting issues where possible
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           Linting issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Linting (SwiftLint) ==="
+
+if $FIX; then
+    swiftlint lint --fix || { echo "✗ SwiftLint fix failed" >&2; exit 1; }
+else
+    swiftlint lint --strict || { echo "✗ Linting failed" >&2; exit 1; }
+fi
+
+echo "✓ Linting checks passed"
+exit 0
+"""
+
+    def _swift_test_script(self) -> str:
+        """Generate Swift test.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/test.sh - Run Swift tests
+# Usage: ./scripts/test.sh [--coverage] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+COVERAGE=false
+VERBOSE=false
+THRESHOLD=90
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run Swift tests (XCTest via swift test).
+
+OPTIONS:
+    --coverage  Enforce >=${THRESHOLD}% line coverage via llvm-cov data
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All tests passed (and coverage met, with --coverage)
+    1           Test failures or coverage below threshold
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Running Tests (swift test) ==="
+
+swift test --enable-code-coverage || { echo "✗ Tests failed" >&2; exit 1; }
+
+if $COVERAGE; then
+    # swift test emits llvm-cov export JSON; --show-codecov-path points
+    # at it without re-running the suite.
+    CODECOV_JSON="$(swift test --show-codecov-path)"
+    python3 - "$CODECOV_JSON" "$THRESHOLD" << 'PYEOF' || exit 1
+import json
+import sys
+
+path, threshold = sys.argv[1], float(sys.argv[2])
+with open(path, encoding="utf-8") as handle:
+    percent = json.load(handle)["data"][0]["totals"]["lines"]["percent"]
+print(f"Line coverage: {percent:.2f}% (threshold: {threshold:.0f}%)")
+sys.exit(0 if percent >= threshold else 1)
+PYEOF
+fi
+
+echo "✓ Tests passed"
+exit 0
+"""
+
+    def _swift_security_script(self) -> str:
+        """Generate Swift security.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/security.sh - Security & dead-code checks for Swift
+# Usage: ./scripts/security.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run security and dead-code checks.
+
+Division of labor:
+  - Secret scanning (gitleaks + detect-secrets) runs in pre-commit.
+  - SwiftLint's crash-safety/security rules run in lint.sh.
+  - This script adds Periphery dead-code detection
+    (install: brew install periphery).
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           No issues found (or Periphery not installed; see below)
+    1           Unused/dead code detected
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Security & Dead Code (Periphery) ==="
+
+# Pragmatic default: a missing Periphery binary warns instead of failing
+# so a fresh clone passes check-all.sh out of the box. Tighten by
+# replacing the warning block with `exit 1` once Periphery is installed
+# everywhere (including CI).
+if ! command -v periphery &> /dev/null; then
+    echo "⚠ periphery not found - skipping dead-code scan" >&2
+    echo "⚠ Install with: brew install periphery" >&2
+    exit 0
+fi
+
+periphery scan --strict || { echo "✗ Periphery found unused code" >&2; exit 1; }
+
+echo "✓ Security checks passed"
+exit 0
+"""
+
+    # SwiftLint companion configuration template. Shared by lint.sh and the
+    # pre-commit SwiftLint hook. cyclomatic_complexity mirrors the <=10 gate
+    # used by radon (Python), eslint (TypeScript), gocyclo (Go), and clippy
+    # (Rust). SwiftLint has no dedicated security ruleset, so the security
+    # posture is documented explicitly: crash-safety/randomness rules here,
+    # secret scanning in pre-commit (gitleaks + detect-secrets), dead-code
+    # analysis in security.sh (Periphery).
+    _SWIFTLINT_CONFIG_TEMPLATE = """\
+# SwiftLint configuration generated by Start Green Stay Green.
+#
+# Complexity gate: cyclomatic_complexity <= 10 (error) mirrors the
+# radon/eslint/gocyclo/clippy thresholds enforced for other languages.
+#
+# Security posture (documented, not implied): SwiftLint has no dedicated
+# security ruleset. The opt-in rules below catch crash-prone force
+# operations and insecure randomness; secret scanning is handled by the
+# gitleaks and detect-secrets pre-commit hooks, and dead-code analysis by
+# Periphery (scripts/security.sh).
+
+included:
+  - Sources
+  - Tests
+
+opt_in_rules:
+  # Crash safety: forbid force unwraps/casts/tries outside tests.
+  - force_unwrapping
+  # Insecure randomness: arc4random/rand are not CSPRNGs.
+  - legacy_random
+  # Memory safety: capturing unowned references invites use-after-free.
+  - unowned_variable_capture
+  # Diagnostics: fatalError without a message hides crash causes.
+  - fatal_error_message
+
+cyclomatic_complexity:
+  warning: 10
+  error: 10
+"""
+
+    def _write_swiftlint_config_template(self) -> Path | None:
+        """Write the companion ``.swiftlint.yml`` at the project root.
+
+        The config lives at ``$PROJECT_ROOT`` so both ``lint.sh`` and the
+        pre-commit SwiftLint hook resolve it implicitly. An existing file
+        is preserved (user customisations win).
+
+        Returns:
+            Path to the written config, or ``None`` if a file already
+            exists at the destination.
+        """
+        config_path = self.project_root / ".swiftlint.yml"
+        if config_path.exists():
+            return None
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._file_writer is not None:
+            self._file_writer.write_file(config_path, self._SWIFTLINT_CONFIG_TEMPLATE)
+        else:
+            config_path.write_text(self._SWIFTLINT_CONFIG_TEMPLATE, encoding="utf-8")
+        return config_path
 
     # Language-agnostic script generators
 

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -5,6 +5,7 @@ import tomllib
 from unittest.mock import create_autospec
 
 import pytest
+import yaml
 
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.generators.architecture import (
@@ -527,6 +528,188 @@ class TestArchitectureEnforcementGeneratorRust:
         assert "command -v cargo-deny" in script
 
 
+class TestArchitectureEnforcementGeneratorSwift:
+    """Test Swift-specific architecture rules (#352)."""
+
+    @staticmethod
+    def _generate(tmp_path: Path) -> Path:
+        """Generate the Swift architecture config and return its directory."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+        generator.generate(language="swift", project_name="myapp")
+        return output_dir
+
+    def test_generate_swift_creates_swiftlint_architecture_config(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test generating SwiftLint custom-rules config for Swift."""
+        output_dir = self._generate(tmp_path)
+
+        # Should create the SwiftLint custom-rules config file
+        config_file = output_dir / ".swiftlint-architecture.yml"
+        assert config_file.exists()
+
+        # Should create README and run script
+        assert (output_dir / "README.md").exists()
+        assert (output_dir / "run-check.sh").exists()
+
+    def test_swift_config_is_parseable_yaml(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """.swiftlint-architecture.yml must be syntactically valid YAML."""
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        parsed = yaml.safe_load(config)  # raises on parse error
+        assert isinstance(parsed, dict)
+
+    def test_swift_config_enforces_layer_separation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test Swift config expresses layer rules as custom regex rules."""
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        parsed = yaml.safe_load(config)
+
+        rules = parsed["custom_rules"]
+        assert "domain_layer_purity" in rules
+        assert "application_layer_boundary" in rules
+        assert "infrastructure_layer_boundary" in rules
+        assert "presentation_layer_boundary" in rules
+
+    def test_swift_config_keeps_domain_pure(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The domain rule forbids importing every outer-layer module."""
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        parsed = yaml.safe_load(config)
+
+        domain_rule = parsed["custom_rules"]["domain_layer_purity"]
+        for module in ("Presentation", "Application", "Infrastructure"):
+            assert module in domain_rule["regex"]
+        assert domain_rule["severity"] == "error"
+
+    def test_swift_config_runs_only_custom_rules(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The architecture pass stays orthogonal to the general lint pass."""
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        parsed = yaml.safe_load(config)
+
+        assert parsed["only_rules"] == ["custom_rules"]
+
+    def test_swift_config_documents_regex_limits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The config documents what regex custom rules cannot enforce.
+
+        No native Swift layer linter exists; SwiftLint custom rules match
+        source text, not a resolved dependency graph. The generated config
+        must disclose that limit (mirroring the Rust deny.toml gap note)
+        rather than imply complete enforcement.
+        """
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        assert "regex matches over source text" in config
+        assert "not a resolved dependency graph" in config
+
+    def test_swift_config_cycle_comment_is_accurate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Cycle prevention is attributed to SPM, not to SwiftLint.
+
+        SwiftLint custom rules cannot detect dependency cycles; Swift
+        Package Manager itself rejects circular target dependencies at
+        build time. The generated config must say so rather than
+        overclaiming what SwiftLint does.
+        """
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        assert "Swift Package Manager itself rejects circular" in config
+
+    def test_swift_config_catches_testable_imports(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Layer rules also match @testable import statements."""
+        output_dir = self._generate(tmp_path)
+
+        config = (output_dir / ".swiftlint-architecture.yml").read_text()
+        parsed = yaml.safe_load(config)
+
+        domain_rule = parsed["custom_rules"]["domain_layer_purity"]
+        assert "@testable" in domain_rule["regex"]
+
+    def test_swift_readme_mentions_swiftlint(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Swift README references the SwiftLint tooling."""
+        output_dir = self._generate(tmp_path)
+
+        readme = (output_dir / "README.md").read_text()
+        assert "SwiftLint" in readme
+
+    def test_swift_run_script_invokes_swiftlint(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Swift run-check.sh script invokes swiftlint."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "command -v swiftlint" in script
+
+    def test_swift_run_script_prefixes_config_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Swift run-check.sh points at the plans/architecture config."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert (
+            "swiftlint lint --config "
+            "plans/architecture/.swiftlint-architecture.yml" in script
+        )
+
+    def test_swift_run_script_uses_display_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Swift run-check.sh announces the 'Swift' display name."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "Checking Swift architecture" in script
+
+    def test_swift_result_reports_swift_language(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the result object records the Swift language."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        result = generator.generate(language="swift", project_name="myapp")
+
+        assert result.language == "swift"
+
+
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
 
@@ -573,6 +756,7 @@ class TestLanguageTooling:
             ("typescript", "TypeScript"),
             ("go", "Go"),
             ("rust", "Rust"),
+            ("swift", "Swift"),
         ],
     )
     def test_each_tooling_carries_a_display_name(
@@ -581,7 +765,9 @@ class TestLanguageTooling:
         """Display name is a single-source-of-truth field on the dataclass."""
         assert _LANGUAGE_TOOLING[language].display_name == expected_display
 
-    @pytest.mark.parametrize("language", ["python", "typescript", "go", "rust"])
+    @pytest.mark.parametrize(
+        "language", ["python", "typescript", "go", "rust", "swift"]
+    )
     def test_run_cmd_is_a_config_file_template(self, language: str) -> None:
         """run_cmd holds a {config_file} placeholder, not a literal path."""
         tooling = _LANGUAGE_TOOLING[language]

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -176,8 +176,24 @@ class TestLanguageTools:
 
     def test_supports_required_languages(self) -> None:
         """Test that all required languages are supported."""
-        required_languages = {"python", "typescript", "javascript", "go", "rust"}
+        required_languages = {
+            "python",
+            "typescript",
+            "javascript",
+            "go",
+            "rust",
+            "swift",
+        }
         assert required_languages.issubset(set(LANGUAGE_TOOLS.keys()))
+
+    def test_swift_tools(self) -> None:
+        """Test Swift tool mappings (#352)."""
+        tools = LANGUAGE_TOOLS["swift"]
+        assert tools["coverage"] == "swift test --enable-code-coverage + llvm-cov"
+        assert tools["mutation"] == "muter"
+        assert tools["complexity"] == "swiftlint (cyclomatic_complexity)"
+        assert tools["documentation"] == "swift-docc"
+        assert tools["security"] == "swiftlint + periphery"
 
     def test_python_tools(self) -> None:
         """Test Python tool mappings."""
@@ -705,6 +721,29 @@ class TestMetricsConfigGeneration:
 
         assert metrics["code_coverage"]["tool"] == "jest"
         assert metrics["mutation_score"]["tool"] == "stryker"
+
+    def test_generate_metrics_config_swift_tools(self) -> None:
+        """Swift metric config reports llvm-cov coverage and SwiftLint (#352)."""
+        config = MetricsGenerationConfig(
+            language="swift",
+            project_name="watch-app",
+        )
+        generator = MetricsGenerator(None, config)
+
+        metrics_config = generator._generate_metrics_config()
+        metrics = metrics_config["metrics"]
+
+        assert metrics_config["language"] == "swift"
+        assert (
+            metrics["code_coverage"]["tool"]
+            == "swift test --enable-code-coverage + llvm-cov"
+        )
+        assert (
+            metrics["cyclomatic_complexity"]["tool"]
+            == "swiftlint (cyclomatic_complexity)"
+        )
+        assert metrics["code_coverage"]["threshold"] == 90
+        assert metrics["cyclomatic_complexity"]["threshold"] == 10
 
 
 class TestSonarQubeGeneration:

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -1,5 +1,6 @@
 """Unit tests for Pre-commit Generator."""
 
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -404,6 +405,126 @@ class TestGenerateWithRust:
         assert "clippy" in hook_ids
 
 
+class TestGenerateWithSwift:
+    """Test content generation for Swift projects."""
+
+    @staticmethod
+    def _parsed_repos(generator: PreCommitGenerator) -> list[dict[str, Any]]:
+        """Generate the Swift config and return its parsed repos list."""
+        config = GenerationConfig(
+            project_name="swift-project",
+            language="swift",
+            language_config={},
+        )
+        result = generator.generate(config)
+        yaml_content = "\n".join(
+            line for line in result["content"].split("\n") if not line.startswith("#")
+        )
+        parsed = yaml.safe_load(yaml_content)
+        return list(parsed["repos"])
+
+    def test_generate_swift_returns_dict(self, mock_orchestrator: Mock) -> None:
+        """Test generate returns dict for Swift."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        config = GenerationConfig(
+            project_name="swift-project",
+            language="swift",
+            language_config={},
+        )
+        result = generator.generate(config)
+        assert isinstance(result, dict)
+        assert result["content"]
+
+    def test_generate_swift_content_is_valid_yaml(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Generated Swift pre-commit config must be parseable YAML."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        assert isinstance(repos, list)
+        assert repos
+
+    def test_generate_swift_includes_swift_format(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test generated Swift config includes a swift-format hook."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(
+            (repo for repo in repos if repo.get("repo") == "local"),
+            None,
+        )
+        assert local_repo is not None
+        hook_ids = [hook.get("id", "") for hook in local_repo.get("hooks", [])]
+        assert "swift-format" in hook_ids
+
+    def test_generate_swift_includes_swiftlint(self, mock_orchestrator: Mock) -> None:
+        """Test generated Swift config includes a SwiftLint hook."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(
+            (repo for repo in repos if repo.get("repo") == "local"),
+            None,
+        )
+        assert local_repo is not None
+        hook_ids = [hook.get("id", "") for hook in local_repo.get("hooks", [])]
+        assert "swiftlint" in hook_ids
+
+    def test_swift_swiftlint_hook_is_strict(self, mock_orchestrator: Mock) -> None:
+        """The SwiftLint hook runs with --strict so warnings fail commits."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        swiftlint = next(
+            hook for hook in local_repo["hooks"] if hook.get("id") == "swiftlint"
+        )
+        assert "--strict" in swiftlint["entry"]
+
+    def test_swift_local_hooks_use_system_language(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Local Swift hooks invoke system binaries, not SPM source builds.
+
+        Building SwiftLint from source via pre-commit's swift language
+        support takes multiple minutes on first run; the hooks must probe
+        the brew/toolchain-installed binaries instead.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        for hook in local_repo["hooks"]:
+            assert hook["language"] == "system", f"{hook['id']} not language: system"
+            assert hook["types"] == ["swift"], f"{hook['id']} missing swift types"
+
+    def test_generate_swift_includes_gitleaks(self, mock_orchestrator: Mock) -> None:
+        """Test generated Swift config includes the gitleaks secrets hook."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        gitleaks_repo = next(
+            (repo for repo in repos if "gitleaks/gitleaks" in repo.get("repo", "")),
+            None,
+        )
+        assert gitleaks_repo is not None
+        hook_ids = [hook.get("id", "") for hook in gitleaks_repo.get("hooks", [])]
+        assert "gitleaks" in hook_ids
+
+    def test_generate_swift_includes_detect_secrets(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Swift keeps the detect-secrets hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("Yelp/detect-secrets" in url for url in repo_urls)
+
+    def test_generate_swift_includes_shellcheck(self, mock_orchestrator: Mock) -> None:
+        """Swift keeps the shellcheck hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("shellcheck-py" in url for url in repo_urls)
+
+
 class TestValidateLanguage:
     """Test language validation functionality."""
 
@@ -425,6 +546,13 @@ class TestValidateLanguage:
         """Test validate_language returns True for Go."""
         generator = PreCommitGenerator(mock_orchestrator)
         assert generator.validate_language("go")
+
+    def test_validate_language_swift_returns_true(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test validate_language returns True for Swift."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        assert generator.validate_language("swift")
 
     def test_validate_language_rust_returns_true(self, mock_orchestrator: Mock) -> None:
         """Test validate_language returns True for Rust."""
@@ -493,11 +621,19 @@ class TestGetSupportedLanguages:
         result = generator.get_supported_languages()
         assert "rust" in result
 
+    def test_get_supported_languages_includes_swift(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test get_supported_languages includes swift."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.get_supported_languages()
+        assert "swift" in result
+
     def test_get_supported_languages_exact_count(self, mock_orchestrator: Mock) -> None:
         """Test get_supported_languages returns expected count."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_supported_languages()
-        assert len(result) == 4
+        assert len(result) == 5
 
     def test_get_supported_languages_no_duplicates(
         self, mock_orchestrator: Mock
@@ -545,6 +681,14 @@ class TestGetLanguageHooks:
         """Test get_language_hooks returns list for rust."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_language_hooks("rust")
+        assert isinstance(result, list)
+
+    def test_get_language_hooks_swift_returns_list(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test get_language_hooks returns list for swift."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.get_language_hooks("swift")
         assert isinstance(result, list)
 
     def test_get_language_hooks_unsupported_raises_error(
@@ -608,6 +752,16 @@ class TestCountHooksForLanguage:
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.count_hooks_for_language("rust")
         assert isinstance(result, int)
+
+    def test_count_hooks_swift_counts_every_hook(self, mock_orchestrator: Mock) -> None:
+        """Test count_hooks_for_language sums all Swift hooks exactly.
+
+        12 shared pre-commit-hooks + swift-format + swiftlint + gitleaks
+        + shellcheck + detect-secrets = 17.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.count_hooks_for_language("swift")
+        assert result == 17
 
     def test_count_hooks_unsupported_raises_error(
         self, mock_orchestrator: Mock
@@ -696,6 +850,10 @@ class TestLanguageConfigsStructure:
     def test_language_configs_has_rust(self) -> None:
         """Test LANGUAGE_CONFIGS has rust entry."""
         assert "rust" in LANGUAGE_CONFIGS
+
+    def test_language_configs_has_swift(self) -> None:
+        """Test LANGUAGE_CONFIGS has swift entry."""
+        assert "swift" in LANGUAGE_CONFIGS
 
     def test_each_language_has_hooks_key(self) -> None:
         """Test each language config has hooks key."""
@@ -1655,6 +1813,11 @@ class TestLanguageConfigsStructureValidation:
                 # Skip local hooks (id-only entries)
                 if "id" in repo and "repo" not in repo:
                     continue
+                # Skip `repo: local` blocks: pre-commit's schema defines
+                # local repos without a rev (hooks declare entry/language
+                # inline). Used by Swift's system-binary hooks.
+                if repo.get("repo") == "local":
+                    continue
                 actual_keys = set(repo.keys())
                 assert required_keys.issubset(actual_keys), (
                     f"{language} repo {idx} missing keys: "
@@ -1709,6 +1872,10 @@ class TestLanguageConfigsStructureValidation:
     def test_rust_repos_exact_count(self) -> None:
         """Test Rust has exactly 4 repository configurations."""
         assert len(LANGUAGE_CONFIGS["rust"]["hooks"]) == 4
+
+    def test_swift_repos_exact_count(self) -> None:
+        """Test Swift has exactly 5 repository configurations."""
+        assert len(LANGUAGE_CONFIGS["swift"]["hooks"]) == 5
 
     def test_every_hook_has_id_key(self) -> None:
         """Test every individual hook has an 'id' key."""

--- a/tests/unit/generators/test_readme.py
+++ b/tests/unit/generators/test_readme.py
@@ -366,9 +366,9 @@ class TestSwiftReadme:
     def test_swift_readme_only_checkmarks_generated_features(self) -> None:
         """Swift README must not ✅ features the scaffold does not generate.
 
-        Swift is a foundation-only scaffold: pre-commit hooks, CI/CD, and the
-        SwiftLint/swift-format toolchain are deferred. The README must not
-        advertise them with a ✅ checkmark.
+        After #352 the quality toolchain (SwiftLint, swift-format,
+        pre-commit hooks, quality scripts) IS generated and may carry a
+        checkmark; the CI/CD pipeline (#353) remains deferred and must not.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ReadmeConfig(
@@ -384,15 +384,14 @@ class TestSwiftReadme:
             # Features that ARE generated may carry a checkmark.
             assert "- ✅" in content
             assert "Swift Package Manager manifest" in content
+            wired = ("SwiftLint", "swift-format", "Pre-commit hooks")
+            for feature in wired:
+                assert any(
+                    "✅" in line and feature in line for line in content.splitlines()
+                ), f"README must advertise wired feature: {feature}"
 
             # Unwired features must never be claimed with a ✅ checkmark.
-            unwired = (
-                "SwiftLint",
-                "swift-format",
-                "Pre-commit hooks",
-                "CI/CD pipeline",
-                "Security scanning",
-            )
+            unwired = ("CI/CD pipeline",)
             for feature in unwired:
                 assert (
                     f"✅ {feature}" not in content
@@ -417,11 +416,14 @@ class TestSwiftReadme:
 
             content = files["README.md"].read_text()
             assert "Planned / coming soon" in content
-            assert "SwiftLint" in content
             assert "CI/CD pipeline" in content
 
-    def test_swift_readme_does_not_instruct_pre_commit_install(self) -> None:
-        """README must not tell users to install non-existent pre-commit hooks."""
+    def test_swift_readme_instructs_pre_commit_install(self) -> None:
+        """README tells users to install the now-generated pre-commit hooks.
+
+        Inverted from the #351 foundation scaffold: #352 wires a Swift
+        .pre-commit-config.yaml, so the README must document installing it.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ReadmeConfig(
                 project_name="test-project",
@@ -432,4 +434,18 @@ class TestSwiftReadme:
             files = generator.generate()
 
             content = files["README.md"].read_text()
-            assert "pre-commit install" not in content
+            assert "pre-commit install" in content
+
+    def test_swift_readme_documents_quality_tool_installs(self) -> None:
+        """README documents installing the brew-distributed quality tools."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ReadmeConfig(
+                project_name="test-project",
+                language="swift",
+                package_name="test_project",
+            )
+            generator = ReadmeGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["README.md"].read_text()
+            assert "brew install swiftlint swift-format periphery" in content

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import tempfile
 
 import pytest
+import yaml
 
 from start_green_stay_green.generators.scripts import ScriptConfig
 from start_green_stay_green.generators.scripts import ScriptsGenerator
@@ -63,7 +64,7 @@ class TestScriptConfig:
 
     def test_script_config_language_various_values(self) -> None:
         """Test ScriptConfig accepts various language values."""
-        languages = ["python", "typescript", "go", "rust", "javascript"]
+        languages = ["python", "typescript", "go", "rust", "swift", "javascript"]
         for lang in languages:
             config = ScriptConfig(
                 language=lang,
@@ -599,6 +600,132 @@ class TestScriptsGeneratorRustGeneration:
             assert "cargo test" in content
 
 
+class TestScriptsGeneratorSwiftGeneration:
+    """Test Swift script generation (#352)."""
+
+    @staticmethod
+    def _generate(tmpdir: str) -> dict[str, Path]:
+        """Generate Swift scripts into ``tmpdir`` and return the mapping."""
+        config = ScriptConfig(
+            language="swift",
+            package_name="my_watch_app",
+        )
+        generator = ScriptsGenerator(Path(tmpdir), config)
+        return generator.generate()
+
+    def test_generate_swift_scripts_creates_files(self) -> None:
+        """Test generate creates the full Swift script set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            assert "check-all.sh" in scripts
+            assert "format.sh" in scripts
+            assert "lint.sh" in scripts
+            assert "test.sh" in scripts
+            assert "security.sh" in scripts
+
+    def test_swift_format_script_uses_swift_format(self) -> None:
+        """Test Swift format.sh uses swift-format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "swift-format" in content
+
+    def test_swift_lint_script_uses_swiftlint_strict(self) -> None:
+        """Test Swift lint.sh runs SwiftLint with --strict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "swiftlint lint --strict" in content
+
+    def test_swift_test_script_enables_code_coverage(self) -> None:
+        """Test Swift test.sh runs swift test with coverage instrumentation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "swift test --enable-code-coverage" in content
+
+    def test_swift_test_script_enforces_90_percent_coverage(self) -> None:
+        """Coverage mode reads the llvm-cov codecov JSON and gates at 90%."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            # llvm-cov export JSON path comes from swift test itself.
+            assert "--show-codecov-path" in content
+            assert "THRESHOLD=90" in content
+
+    def test_swift_security_script_uses_periphery(self) -> None:
+        """Test Swift security.sh runs Periphery dead-code analysis."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "periphery scan" in content
+
+    def test_swift_check_all_runs_full_toolchain(self) -> None:
+        """check-all.sh runs format, lint, tests (with coverage), security."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["check-all.sh"].read_text()
+            assert 'run_check "Format" "format.sh"' in content
+            assert 'run_check "Linting" "lint.sh"' in content
+            assert 'run_check "Tests" "test.sh" --coverage' in content
+            assert 'run_check "Security" "security.sh"' in content
+
+    def test_swift_writes_swiftlint_config_companion(self) -> None:
+        """A .swiftlint.yml companion lands at the project root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            config_path = Path(tmpdir) / ".swiftlint.yml"
+            assert config_path.exists()
+
+    def test_swiftlint_config_is_parseable_yaml(self) -> None:
+        """.swiftlint.yml must be syntactically valid YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            content = (Path(tmpdir) / ".swiftlint.yml").read_text()
+            parsed = yaml.safe_load(content)
+            assert isinstance(parsed, dict)
+
+    def test_swiftlint_config_caps_cyclomatic_complexity_at_10(self) -> None:
+        """.swiftlint.yml errors when cyclomatic complexity exceeds 10."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            content = (Path(tmpdir) / ".swiftlint.yml").read_text()
+            parsed = yaml.safe_load(content)
+            assert parsed["cyclomatic_complexity"]["error"] == 10
+
+    def test_swiftlint_config_preserves_existing_file(self) -> None:
+        """An existing user .swiftlint.yml is never overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing = Path(tmpdir) / ".swiftlint.yml"
+            existing.write_text("disabled_rules: [todo]\n")
+
+            self._generate(tmpdir)
+
+            assert existing.read_text() == "disabled_rules: [todo]\n"
+
+    def test_swiftlint_config_documents_security_gap(self) -> None:
+        """.swiftlint.yml discloses that secret scanning lives in pre-commit.
+
+        SwiftLint has no dedicated security ruleset; the config must say
+        where secret scanning actually happens instead of overclaiming.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            content = (Path(tmpdir) / ".swiftlint.yml").read_text()
+            assert "gitleaks" in content
+
+
 class TestScriptsGeneratorLanguageFallback:
     """Test language fallback behavior."""
 
@@ -847,6 +974,20 @@ class TestMutationKillers:
             # Should generate Rust scripts with clippy
             content = scripts["lint.sh"].read_text()
             assert "clippy" in content
+
+    def test_swift_language_dispatches_to_swift_generator(self) -> None:
+        """Test 'swift' language dispatches to Swift generator."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="swift",
+                package_name="test",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            # Should generate Swift scripts with SwiftLint
+            content = scripts["lint.sh"].read_text()
+            assert "swiftlint" in content
 
     def test_generated_scripts_exact_count_python(self) -> None:
         """Test Python generator creates EXACTLY 12 scripts.
@@ -1527,7 +1668,7 @@ class TestPrStatusScript:
 
     def test_pr_status_script_generated_for_all_languages(self) -> None:
         """Test pr-status.sh is generated for all supported languages."""
-        languages = ["python", "typescript", "go", "rust"]
+        languages = ["python", "typescript", "go", "rust", "swift"]
         for lang in languages:
             with tempfile.TemporaryDirectory() as tmpdir:
                 config = ScriptConfig(

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1457,6 +1457,21 @@ class TestGenerateSteps:
         assert mock_generator.generate.call_args.kwargs["language"] == "rust"
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_swift(self, mock_generator_class: Mock) -> None:
+        """Test _generate_architecture_step generates rules for Swift."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "swift")
+
+        # Swift now has architecture parity: the generator must be invoked.
+        mock_generator.generate.assert_called_once()
+        assert mock_generator.generate.call_args.kwargs["language"] == "swift"
+
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step_skips_unsupported(
         self, mock_generator_class: Mock
     ) -> None:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -161,7 +161,7 @@ class TestMultiLanguageGeneration:
 
 
 class TestMultiLanguageArchitectureParity:
-    """Test that Go (#341) and Rust (#342) have architecture parity."""
+    """Test that Go (#341), Rust (#342) and Swift (#352) have parity."""
 
     def test_go_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
         """Go must emit an architecture-enforcement config like py/ts."""
@@ -177,7 +177,16 @@ class TestMultiLanguageArchitectureParity:
         config = tmp_path / "plans" / "architecture" / "deny.toml"
         assert config.exists(), "Rust init must emit a cargo-deny config"
 
-    @pytest.mark.parametrize("language", ["python", "typescript", "go", "rust"])
+    def test_swift_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
+        """Swift must emit an architecture-enforcement config like py/ts/go."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "swift")
+
+        config = tmp_path / "plans" / "architecture" / ".swiftlint-architecture.yml"
+        assert config.exists(), "Swift init must emit a SwiftLint rules config"
+
+    @pytest.mark.parametrize(
+        "language", ["python", "typescript", "go", "rust", "swift"]
+    )
     def test_supported_languages_emit_architecture_config(
         self, tmp_path: Path, language: str
     ) -> None:


### PR DESCRIPTION
## Summary

Wires the full Swift quality toolchain into generated projects across all four generators (sub-issue of the Swift epic; foundation #351 already merged):

- **precommit.py** — `swift` config with swift-format + SwiftLint (`--strict`) as `language: system` local hooks (apple/swift-format ships no pre-commit manifest; realm/SwiftLint's remote hook builds from source via SPM), plus shared gitleaks/shellcheck/detect-secrets blocks. 17 hooks total.
- **scripts.py** — `_generate_swift_scripts` emitting check-all/format/lint/test/security: `swift test --enable-code-coverage` gated ≥90% via the llvm-cov codecov JSON, SwiftLint `cyclomatic_complexity` ≤10, Periphery for dead code (warn-and-skip when missing so a fresh clone passes day one, with a tighten-me comment). The `generate()` if/elif chain became a dispatch table to stay xenon grade A — the same #342 refactor.
- **metrics.py** — `swift` in `LANGUAGE_TOOLS` (llvm-cov coverage, muter mutation, SwiftLint complexity, swift-docc docs, swiftlint+periphery security).
- **architecture.py** — `swift` via `.swiftlint-architecture.yml` custom regex rules enforcing the same layer matrix as Go/Rust, mirroring the #342 pattern, with the enforcement limits documented in the generated config: regex over source text (not a resolved dependency graph), layers must be separate SPM modules, cycle prevention attributed to SPM itself.

Parity/truthfulness riders: `cli.py` architecture step now includes swift; the generated Swift README truthfully checkmarks the wired tooling and keeps only CI/CD under "Planned" (boundary with #353).

## Test plan

- TDD: **47 new tests**, including parse-validation of all three generated configs (`yaml.safe_load`) and `pre-commit validate-config` / `bash -n` sanity on generated artifacts.
- `./scripts/check-all.sh`: all 7 checks pass — **2154 tests passed, 1 pre-existing platform skip**, coverage **94.65%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#353 (CI pipeline), #354 (tests/coverage), #355 (docs) are intentionally untouched. Noted for a follow-up: `_get_setup_instructions` could add the `brew install swiftlint swift-format periphery` line alongside #353/#355.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
