### PR TITLE
feat(kotlin): generate CI pipeline with JDK matrix and Kover gate (#358)

### DIFF
--- a/reference/ci/kotlin.yml
+++ b/reference/ci/kotlin.yml
@@ -10,69 +10,178 @@ permissions:
   contents: read
   pull-requests: write
 
+# Runner reality for the generated Wear OS scaffold:
+# - The scaffold is an Android/JVM Gradle project (Jetpack Compose for
+#   Wear OS). Android builds need only a JDK and the Android SDK, both of
+#   which ship on GitHub's ubuntu images (ANDROID_HOME preconfigured,
+#   licenses accepted), so every job runs on ubuntu — no macOS required,
+#   unlike the Swift/watchOS pipeline.
+# - The scaffold deliberately ships WITHOUT the Gradle wrapper: gradlew
+#   and gradle-wrapper.jar are binary artifacts the generator never
+#   writes (see the note in settings.gradle.kts). setup-gradle therefore
+#   provisions a pinned Gradle and every step invokes `gradle` directly.
+#   Once you commit a wrapper (run `gradle wrapper` locally), you may
+#   switch these invocations to ./gradlew and drop the gradle-version
+#   inputs below.
+env:
+  # One Gradle for all jobs — the same version the scaffold README tells
+  # users to materialise locally (AGP 8.7 requires Gradle >= 8.9).
+  GRADLE_VERSION: "8.9"
+
 jobs:
   quality:
     name: Code Quality Checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jdk-version: ["17", "21"]
+    env:
+      # Pinned quality-tool versions. Homebrew — the install path the
+      # generated pre-commit hooks document for local development — was
+      # removed from GitHub's Ubuntu runner images, so CI fetches the
+      # same tools as pinned GitHub release artifacts instead.
+      # GITLEAKS_VERSION matches the rev pinned in .pre-commit-config.yaml.
+      KTLINT_VERSION: "1.5.0"
+      DETEKT_VERSION: "1.23.8"
+      GITLEAKS_VERSION: "8.18.4"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK ${{ matrix.jdk-version }}
+      # JDK 17 matches the jvmToolchain(17) pin in app/build.gradle.kts.
+      # Gradle/dependency caching is handled by setup-gradle below, so
+      # setup-java's own `cache: gradle` input stays off (no double cache).
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.jdk-version }}
-          distribution: 'temurin'
-          cache: 'gradle'
+          distribution: temurin
+          java-version: "17"
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Run ktlint
-        run: ./gradlew ktlintCheck
-
-      - name: Run detekt
-        run: ./gradlew detekt
-
-      - name: Build with Gradle
-        run: ./gradlew build
-
-      - name: Run tests with JaCoCo coverage
-        run: ./gradlew test jacocoTestReport
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
         with:
-          file: ./build/reports/jacoco/test/jacocoTestReport.xml
-          fail_ci_if_error: true
+          gradle-version: ${{ env.GRADLE_VERSION }}
 
-      - name: Check coverage threshold
-        run: ./gradlew jacocoTestCoverageVerification
+      # Every URL below is a static, version-pinned literal — nothing is
+      # discovered at runtime, so no value ever needs to be validated and
+      # exported through GITHUB_ENV/GITHUB_PATH (the documented Actions
+      # env-injection vector that dynamic discovery has to guard against).
+      - name: Install ktlint, detekt, and gitleaks
+        run: |
+          curl -fsSL -o /tmp/ktlint \
+            "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint"
+          chmod +x /tmp/ktlint
+          sudo mv /tmp/ktlint /usr/local/bin/ktlint
+          curl -fsSL -o /tmp/detekt-cli.zip \
+            "https://github.com/detekt/detekt/releases/download/v${DETEKT_VERSION}/detekt-cli-${DETEKT_VERSION}.zip"
+          unzip -q /tmp/detekt-cli.zip -d "$HOME/.detekt"
+          sudo ln -s "$HOME/.detekt/detekt-cli-${DETEKT_VERSION}/bin/detekt" \
+            /usr/local/bin/detekt
+          curl -fsSL -o /tmp/gitleaks.tgz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
 
