### PR TITLE
test(swift): fill unit/integration/e2e coverage gaps (#354)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ This module provides:
 from collections.abc import Generator
 import os
 from pathlib import Path
+import sys
 
 import pytest
 
@@ -44,13 +45,20 @@ def get_env_without_api_keys() -> dict[str, str]:
     This is the canonical helper for API key isolation in subprocess tests.
     See Issue #196.
 
+    Also pins the running interpreter's bin directory to the front of PATH
+    so console scripts (e.g. ``sgsg``) resolve to the environment under
+    test rather than a stale globally-installed copy (#354).
+
     Returns:
-        Environment dict with API keys removed and null keyring backend.
+        Environment dict with API keys removed, null keyring backend, and
+        the current interpreter's bin directory first on PATH.
     """
     env = os.environ.copy()
     env.pop("ANTHROPIC_API_KEY", None)
     env.pop("CLAUDE_API_KEY", None)
     env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    interpreter_bin = str(Path(sys.executable).parent)
+    env["PATH"] = os.pathsep.join([interpreter_bin, env.get("PATH", "")])
     return env
 
 
@@ -63,6 +71,7 @@ LANGUAGE_EXTENSIONS: dict[str, str] = {
     "java": ".java",
     "csharp": ".cs",
     "ruby": ".rb",
+    "swift": ".swift",
 }
 
 
@@ -70,7 +79,7 @@ LANGUAGE_EXTENSIONS: dict[str, str] = {
 def language(request: pytest.FixtureRequest) -> str:
     """Parametrized fixture providing each supported language.
 
-    Yields each of the 7 supported languages as a separate test case.
+    Yields each entry of SUPPORTED_LANGUAGES as a separate test case.
 
     Args:
         request: Pytest fixture request.

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -3,10 +3,10 @@
 Tests the complete sgsg init flow for supported languages, verifying
 that the CLI produces valid project structures end-to-end.
 
-Note: swift, java, csharp, and ruby are supported at the generator level but
+Note: java, csharp, and ruby are supported at the generator level but
 the full CLI pipeline (PreCommitGenerator) only supports python, typescript,
-go, and rust currently. Those 4 languages are tested at the unit/integration
-level via test_language_generators.py.
+go, rust, and swift currently. The generator-level languages are tested at
+the unit/integration level via test_language_generators.py.
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.
@@ -23,7 +23,7 @@ import pytest
 from tests.conftest import get_env_without_api_keys
 
 # Languages fully supported in the CLI pipeline (all generators)
-CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust")
+CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust", "swift")
 
 # Expected key files per language that sgsg init should create
 EXPECTED_KEY_FILES: dict[str, list[str]] = {
@@ -54,6 +54,14 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "src/main.rs",
         "Cargo.toml",
         "tests/integration_test.rs",
+        "README.md",
+    ],
+    "swift": [
+        "Sources/test_project/TestProjectApp.swift",
+        "Sources/test_project/ContentView.swift",
+        "Package.swift",
+        "Tests/test_projectTests/test_projectTests.swift",
+        ".swiftlint.yml",
         "README.md",
     ],
 }

--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -92,7 +92,7 @@ class TestPreCommitGeneratorIntegration:
     def test_multiple_languages_workflow(self, mock_orchestrator: Mock) -> None:
         """Test generating configs for multiple languages."""
         generator = PreCommitGenerator(mock_orchestrator)
-        languages = ["python", "typescript", "go", "rust"]
+        languages = ["python", "typescript", "go", "rust", "swift"]
 
         for language in languages:
             config = GenerationConfig(

--- a/tests/integration/generators/test_swift_init_integration.py
+++ b/tests/integration/generators/test_swift_init_integration.py
@@ -1,0 +1,178 @@
+"""Integration tests for ``sgsg init --language swift`` (#354).
+
+Runs the full init flow once via the Typer CliRunner and asserts the
+generated Swift (watchOS) project tree and the ``Package.swift`` manifest
+contents. The AI orchestrator is patched to ``None`` so no real Anthropic
+API calls are made (Issue #196); the null keyring backend is enforced
+globally by ``tests/conftest.py``.
+
+These tests are structural only — they never invoke the Swift toolchain —
+so they pass on CI runners (ubuntu) where swift/swiftlint/swift-format are
+not installed, mirroring the established multi-language e2e pattern in
+``tests/e2e/test_language_e2e.py``.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green.cli import app
+
+# Project name chosen to exercise the hyphen-to-underscore package-name
+# conversion (wrist-timer -> wrist_timer) and PascalCase type naming
+# (wrist-timer -> WristTimer).
+_PROJECT_NAME = "wrist-timer"
+_PACKAGE_NAME = "wrist_timer"
+_TYPE_NAME = "WristTimer"
+
+
+@pytest.fixture(scope="module")
+def swift_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Run ``sgsg init --language swift`` once and return the project root.
+
+    Args:
+        tmp_path_factory: Pytest factory for a module-scoped temp directory.
+
+    Returns:
+        Path to the generated project directory.
+    """
+    output_dir = tmp_path_factory.mktemp("swift-init")
+    runner = CliRunner()
+    with patch(
+        "start_green_stay_green.cli._initialize_orchestrator", return_value=None
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                _PROJECT_NAME,
+                "--language",
+                "swift",
+                "--output-dir",
+                str(output_dir),
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0, f"sgsg init failed for swift: {result.output}"
+    return output_dir / _PROJECT_NAME
+
+
+class TestSwiftInitTree:
+    """Assert the generated Swift project tree."""
+
+    def test_project_directory_created(self, swift_project: Path) -> None:
+        """Init creates the project directory."""
+        assert swift_project.is_dir()
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "Package.swift",
+            f"Sources/{_PACKAGE_NAME}/{_TYPE_NAME}App.swift",
+            f"Sources/{_PACKAGE_NAME}/ContentView.swift",
+            f"Tests/{_PACKAGE_NAME}Tests/{_PACKAGE_NAME}Tests.swift",
+            ".swiftlint.yml",
+            ".pre-commit-config.yaml",
+            ".github/workflows/ci.yml",
+            "plans/architecture/.swiftlint-architecture.yml",
+            "scripts/check-all.sh",
+            "scripts/test.sh",
+            "scripts/lint.sh",
+            "scripts/format.sh",
+            "scripts/security.sh",
+            "README.md",
+        ],
+    )
+    def test_expected_file_generated(
+        self, swift_project: Path, relative_path: str
+    ) -> None:
+        """Every expected Swift project file exists and is non-empty."""
+        file_path = swift_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+
+class TestSwiftInitManifest:
+    """Assert the generated ``Package.swift`` manifest contents."""
+
+    def test_manifest_declares_swift_tools_version(self, swift_project: Path) -> None:
+        """The manifest pins swift-tools-version 5.9 on its first line."""
+        first_line = (swift_project / "Package.swift").read_text().splitlines()[0]
+        assert first_line == "// swift-tools-version:5.9"
+
+    def test_manifest_names_package_in_pascal_case(self, swift_project: Path) -> None:
+        """The package name is the PascalCase form of the project name."""
+        manifest = (swift_project / "Package.swift").read_text()
+        assert f'name: "{_TYPE_NAME}",' in manifest
+
+    def test_manifest_targets_watchos_v10(self, swift_project: Path) -> None:
+        """The manifest declares the watchOS v10 platform."""
+        manifest = (swift_project / "Package.swift").read_text()
+        assert ".watchOS(.v10)" in manifest
+
+    def test_manifest_declares_main_target(self, swift_project: Path) -> None:
+        """The manifest declares the package-named source target."""
+        manifest = (swift_project / "Package.swift").read_text()
+        assert f'.target(name: "{_PACKAGE_NAME}")' in manifest
+
+    def test_manifest_declares_test_target_with_dependency(
+        self, swift_project: Path
+    ) -> None:
+        """The test target depends on the main target."""
+        manifest = (swift_project / "Package.swift").read_text()
+        assert f'name: "{_PACKAGE_NAME}Tests"' in manifest
+        assert f'dependencies: ["{_PACKAGE_NAME}"]' in manifest
+
+
+class TestSwiftInitSources:
+    """Assert the generated Swift source and test files."""
+
+    def test_app_entry_point_is_watchos_gated(self, swift_project: Path) -> None:
+        """@main is gated to watchOS so the macOS test host can link."""
+        app_source = (
+            swift_project / "Sources" / _PACKAGE_NAME / f"{_TYPE_NAME}App.swift"
+        ).read_text()
+        assert "#if os(watchOS)" in app_source
+        assert "@main" in app_source
+        assert f"struct {_TYPE_NAME}App: App" in app_source
+
+    def test_generated_tests_use_xctest(self, swift_project: Path) -> None:
+        """The generated test file imports XCTest and the package target."""
+        test_source = (
+            swift_project
+            / "Tests"
+            / f"{_PACKAGE_NAME}Tests"
+            / f"{_PACKAGE_NAME}Tests.swift"
+        ).read_text()
+        assert "import XCTest" in test_source
+        assert f"@testable import {_PACKAGE_NAME}" in test_source
+        assert f"final class {_TYPE_NAME}Tests: XCTestCase" in test_source
+
+
+class TestSwiftInitQualityConfigs:
+    """Assert the generated quality-tooling configuration files."""
+
+    def test_precommit_config_wires_swift_hooks(self, swift_project: Path) -> None:
+        """The pre-commit config contains strict swiftlint and swift-format."""
+        config = yaml.safe_load((swift_project / ".pre-commit-config.yaml").read_text())
+        hooks = {hook["id"]: hook for repo in config["repos"] for hook in repo["hooks"]}
+        assert hooks["swiftlint"]["entry"] == "swiftlint lint --strict"
+        assert hooks["swift-format"]["entry"] == "swift-format format --in-place"
+        assert "gitleaks" in hooks
+        assert "detect-secrets" in hooks
+
+    def test_swiftlint_config_is_parseable_and_scoped(
+        self, swift_project: Path
+    ) -> None:
+        """.swiftlint.yml parses as YAML and lints Sources and Tests."""
+        config = yaml.safe_load((swift_project / ".swiftlint.yml").read_text())
+        assert config["included"] == ["Sources", "Tests"]
+
+    def test_test_script_enables_coverage(self, swift_project: Path) -> None:
+        """scripts/test.sh runs swift test with code coverage enabled."""
+        test_script = (swift_project / "scripts" / "test.sh").read_text()
+        assert "swift test --enable-code-coverage" in test_script

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -9,7 +9,7 @@ from start_green_stay_green.cli import _venv_activation_command
 
 # Languages exercised by the per-language common-tail tests; "java" covers
 # the unknown-language default path.
-ALL_LANGUAGES = ("python", "typescript", "go", "rust", "java")
+ALL_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "java")
 
 
 class TestVenvActivationCommand:


