### PR TITLE
test(kotlin): add kotlin to remaining cross-language test matrices (#359)

### DIFF
--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -92,7 +92,7 @@ class TestPreCommitGeneratorIntegration:
     def test_multiple_languages_workflow(self, mock_orchestrator: Mock) -> None:
         """Test generating configs for multiple languages."""
         generator = PreCommitGenerator(mock_orchestrator)
-        languages = ["python", "typescript", "go", "rust", "swift"]
+        languages = ["python", "typescript", "go", "rust", "swift", "kotlin"]
 
         for language in languages:
             config = GenerationConfig(

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -9,7 +9,7 @@ from start_green_stay_green.cli import _venv_activation_command
 
 # Languages exercised by the per-language common-tail tests; "java" covers
 # the unknown-language default path.
-ALL_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "java")
+ALL_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "kotlin", "java")
 
 
 class TestVenvActivationCommand:


### PR DESCRIPTION
## Summary

Survey-first execution mirroring the Swift analogue (#354): the Kotlin epic's #356–#358 PRs already delivered the bulk of this issue's literal task list — a 20-test `init -l kotlin` integration suite (more extensive than Swift's 12), kotlin in every `test_multi_language.py` parametrize list, the e2e `CLI_SUPPORTED_LANGUAGES`/`EXPECTED_KEY_FILES` matrices (#358), and `conftest.py`'s `LANGUAGE_EXTENSIONS` (#356).

The only genuine gaps, both filled:
- `test_precommit_integration.py` multi-language workflow list now includes kotlin.
- `ALL_LANGUAGES` in `test_cli_setup_instructions.py` now includes kotlin (java stays last as the unknown-language default-path probe).

## Mutation testing (honest status)

Verified live in this PR's venv: **mutmut 3.6.0** (resolved by the existing `<4.0.0` range — the version dependabot #418 proposes) **still crashes** on the repo's 2.x-style `[tool.mutmut]` config with the `tests_dir` str-vs-list TypeError, after emitting deprecation warnings pointing at the needed migration (`paths_to_mutate`→`source_paths`, `tests_dir`→`pytest_add_cli_args_test_selection`). So the dependency bump alone won't restore the mutation gate; the config migration plus fixing `mutation.sh`'s vacuous exit-0 remain a separately-tracked tooling gap. No score is claimed.

## Test plan

- `./scripts/check-all.sh`: all 7 checks pass (coverage ≥90% gate green).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.
- Touched suites pass directly: 67 tests across the two files.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