-  build:
-    name: Build and Verify
+      # Check-mode counterpart of the `ktlint --format` pre-commit hook —
+      # identical to scripts/format.sh without --fix, so a tree that
+      # passed pre-commit locally passes here.
+      - name: Run ktlint format check
+        run: ktlint
+
+      # Same invocation as the detekt pre-commit hook and scripts/lint.sh:
+      # the shared detekt.yml (cyclomatic complexity <= 10 gate +
+      # potential-bugs rules) applied on top of detekt's default config,
+      # with Gradle build output excluded.
+      - name: Run detekt static analysis
+        run: detekt --config detekt.yml --build-upon-default-config --excludes '**/build/**'
+
+      # Secret-scanning parity with the gitleaks pre-commit hook.
+      - name: Run gitleaks secret scan
+        run: gitleaks detect --source . --no-banner --redact
+
+      # Coverage gate — the same Gradle invocation as scripts/test.sh
+      # --coverage. One invocation, one task graph: koverXmlReportDebug
+      # (the report the metrics dashboard reads) and koverVerifyDebug
+      # (the gate) share a single testDebugUnitTest execution, so the
+      # suite never runs twice for one coverage measurement. The >=90%
+      # line bound lives in app/build.gradle.kts
+      # (kover { ... minBound(90) }) as the single source of truth and is
+      # deliberately NOT repeated here — raise it there, not in CI.
+      - name: Run tests with Kover coverage gate
+        run: gradle koverXmlReportDebug koverVerifyDebug
+
+  test:
+    name: JDK ${{ matrix.java-version }} Tests
+    runs-on: ubuntu-latest
+    strategy:
+      # Run every leg to completion: the point of a version matrix is to
+      # see exactly which JDKs fail, not just the first one.
+      fail-fast: false
+      matrix:
+        # The Kotlin version (2.0.21) and the bytecode target
+        # (jvmToolchain(17)) are pinned by the generated Gradle manifests
+        # — project decisions, not CI inputs — so the meaningful matrix
+        # axis is the JVM that runs Gradle/AGP itself: both current JDK
+        # LTS releases. On the 21 leg, Gradle resolves the
+        # jvmToolchain(17) compile JDK from the Temurin 17 preinstalled
+        # under /usr/lib/jvm on the runner image (a location on Gradle's
+        # toolchain auto-detection path).
+        java-version: ["17", "21"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ env.GRADLE_VERSION }}
+
+      - name: Show toolchain versions
+        run: |
+          java -version
+          gradle --version
+
+      # Runs every unit-test variant on the matrix JVM (the quality job
+      # already gates debug-variant coverage; this job's axis is JDK
+      # compatibility, not coverage, so no Kover tasks here).
+      - name: Run unit tests
+        run: gradle test
+
+  wear:
+    name: Wear OS APK Build
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
-          distribution: 'temurin'
-          cache: 'gradle'
+          distribution: temurin
+          java-version: "17"
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ env.GRADLE_VERSION }}
 