### PR DESCRIPTION
## Summary

Survey-first execution: most of this issue's literal task list already landed with #351–#353 (extensive Swift unit tests across all 9 touched generators, swift in every multi-language parametrize list, coverage at 94.65%). This PR fills the real gaps:

- **New** `tests/integration/generators/test_swift_init_integration.py` — 25 tests running a full CliRunner `init -l swift` and asserting the generated tree (14 parametrized file cases), exact `Package.swift` manifest contents, the watchOS-gated `@main` entry, XCTest scaffold, strict swiftlint/swift-format hooks, and the coverage-enabled `test.sh`. Structural-only (no Swift toolchain invoked), mirroring the established cross-language pattern so it passes on ubuntu CI — no skip/skipif anywhere.
- **e2e matrix** — swift added to `CLI_SUPPORTED_LANGUAGES`/`EXPECTED_KEY_FILES` in `test_language_e2e.py`; a stale docstring claiming the CLI couldn't generate swift was corrected (verified against a real end-to-end run).
- swift added to the remaining matrices: `test_precommit_integration.py`, `ALL_LANGUAGES` in `test_cli_setup_instructions.py`, `LANGUAGE_EXTENSIONS` in `conftest.py`.
- **Hermeticity bug fixed (test infra, root cause)**: e2e tests invoked bare `sgsg` from ambient PATH — locally a stale Homebrew install was being tested and the existing 4-language tests passed by luck. `get_env_without_api_keys()` now pins the interpreter-under-test's bin dir to the front of PATH. Zero production code changed.

## Mutation testing (honest status)

`scripts/mutation.sh --paths-to-mutate` cannot run: mutmut 3.5.0 crashes on the repo's 2.x-style `[tool.mutmut]` config (`tests_dir` str-vs-list TypeError) and the script then exits 0 vacuously. Even a scoped run is impossible without out-of-scope config changes — no score is claimed. This deserves a follow-up tooling issue (noted here since issue creation is permission-gated in this session).

## Test plan

- Unit: 2040 passed, coverage **94.65%** (≥90% gate). Integration + e2e: 167 passed, 1 pre-existing unrelated platform skip.
- `./scripts/check-all.sh`: all 7 checks pass.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