-      - name: Build with Gradle
-        run: ./gradlew assemble
-
-      - name: Verify artifacts
-        run: ./gradlew check
+      # assembleDebug compiles the Compose-for-Wear-OS sources against
+      # the Android SDK and packages the wear APK — the AndroidManifest's
+      # watch uses-feature and standalone metadata make this the actual
+      # Wear OS artifact — proving the scaffold builds for its target.
+      #
+      # No emulator (instrumentation) tests run here, honestly: the
+      # scaffold generates no androidTest source set, so an emulator job
+      # would have nothing to execute, and Wear OS AVD boots on shared
+      # runners are slow and nondeterministic. When you add androidTest
+      # sources, wire an emulator job (e.g. reactivecircus/
+      # android-emulator-runner with a wear-os system image) and make it
+      # required only once it runs deterministically.
+      - name: Assemble the Wear OS debug APK
+        run: gradle assembleDebug

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1117,9 +1117,10 @@ def _generate_ci_step(
     only used to opt into the legacy AI-tuned path for backward
     compatibility. ``project_name`` is forwarded to the template
     renderer so any ``<<% project_name %>>`` placeholder lands with
-    the real value rather than the empty string. Languages CIGenerator
-    does not support yet (kotlin CI lands with #358) are skipped with an
-    informational message instead of aborting init.
+    the real value rather than the empty string. Languages without a
+    CIGenerator config are skipped with an informational message instead
+    of aborting init — with kotlin wired in (#358) every CLI language
+    has one, so this guard is defensive for future additions.
     """
     if language not in CI_LANGUAGE_CONFIGS:
         console.print(

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -86,6 +86,30 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         "supported_versions": ["5.9", "5.10", "6.0"],
         "package_manager": "spm",
     },
+    "kotlin": {
+        # JUnit on the plain JVM via Gradle; coverage is measured and
+        # gated by Kover (koverVerifyDebug), whose >=90% bound lives in
+        # the generated app/build.gradle.kts — the single source of
+        # truth, deliberately not duplicated in the workflow.
+        "test_framework": "junit",
+        # ktlint genuinely is both a linter and a formatter (like ruff,
+        # eslint, and rubocop), so it appears in both lists. detekt's
+        # potential-bugs rules serve security duty too, but it is listed
+        # once (here) so tool-install consumers don't double-install it.
+        "linters": ["ktlint", "detekt"],
+        "formatters": ["ktlint"],
+        # gitleaks covers secret scanning (shared with pre-commit) and
+        # OWASP dependency-check covers dependency CVE scanning
+        # (scripts/security.sh).
+        "security_tools": ["gitleaks", "dependency-check"],
+        # JDK LTS releases the CI matrix runs Gradle/AGP on. The Kotlin
+        # version (2.0.21) is pinned by the generated root
+        # build.gradle.kts — a project decision, not a CI input — and
+        # bytecode always targets 17 via jvmToolchain(17), so the JVM
+        # executing the build is the meaningful matrix axis.
+        "supported_versions": ["17", "21"],
+        "package_manager": "gradle",
+    },
     "java": {
         "test_framework": "junit",
         "linters": ["checkstyle"],
@@ -164,7 +188,7 @@ class CIGenerator(BaseGenerator):
                 deterministic template-based path
                 (``generate_workflow_from_template``).
             language: Target language (python, typescript, go, rust, swift,
-                java, csharp, ruby).
+                kotlin, java, csharp, ruby).
             framework: Optional framework (e.g., FastAPI, Express, Gin).
             reference_dir: Directory containing ``<language>.yml``
                 reference templates. Defaults to ``reference/ci/`` shipped

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -5,11 +5,11 @@ that the CLI produces valid project structures end-to-end.
 
 Note: java, csharp, and ruby are supported at the generator level but the
 quality-tooling pipeline steps (PreCommitGenerator, scripts, CI) skip
-them (#356). Kotlin gained its quality tooling with #357 but still lacks
-a CI workflow (#358), so it stays out of CLI_SUPPORTED_LANGUAGES below;
-its full init flow is covered at the integration level by
-test_kotlin_init_integration.py (and test_language_generators.py covers
-the generator-only languages).
+them (#356). Kotlin gained its quality tooling with #357 and its CI
+workflow with #358, completing the pipeline, so it joins
+CLI_SUPPORTED_LANGUAGES below (test_kotlin_init_integration.py covers
+its full init flow in depth and test_language_generators.py covers the
+generator-only languages).
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.
@@ -26,7 +26,7 @@ import pytest
 from tests.conftest import get_env_without_api_keys
 
 # Languages fully supported in the CLI pipeline (all generators)
-CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust", "swift")
+CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "kotlin")
 
 # Expected key files per language that sgsg init should create
 EXPECTED_KEY_FILES: dict[str, list[str]] = {
@@ -65,6 +65,18 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "Package.swift",
         "Tests/test_projectTests/test_projectTests.swift",
         ".swiftlint.yml",
+        "README.md",
+    ],
+    "kotlin": [
+        "settings.gradle.kts",
+        "build.gradle.kts",
+        "gradle.properties",
+        "app/build.gradle.kts",
+        "app/src/main/AndroidManifest.xml",
+        "app/src/main/kotlin/com/example/test_project/MainActivity.kt",
+        "app/src/test/kotlin/com/example/test_project/GreetingTest.kt",
+        "detekt.yml",
+        ".github/workflows/ci.yml",
         "README.md",
     ],
 }

--- a/tests/integration/generators/test_kotlin_init_integration.py
+++ b/tests/integration/generators/test_kotlin_init_integration.py
@@ -11,9 +11,10 @@ toolchain — so they pass on CI runners where the Android SDK and Gradle
 are not installed, mirroring ``test_swift_init_integration.py`` (#354).
 
 With #357 the quality toolchain (pre-commit config, quality scripts,
-metrics dashboard, architecture rules) is generated for Kotlin; only the
-CI workflow remains deferred (#358), so this suite locks in the presence
-of the tooling artifacts and the *absence* of ci.yml.
+metrics dashboard, architecture rules) landed, and with #358 the CI
+workflow (.github/workflows/ci.yml) is generated too, so this suite
+locks in the presence of all tooling artifacts; only the wrapper
+binaries remain forbidden output.
 """
 
 from pathlib import Path
@@ -107,6 +108,8 @@ class TestKotlinInitTree:
             "scripts/security.sh",
             "plans/architecture/ArchitectureTest.kt",
             "plans/architecture/run-check.sh",
+            # CI pipeline (#358) is now generated alongside the tooling.
+            ".github/workflows/ci.yml",
         ],
     )
     def test_quality_tooling_artifact_generated(
@@ -120,8 +123,6 @@ class TestKotlinInitTree:
     @pytest.mark.parametrize(
         "relative_path",
         [
-            # CI is #358 — it must not be generated yet.
-            ".github/workflows/ci.yml",
             # Binary wrapper artifacts must never be scaffolded.
             "gradlew",
             "gradle/wrapper/gradle-wrapper.jar",
@@ -130,7 +131,7 @@ class TestKotlinInitTree:
     def test_out_of_scope_artifact_not_generated(
         self, kotlin_project: Path, relative_path: str
     ) -> None:
-        """The scaffold must not emit #358 artifacts or wrapper binaries."""
+        """The scaffold must never emit wrapper binaries."""
         assert not (kotlin_project / relative_path).exists()
 
 
@@ -179,6 +180,37 @@ class TestKotlinInitQualityTooling:
         build = (kotlin_project / "app" / "build.gradle.kts").read_text()
         assert 'id("org.jetbrains.kotlinx.kover")' in build
         assert "minBound(90)" in build
+
+
+class TestKotlinInitCIWorkflow:
+    """Assert the generated CI workflow matches the scaffold (#358)."""
+
+    def test_ci_workflow_parses_and_declares_kotlin_jobs(
+        self, kotlin_project: Path
+    ) -> None:
+        """ci.yml parses as YAML and carries the quality/test/wear jobs."""
+        content = (kotlin_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "Kotlin Quality Checks"
+        assert set(parsed["jobs"]) == {"quality", "test", "wear"}
+
+    def test_ci_workflow_never_invokes_the_missing_wrapper(
+        self, kotlin_project: Path
+    ) -> None:
+        """CI provisions Gradle itself: the scaffold ships no gradlew.
+
+        Run commands are parsed (comments may mention the wrapper when
+        documenting why the workflow avoids it).
+        """
+        content = (kotlin_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        run_commands = [
+            step.get("run", "")
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+        ]
+        assert not any("gradlew" in cmd for cmd in run_commands)
+        assert "gradle/actions/setup-gradle" in content
 
 
 class TestKotlinInitManifests:

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -10,6 +10,7 @@ Comprehensive tests for CI pipeline generation covering:
 """
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 from jinja2 import UndefinedError
@@ -24,6 +25,7 @@ from start_green_stay_green.ai.orchestrator import TokenUsage
 from start_green_stay_green.generators.ci import CIGenerator
 from start_green_stay_green.generators.ci import CIWorkflow
 from start_green_stay_green.generators.ci import LANGUAGE_CONFIGS
+from start_green_stay_green.utils.kotlin import GRADLE_WRAPPER_VERSION
 
 
 class TestCIWorkflowDataClass:
@@ -1174,10 +1176,52 @@ jobs:
         """Test Swift package_manager is exactly spm."""
         assert LANGUAGE_CONFIGS["swift"]["package_manager"] == "spm"
 
+    # LANGUAGE_CONFIGS Exact Value Tests - Kotlin
+    def test_kotlin_test_framework_exact(self) -> None:
+        """Test Kotlin test_framework is exactly junit."""
+        assert LANGUAGE_CONFIGS["kotlin"]["test_framework"] == "junit"
+
+    def test_kotlin_linters_exact(self) -> None:
+        """Test Kotlin linters list is exact."""
+        assert LANGUAGE_CONFIGS["kotlin"]["linters"] == ["ktlint", "detekt"]
+
+    def test_kotlin_formatters_exact(self) -> None:
+        """Test Kotlin formatters list is exact.
+
+        ktlint genuinely is both a linter and a formatter (like ruff,
+        eslint, and rubocop in the other configs), so it appears in both
+        lists; that is established precedent, unlike double-listing a
+        tool under security_tools (the Swift PR #414 lesson).
+        """
+        assert LANGUAGE_CONFIGS["kotlin"]["formatters"] == ["ktlint"]
+
+    def test_kotlin_security_tools_exact(self) -> None:
+        """Test Kotlin security_tools list is exact.
+
+        detekt's potential-bugs rules serve security duty too but it is
+        listed only under linters so tool-install consumers don't
+        double-install it (the Swift PR #414 review lesson).
+        """
+        expected = ["gitleaks", "dependency-check"]
+        assert LANGUAGE_CONFIGS["kotlin"]["security_tools"] == expected
+
+    def test_kotlin_supported_versions_exact(self) -> None:
+        """Test Kotlin supported_versions are the JDK LTS releases.
+
+        The Kotlin version (2.0.21) is pinned by the generated root
+        build.gradle.kts — a project decision, not a CI input — so the
+        meaningful matrix axis is the JVM running Gradle/AGP.
+        """
+        assert LANGUAGE_CONFIGS["kotlin"]["supported_versions"] == ["17", "21"]
+
+    def test_kotlin_package_manager_exact(self) -> None:
+        """Test Kotlin package_manager is exactly gradle."""
+        assert LANGUAGE_CONFIGS["kotlin"]["package_manager"] == "gradle"
+
     # Config Keys Exact Tests
-    def test_language_configs_has_exactly_8_languages(self) -> None:
-        """Test LANGUAGE_CONFIGS has exactly 8 supported languages."""
-        assert len(LANGUAGE_CONFIGS) == 8
+    def test_language_configs_has_exactly_9_languages(self) -> None:
+        """Test LANGUAGE_CONFIGS has exactly 9 supported languages."""
+        assert len(LANGUAGE_CONFIGS) == 9
 
     def test_language_configs_contains_python(self) -> None:
         """Test LANGUAGE_CONFIGS contains python key."""
@@ -1210,6 +1254,10 @@ jobs:
     def test_language_configs_contains_swift(self) -> None:
         """Test LANGUAGE_CONFIGS contains swift key."""
         assert "swift" in LANGUAGE_CONFIGS
+
+    def test_language_configs_contains_kotlin(self) -> None:
+        """Test LANGUAGE_CONFIGS contains kotlin key."""
+        assert "kotlin" in LANGUAGE_CONFIGS
 
     def test_all_configs_have_test_framework_key(self) -> None:
         """Test all language configs have test_framework key."""
@@ -1275,7 +1323,7 @@ class TestCIGeneratorTemplatePath:
 
     @pytest.mark.parametrize(
         "language",
-        ["python", "typescript", "go", "rust", "swift"],
+        ["python", "typescript", "go", "rust", "swift", "kotlin"],
     )
     def test_generate_from_template_for_supported_language(self, language: str) -> None:
         """Each canonical language renders without an orchestrator."""
@@ -1564,3 +1612,235 @@ class TestSwiftReferenceTemplate:
         assert "xcodebuild -list -json" in swift_workflow.content
         # The old stub hardcoded a placeholder scheme that could never exist.
         assert "YourScheme" not in swift_workflow.content
+
+
+def _all_run_commands(parsed_workflow: dict[str, Any]) -> list[str]:
+    """Collect every step ``run`` command across all workflow jobs.
+
+    Parsing (instead of scanning raw content) lets assertions target the
+    commands that actually execute while YAML comments stay free to
+    document decisions honestly — the PR #414 review noted raw string
+    assertions are brittle exactly because they cannot tell the two
+    apart.
+
+    Args:
+        parsed_workflow: ``yaml.safe_load`` result for a workflow.
+
+    Returns:
+        Every non-empty ``run`` value, in job/step order.
+    """
+    return [
+        step["run"]
+        for job in parsed_workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("run")
+    ]
+
+
+class TestKotlinReferenceTemplate:
+    """Tests for the Kotlin reference CI workflow (Issue #358).
+
+    The Kotlin scaffold is a Jetpack Compose for Wear OS Android app
+    built with Gradle (Kotlin DSL), so every assertion reflects what can
+    actually run: Android/JVM builds work on GitHub's ubuntu runners
+    (Android SDK and Temurin JDKs preinstalled, no macOS needed unlike
+    Swift), the scaffold deliberately ships no Gradle wrapper binary,
+    and the >=90% coverage bound lives in the generated
+    app/build.gradle.kts Kover block — not in the workflow.
+    """
+
+    @pytest.fixture
+    def kotlin_workflow(self) -> CIWorkflow:
+        """Render the deterministic Kotlin reference workflow."""
+        return CIGenerator(language="kotlin").generate_workflow_from_template()
+
+    def test_workflow_is_valid_yaml(self, kotlin_workflow: CIWorkflow) -> None:
+        """Rendered workflow parses with yaml.safe_load and validates."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        assert kotlin_workflow.is_valid
+        assert isinstance(parsed, dict)
+        assert parsed["name"] == "Kotlin Quality Checks"
+
+    def test_workflow_has_quality_test_and_wear_jobs(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """Workflow declares the quality, test, and wear jobs."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        assert set(parsed["jobs"]) == {"quality", "test", "wear"}
+
+    def test_all_jobs_run_on_ubuntu(self, kotlin_workflow: CIWorkflow) -> None:
+        """Every job runs on ubuntu: Android/JVM builds need no macOS."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        for name, job in parsed["jobs"].items():
+            assert job["runs-on"] == "ubuntu-latest", f"{name} must run on ubuntu"
+
+    def test_jdk_matrix_does_not_fail_fast(self, kotlin_workflow: CIWorkflow) -> None:
+        """Matrix legs run to completion so every failing JDK is seen."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        assert parsed["jobs"]["test"]["strategy"]["fail-fast"] is False
+
+    def test_jdk_matrix_matches_language_config_versions(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """The test job matrixes over the LANGUAGE_CONFIGS JDK versions."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        matrix = parsed["jobs"]["test"]["strategy"]["matrix"]
+        assert matrix["java-version"] == (
+            LANGUAGE_CONFIGS["kotlin"]["supported_versions"]
+        )
+
+    def test_setup_actions_are_pinned_to_majors(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """checkout, setup-java, and setup-gradle are pinned majors."""
+        content = kotlin_workflow.content
+        assert "actions/checkout@v4" in content
+        assert "actions/setup-java@v4" in content
+        assert "gradle/actions/setup-gradle@v4" in content
+
+    def test_workflow_provisions_gradle_instead_of_missing_wrapper(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """CI never invokes the wrapper the scaffold deliberately omits.
+
+        The generator never writes binary artifacts, so gradlew and
+        gradle-wrapper.jar do not exist in a fresh project; any
+        ``./gradlew`` (or ``chmod +x gradlew``) step would fail on the
+        first run. setup-gradle provisions a pinned Gradle matching
+        utils/kotlin.GRADLE_WRAPPER_VERSION (the version the scaffold
+        README tells users to materialise) and steps call ``gradle``.
+        Assertions parse the workflow so YAML comments may still
+        document the wrapper situation honestly.
+        """
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        # Covers both `./gradlew ...` invocations and the old stub's
+        # `chmod +x gradlew` step.
+        assert not any("gradlew" in cmd for cmd in run_commands)
+        assert parsed["env"]["GRADLE_VERSION"] == GRADLE_WRAPPER_VERSION
+        gradle_setups = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "setup-gradle" in step.get("uses", "")
+        ]
+        assert gradle_setups
+        for step in gradle_setups:
+            assert step["with"]["gradle-version"] == "${{ env.GRADLE_VERSION }}"
+
+    def test_coverage_gate_runs_kover_once_without_duplicating_bound(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """One Gradle invocation gates coverage; the bound stays in Gradle.
+
+        koverXmlReportDebug and koverVerifyDebug share a single
+        testDebugUnitTest execution inside one task graph (the Swift
+        PR #414 no-double-test-run lesson), and the >=90% bound lives
+        only in app/build.gradle.kts (kover { ... minBound(90) }) so the
+        threshold can never drift between the manifest and the workflow.
+        Run commands are parsed so comments may reference the bound.
+        """
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert any(
+            cmd.strip() == "gradle koverXmlReportDebug koverVerifyDebug"
+            for cmd in run_commands
+        )
+        assert not any("minBound" in cmd for cmd in run_commands)
+        assert not any("90" in cmd for cmd in run_commands)
+
+    def test_quality_job_does_not_rerun_the_test_suite(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """No standalone test step duplicates the Kover coverage run."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = [
+            step.get("run", "") for step in parsed["jobs"]["quality"]["steps"]
+        ]
+        kover_runs = [cmd for cmd in run_commands if "koverVerifyDebug" in cmd]
+        assert len(kover_runs) == 1
+        assert not any(cmd.strip() == "gradle test" for cmd in run_commands)
+
+    def test_quality_job_mirrors_precommit_lint_and_format_hooks(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """CI runs the same ktlint/detekt checks as pre-commit."""
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = [
+            step.get("run", "") for step in parsed["jobs"]["quality"]["steps"]
+        ]
+        # Check-mode counterpart of the `ktlint --format` pre-commit hook
+        # (identical to scripts/format.sh without --fix).
+        assert any(cmd.strip() == "ktlint" for cmd in run_commands)
+        # Same invocation as the detekt pre-commit hook and scripts/lint.sh:
+        # the shared detekt.yml on top of detekt's default config.
+        assert (
+            "detekt --config detekt.yml --build-upon-default-config"
+            in kotlin_workflow.content
+        )
+        assert "--excludes '**/build/**'" in kotlin_workflow.content
+
+    def test_quality_job_runs_gitleaks_secret_scan(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """CI runs gitleaks at the same version pre-commit pins."""
+        content = kotlin_workflow.content
+        assert "gitleaks detect" in content
+        # Parity with the rev pinned in the generated .pre-commit-config
+        # (https://github.com/gitleaks/gitleaks rev v8.18.4).
+        assert 'GITLEAKS_VERSION: "8.18.4"' in content
+
+    def test_quality_tools_are_version_pinned_downloads(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """ktlint/detekt come from pinned GitHub release downloads.
+
+        Homebrew (the documented local install path) was removed from
+        GitHub's Ubuntu runner images, so the workflow fetches pinned
+        release binaries instead — deterministically, never "latest".
+        """
+        content = kotlin_workflow.content
+        assert "KTLINT_VERSION" in content
+        assert "DETEKT_VERSION" in content
+        assert "releases/download" in content
+        assert "releases/latest" not in content
+        assert "brew install" not in content
+
+    def test_wear_job_assembles_debug_apk_without_emulator(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """The wear job builds the Wear OS APK; no emulator steps exist.
+
+        The scaffold generates no androidTest source set, so an emulator
+        job would have nothing to execute; assembleDebug is the honest
+        deterministic proof the Wear OS target builds. The emulator
+        stance is documented in YAML comments, not dead steps.
+        """
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        wear_commands = [
+            step.get("run", "") for step in parsed["jobs"]["wear"]["steps"]
+        ]
+        assert any("gradle assembleDebug" in cmd for cmd in wear_commands)
+        uses = [
+            step.get("uses", "")
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+        ]
+        assert not any("emulator" in action for action in uses)
+
+    def test_workflow_writes_nothing_to_github_env(
+        self, kotlin_workflow: CIWorkflow
+    ) -> None:
+        """Nothing discovered at runtime is exported to GITHUB_ENV.
+
+        The Swift PR #414 review flagged unvalidated GITHUB_ENV writes
+        as the documented Actions env-injection vector. The Kotlin
+        workflow sidesteps the vector entirely: every value (versions,
+        tasks, paths) is a static literal, so there is no dynamic
+        discovery and no GITHUB_ENV/GITHUB_PATH write to guard. Run
+        commands are parsed so comments may explain that decision.
+        """
+        parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
+        assert not any("GITHUB_PATH" in cmd for cmd in run_commands)

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -320,7 +320,7 @@ class TestGeneratorOnlyLanguagePipelineGates:
     but no quality-tooling support — instead of crashing init, the tooling
     steps must no-op with an informational message. Kotlin graduated from
     this set when #357 wired its pre-commit/scripts/metrics/architecture
-    tooling; only its CI step (#358) still skips.
+    tooling and #358 wired its CI workflow.
     """
 
     def test_precommit_step_writes_for_kotlin(self, tmp_path: Path) -> None:
@@ -359,11 +359,13 @@ class TestGeneratorOnlyLanguagePipelineGates:
 
         assert not (tmp_path / "scripts").exists()
 
-    def test_ci_step_skips_kotlin_without_workflow(self, tmp_path: Path) -> None:
-        """No ci.yml is written for kotlin (CI generation is #358)."""
+    def test_ci_step_writes_kotlin_workflow(self, tmp_path: Path) -> None:
+        """The kotlin CI workflow is now generated (#358)."""
         cli_mod._generate_ci_step(tmp_path, "my-project", "kotlin", None)
 
-        assert not (tmp_path / ".github" / "workflows" / "ci.yml").exists()
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "Kotlin Quality Checks" in ci_file.read_text()
 
     def test_metrics_step_writes_kotlin_dashboard(self, tmp_path: Path) -> None:
         """The metrics dashboard is now generated for kotlin (#357)."""


### PR DESCRIPTION
## Summary

Generates the GitHub Actions pipeline for Kotlin/Wear OS projects (epic sub-issue; #356 foundation and #357 quality tooling merged):

- **`LANGUAGE_CONFIGS["kotlin"]`** — junit (Kover gates coverage), linters `[ktlint, detekt]`, formatters `[ktlint]` (ruff/eslint dual-listing precedent), security_tools `[gitleaks, dependency-check]` with detekt listed once (the #414 double-install lesson), JDK `["17", "21"]`, gradle.
- **`reference/ci/kotlin.yml`** rewritten — the prior stub invoked the nonexistent `gradlew`, used JaCoCo, and called Gradle-plugin tasks the scaffold never applies. Three jobs, all ubuntu (Android SDK + Temurin preinstalled; no macOS needed, unlike Swift):
  - **quality**: ktlint check + detekt + gitleaks in exact parity with #357's hooks (gitleaks pinned to the same 8.18.4; tools fetched as version-pinned release artifacts since Homebrew left GitHub Ubuntu images — all URLs verified 200). Coverage gate is a single `gradle koverXmlReportDebug koverVerifyDebug` run; the ≥90% bound lives only in `app/build.gradle.kts`, commented as such — no duplicated threshold, no double test run.
  - **test**: JDK 17/21 matrix with `fail-fast: false`; the matrix axis is the JVM running Gradle/AGP since Kotlin/toolchain versions are pinned project decisions (justified in comments).
  - **wear**: `gradle assembleDebug` packages the Wear APK; no emulator job because the scaffold has no androidTest source set — tighten-up path documented in comments instead of dead steps.
- **Wrapper reality**: every job uses `gradle/actions/setup-gradle@v4` with `gradle-version: 8.9` (matching `utils/kotlin.GRADLE_WRAPPER_VERSION`) and invokes `gradle` directly — nothing references the deliberately-absent wrapper.
- **#414 lessons pre-applied**: the env-injection vector is eliminated rather than guarded — zero dynamic discovery, zero `GITHUB_ENV` writes, test-pinned.

## Test plan

- TDD: **+21 new tests** (exact-value config tests; 14-test `TestKotlinReferenceTemplate` using parse-based assertions on actual `run` commands) and 4 flipped/extended (ci.yml absence→presence; kotlin into e2e `CLI_SUPPORTED_LANGUAGES`, the item #357 deferred here).
- `actionlint reference/ci/kotlin.yml`: clean.
- `./scripts/check-all.sh`: all 7 checks pass — 2182 unit tests, coverage **94.73%**. Integration + e2e green, including a full `init -l kotlin` subprocess run emitting ci.yml.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#359 (tests/coverage depth) and #360 (docs — including the generated README's CI "Planned" flip, matching the Swift precedent) remain.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
