### PR TITLE
feat(cpp): generate CI pipeline with compiler matrix and lcov gate (#363)

### DIFF
--- a/reference/ci/cpp.yml
+++ b/reference/ci/cpp.yml
@@ -1,0 +1,202 @@
+name: C/C++ Quality Checks
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Runner reality for the generated Tizen native watch-app scaffold:
+# - The CMake/Conan build covers ONLY the pure-logic library and its
+#   Catch2 tests (the #361 two-build split): src/main.cpp needs the
+#   Tizen native SDK and is deliberately outside this build — which is
+#   exactly what makes every job below runnable on a plain ubuntu
+#   runner with a compiler, CMake, and Conan.
+# - The .tpk wearable package is produced by the Tizen Studio CLI
+#   (tizen build-native / tizen package). Tizen Studio is distributed
+#   only as a manual, login-gated GUI installer download — there is no
+#   apt/pipx/headless install path a GitHub-hosted runner could
+#   provision deterministically. Following the Kotlin no-emulator and
+#   Swift no-Periphery-on-Linux precedents, that packaging gap is
+#   documented here instead of emitting `tizen` steps that can never
+#   pass: CI builds and tests everything that IS buildable, on both
+#   major compilers, and packaging stays a local Tizen Studio step
+#   (see README.md).
+env:
+  # Conan provisions Catch2 and generates the CMake toolchain file in
+  # every job — one pinned version for all of them.
+  CONAN_VERSION: "2.29.0"
+
+jobs:
+  quality:
+    name: Code Quality Checks
+    # Pinned to 24.04 (not ubuntu-latest): noble's default apt clang
+    # tooling is LLVM 18, matching the mirrors-clang-format v18.1.8 rev
+    # pinned in the generated .pre-commit-config.yaml, so CI and the
+    # local hooks format/lint with the same major version. A floating
+    # ubuntu-latest could silently change that major and break parity.
+    runs-on: ubuntu-24.04
+    env:
+      # Pinned quality-tool versions. GITLEAKS_VERSION matches the rev
+      # pinned in .pre-commit-config.yaml; lizard and flawfinder are
+      # the CLI tools scripts/lint.sh and scripts/security.sh invoke.
+      GITLEAKS_VERSION: "8.18.4"
+      LIZARD_VERSION: "1.23.0"
+      FLAWFINDER_VERSION: "2.0.20"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # clang-format/clang-tidy arrive at LLVM 18 on the pinned 24.04
+      # image (parity with the pre-commit mirror rev above); cppcheck
+      # backs scripts/lint.sh and lcov scripts/test.sh --coverage.
+      - name: Install clang-format, clang-tidy, cppcheck, and lcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang-format clang-tidy cppcheck lcov
+
+      # pipx (preinstalled on the runner image) keeps these pinned CLI
+      # tools out of the PEP 668 externally-managed system Python.
+      # Homebrew — the install path the generated scripts document for
+      # local macOS development — is gone from GitHub's Ubuntu images.
+      - name: Install conan, lizard, and flawfinder (pinned, via pipx)
+        run: |
+          pipx install "conan==${CONAN_VERSION}"
+          pipx install "lizard==${LIZARD_VERSION}"
+          pipx install "flawfinder==${FLAWFINDER_VERSION}"
+
+      # Static, version-pinned release artifact (never "latest") —
+      # every URL below is a literal, nothing is discovered at runtime,
+      # so no value ever needs to be validated and exported through
+      # GITHUB_ENV/GITHUB_PATH (the documented Actions env-injection
+      # vector that dynamic discovery has to guard against).
+      - name: Install gitleaks
+        run: |
+          curl -fsSL -o /tmp/gitleaks.tgz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+
+      # The documented configure flow from the CMakeLists.txt header,
+      # verbatim. The build/ directory name is the scaffold-wide
+      # convention: the clang-tidy pre-commit hook, scripts/lint.sh
+      # (-p build), and scripts/test.sh all assume `cmake -B build` —
+      # change it everywhere or nowhere. The configure step also exports
+      # build/compile_commands.json for clang-tidy
+      # (CMAKE_EXPORT_COMPILE_COMMANDS is ON in CMakeLists.txt).
+      - name: Configure the CMake build (Conan toolchain)
+        run: |
+          conan profile detect --force
+          conan install . --output-folder=build --build=missing
+          cmake -B build -S . \
+            -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=Release
+
+      # The four gates below run the generated scripts themselves rather
+      # than reimplementing their tool invocations in YAML: one source
+      # of truth, so CI can never drift from what the pre-commit hooks
+      # and ./scripts/check-all.sh enforce locally.
+
+      # Check-mode counterpart of the clang-format pre-commit hook —
+      # same root .clang-format config, --dry-run --Werror, and full
+      # .c/.cc/.cpp/.cxx/.h/.hh/.hpp extension coverage.
+      - name: Run clang-format check
+        run: ./scripts/format.sh --check
+
+      # clang-tidy (root .clang-tidy: bugprone/cert/clang-analyzer/...
+      # promoted to errors), cppcheck (warning/performance/portability),
+      # and lizard's cyclomatic-complexity gate — the <=10 bound lives
+      # in lint.sh, the single source, and is not repeated here.
+      - name: Run static analysis (clang-tidy + cppcheck + lizard)
+        run: ./scripts/lint.sh
+
+      # Secret-scanning parity with the gitleaks pre-commit hook.
+      - name: Run gitleaks secret scan
+        run: gitleaks detect --source . --no-banner --redact
+
+      # Coverage gate — a single instrumented ctest execution. The line
+      # bound deliberately lives in scripts/test.sh (CMake has no
+      # canonical manifest home for a coverage threshold, unlike Kover's
+      # minBound in Gradle — see the note in that script) and is NOT
+      # repeated here: raise it there, not in CI. No separate plain
+      # test step duplicates the suite in this job.
+      - name: Run tests with lcov coverage gate
+        run: ./scripts/test.sh --coverage
+
+      # flawfinder's CWE-mapped dangerous-API scan. The script warns
+      # instead of failing when flawfinder is missing (so fresh local
+      # clones pass); it was installed above, so that soft path never
+      # silently passes in CI.
+      - name: Run security scan (flawfinder)
+        run: ./scripts/security.sh
+
+  test:
+    name: Build & Test (${{ matrix.compiler }})
+    runs-on: ubuntu-24.04
+    strategy:
+      # Run every leg to completion: the point of a compiler matrix is
+      # to see exactly which toolchains fail, not just the first one.
+      fail-fast: false
+      matrix:
+        # The C++ standard is pinned to 17 by the generated
+        # CMakeLists.txt (CMAKE_CXX_STANDARD — a project decision, not a
+        # CI input; a -DCMAKE_CXX_STANDARD cache entry would be shadowed
+        # by the project's plain set()), so the honest matrix axis is
+        # the compiler building that pinned standard: both major
+        # toolchains preinstalled on the runner image. The scaffold's
+        # sources are C++20-ready; when the project bumps its pin, this
+        # matrix keeps gating both compilers unchanged.
+        compiler: ["gcc", "clang"]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+    env:
+      # Static literals from the matrix include above — consumed by both
+      # `conan profile detect` and CMake, so the whole leg (Catch2
+      # dependency build included) really uses the matrix compiler.
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install conan (pinned, via pipx)
+        run: pipx install "conan==${CONAN_VERSION}"
+
+      - name: Show toolchain versions
+        run: |
+          "$CXX" --version
+          cmake --version
+          conan --version
+
+      # Same documented configure flow as the quality job; conan profile
+      # detect honors $CC/$CXX, so Catch2 is fetched or built for the
+      # same matrix compiler CMake uses.
+      - name: Configure the CMake build (Conan toolchain)
+        run: |
+          conan profile detect --force
+          conan install . --output-folder=build --build=missing
+          cmake -B build -S . \
+            -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build the library and tests
+        run: cmake --build build
+
+      # Plain ctest, no instrumentation: the quality job already gates
+      # coverage exactly once; this job's axis is compiler
+      # compatibility, so rerunning the instrumented suite here would
+      # just duplicate that measurement.
+      - name: Run unit tests (ctest)
+        run: ctest --test-dir build --output-on-failure

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -110,6 +110,33 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         "supported_versions": ["17", "21"],
         "package_manager": "gradle",
     },
+    "cpp": {
+        # Catch2, not GoogleTest (the epic text named gtest): the #361
+        # foundation chose Catch2 — conanfile.txt pins catch2/3.x and
+        # the scaffolded tests use Catch2 macros — so CI stays
+        # consistent with what the generated project actually builds.
+        "test_framework": "catch2",
+        "linters": ["clang-tidy", "cppcheck"],
+        "formatters": ["clang-format"],
+        # cppcheck and clang-tidy's clang-analyzer-*/cert-* checks serve
+        # security duty too, but each is listed once (under linters) so
+        # tool-install consumers don't double-install them. gitleaks
+        # covers secret scanning (shared with pre-commit) and flawfinder
+        # the CWE-mapped dangerous-API scan (scripts/security.sh).
+        "security_tools": ["gitleaks", "flawfinder"],
+        # Compilers, not language standards: the generated CMakeLists.txt
+        # pins CMAKE_CXX_STANDARD to 17 (utils.cpp.CPP_STANDARD — a
+        # project decision, not a CI input; a -DCMAKE_CXX_STANDARD cache
+        # entry would be shadowed by the project's plain set()), so the
+        # honest matrix axis is the toolchain building that pinned
+        # standard: both major compilers on the ubuntu runner image.
+        "supported_versions": ["gcc", "clang"],
+        # CMake drives the build; Conan 2 provisions Catch2 and the
+        # CMake toolchain file. The Tizen native SDK comes from Tizen
+        # Studio, not from the package manager (see reference/ci/cpp.yml
+        # for the .tpk packaging stance).
+        "package_manager": "cmake-conan",
+    },
     "java": {
         "test_framework": "junit",
         "linters": ["checkstyle"],

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -5,12 +5,10 @@ that the CLI produces valid project structures end-to-end.
 
 Note: java, csharp, and ruby are supported at the generator level but
 the quality-tooling pipeline steps (PreCommitGenerator, scripts, CI)
-skip them (#356). Kotlin completed the pipeline with #357/#358 and joins
-CLI_SUPPORTED_LANGUAGES below. C/C++ gained its quality tooling with
-#362 but still lacks a CI workflow (#363), so it stays out of
-CLI_SUPPORTED_LANGUAGES; its full init flow is covered at the
-integration level by test_cpp_init_integration.py (and
-test_language_generators.py covers the generator-only languages).
+skip them (#356). Kotlin completed the pipeline with #357/#358, and
+C/C++ followed with #362 (quality tooling) and #363 (CI workflow), so
+both join CLI_SUPPORTED_LANGUAGES below (test_language_generators.py
+covers the generator-only languages).
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.
@@ -27,7 +25,15 @@ import pytest
 from tests.conftest import get_env_without_api_keys
 
 # Languages fully supported in the CLI pipeline (all generators)
-CLI_SUPPORTED_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "kotlin")
+CLI_SUPPORTED_LANGUAGES = (
+    "python",
+    "typescript",
+    "go",
+    "rust",
+    "swift",
+    "kotlin",
+    "cpp",
+)
 
 # Expected key files per language that sgsg init should create
 EXPECTED_KEY_FILES: dict[str, list[str]] = {
@@ -77,6 +83,19 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "app/src/main/kotlin/com/example/test_project/MainActivity.kt",
         "app/src/test/kotlin/com/example/test_project/GreetingTest.kt",
         "detekt.yml",
+        ".github/workflows/ci.yml",
+        "README.md",
+    ],
+    "cpp": [
+        "CMakeLists.txt",
+        "conanfile.txt",
+        "tizen-manifest.xml",
+        "src/main.cpp",
+        "src/greeting.cpp",
+        "inc/greeting.h",
+        "tests/test_greeting.cpp",
+        ".clang-format",
+        ".clang-tidy",
         ".github/workflows/ci.yml",
         "README.md",
     ],

--- a/tests/integration/generators/test_cpp_init_integration.py
+++ b/tests/integration/generators/test_cpp_init_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``sgsg init --language cpp`` (#361/#362).
+"""Integration tests for ``sgsg init --language cpp`` (#361/#362/#363).
 
 Runs the full init flow once via the Typer CliRunner and asserts the
 generated C/C++ (Tizen native watch-app) project tree and the CMake/Conan
@@ -11,9 +11,9 @@ CMake, Conan, or Tizen Studio — so they pass on CI runners where none of
 those are installed, mirroring ``test_kotlin_init_integration.py`` (#356).
 
 With #362 the quality toolchain (pre-commit config, quality scripts,
-clang companion configs, architecture rules) is generated for C/C++;
-only the CI workflow remains deferred (#363), so this suite locks in
-the presence of the tooling artifacts and the *absence* of ci.yml.
+clang companion configs, architecture rules) is generated for C/C++,
+and #363 completed the pipeline with the CI workflow, so this suite
+locks in the presence of every pipeline artifact including ci.yml.
 """
 
 from pathlib import Path
@@ -110,6 +110,8 @@ class TestCppInitTree:
             "scripts/security.sh",
             "plans/architecture/check_architecture.py",
             "plans/architecture/run-check.sh",
+            # The CI workflow (#363) completed the cpp pipeline.
+            ".github/workflows/ci.yml",
         ],
     )
     def test_quality_tooling_artifact_generated(
@@ -123,8 +125,6 @@ class TestCppInitTree:
     @pytest.mark.parametrize(
         "relative_path",
         [
-            # CI is #363 — it must not be generated yet.
-            ".github/workflows/ci.yml",
             # The metrics dashboard is opt-in (--enable-live-dashboard).
             "docs/metrics.json",
             # Tizen Studio project/packaging artifacts and icon binaries
@@ -136,7 +136,7 @@ class TestCppInitTree:
     def test_out_of_scope_artifact_not_generated(
         self, cpp_project: Path, relative_path: str
     ) -> None:
-        """The scaffold must not emit #363 artifacts or Tizen binaries."""
+        """The scaffold must not emit opt-in artifacts or Tizen binaries."""
         assert not (cpp_project / relative_path).exists()
 
 
@@ -186,6 +186,22 @@ class TestCppInitQualityTooling:
         cmake = (cpp_project / "CMakeLists.txt").read_text()
         assert "option(ENABLE_COVERAGE" in cmake
         assert "set(CMAKE_EXPORT_COMPILE_COMMANDS ON)" in cmake
+
+    def test_ci_workflow_parses_and_delegates_to_scripts(
+        self, cpp_project: Path
+    ) -> None:
+        """ci.yml (#363) parses and gates via the generated scripts.
+
+        CI ⇄ local parity: the workflow runs scripts/test.sh --coverage
+        (the single home of the >=90% bound) instead of reimplementing
+        the gate in YAML. Workflow internals are covered in depth by
+        TestCppReferenceTemplate in tests/unit/generators/test_ci.py.
+        """
+        content = (cpp_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "C/C++ Quality Checks"
+        assert set(parsed["jobs"]) == {"quality", "test"}
+        assert "./scripts/test.sh --coverage" in content
 
 
 class TestCppInitManifests:
@@ -282,13 +298,14 @@ class TestCppInitReadme:
 
 
 class TestCppInitConsoleOutput:
-    """Assert init's console output reflects the #362 wiring."""
+    """Assert init's console output reflects the #362/#363 wiring."""
 
-    def test_init_skips_only_the_ci_step(self, tmp_path: Path) -> None:
-        """Init prints the dim skip line for CI (#363) and nothing else.
+    def test_init_skips_no_pipeline_steps(self, tmp_path: Path) -> None:
+        """Init prints no skip notice for any cpp pipeline step.
 
         The pre-commit, scripts, and architecture steps gained cpp
-        support with #362, so their skip notices must be gone.
+        support with #362 and the CI step with #363, so every
+        "unavailable" notice must be gone.
         """
         runner = CliRunner()
         with patch(
@@ -309,7 +326,8 @@ class TestCppInitConsoleOutput:
                 ],
             )
         assert result.exit_code == 0
-        assert "CI pipeline unavailable for cpp" in result.output
+        assert "CI pipeline unavailable for cpp" not in result.output
+        assert "Generated CI pipeline" in result.output
         assert "Pre-commit config unavailable for cpp" not in result.output
         assert "Quality scripts unavailable for cpp" not in result.output
         assert "Architecture rules unavailable for cpp" not in result.output

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -1218,10 +1218,56 @@ jobs:
         """Test Kotlin package_manager is exactly gradle."""
         assert LANGUAGE_CONFIGS["kotlin"]["package_manager"] == "gradle"
 
+    # LANGUAGE_CONFIGS Exact Value Tests - C/C++
+    def test_cpp_test_framework_exact(self) -> None:
+        """Test cpp test_framework is exactly catch2.
+
+        The epic text named GoogleTest, but the #361 foundation chose
+        Catch2 (conanfile.txt pins catch2/3.x and the scaffolded tests
+        use Catch2 macros), so CI stays consistent with what the
+        generated project actually builds.
+        """
+        assert LANGUAGE_CONFIGS["cpp"]["test_framework"] == "catch2"
+
+    def test_cpp_linters_exact(self) -> None:
+        """Test cpp linters list is exact."""
+        assert LANGUAGE_CONFIGS["cpp"]["linters"] == ["clang-tidy", "cppcheck"]
+
+    def test_cpp_formatters_exact(self) -> None:
+        """Test cpp formatters list is exact."""
+        assert LANGUAGE_CONFIGS["cpp"]["formatters"] == ["clang-format"]
+
+    def test_cpp_security_tools_exact(self) -> None:
+        """Test cpp security_tools list is exact.
+
+        cppcheck and clang-tidy's clang-analyzer-*/cert-* checks serve
+        security duty too but are listed only under linters so
+        tool-install consumers don't double-install them (the Swift
+        PR #414 lesson).
+        """
+        assert LANGUAGE_CONFIGS["cpp"]["security_tools"] == [
+            "gitleaks",
+            "flawfinder",
+        ]
+
+    def test_cpp_supported_versions_exact(self) -> None:
+        """Test cpp supported_versions are the matrix compilers.
+
+        The generated CMakeLists.txt pins CMAKE_CXX_STANDARD to 17
+        (utils.cpp.CPP_STANDARD — a project decision, not a CI input),
+        so the honest matrix axis is the compiler building that pinned
+        standard, not a language-standard matrix CI could never vary.
+        """
+        assert LANGUAGE_CONFIGS["cpp"]["supported_versions"] == ["gcc", "clang"]
+
+    def test_cpp_package_manager_exact(self) -> None:
+        """Test cpp package_manager is exactly cmake-conan."""
+        assert LANGUAGE_CONFIGS["cpp"]["package_manager"] == "cmake-conan"
+
     # Config Keys Exact Tests
-    def test_language_configs_has_exactly_9_languages(self) -> None:
-        """Test LANGUAGE_CONFIGS has exactly 9 supported languages."""
-        assert len(LANGUAGE_CONFIGS) == 9
+    def test_language_configs_has_exactly_10_languages(self) -> None:
+        """Test LANGUAGE_CONFIGS has exactly 10 supported languages."""
+        assert len(LANGUAGE_CONFIGS) == 10
 
     def test_language_configs_contains_python(self) -> None:
         """Test LANGUAGE_CONFIGS contains python key."""
@@ -1258,6 +1304,10 @@ jobs:
     def test_language_configs_contains_kotlin(self) -> None:
         """Test LANGUAGE_CONFIGS contains kotlin key."""
         assert "kotlin" in LANGUAGE_CONFIGS
+
+    def test_language_configs_contains_cpp(self) -> None:
+        """Test LANGUAGE_CONFIGS contains cpp key."""
+        assert "cpp" in LANGUAGE_CONFIGS
 
     def test_all_configs_have_test_framework_key(self) -> None:
         """Test all language configs have test_framework key."""
@@ -1323,7 +1373,7 @@ class TestCIGeneratorTemplatePath:
 
     @pytest.mark.parametrize(
         "language",
-        ["python", "typescript", "go", "rust", "swift", "kotlin"],
+        ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp"],
     )
     def test_generate_from_template_for_supported_language(self, language: str) -> None:
         """Each canonical language renders without an orchestrator."""
@@ -1841,6 +1891,231 @@ class TestKotlinReferenceTemplate:
         commands are parsed so comments may explain that decision.
         """
         parsed = yaml.safe_load(kotlin_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
+        assert not any("GITHUB_PATH" in cmd for cmd in run_commands)
+
+
+class TestCppReferenceTemplate:
+    """Tests for the C/C++ reference CI workflow (Issue #363).
+
+    The cpp scaffold is a Tizen native watch app whose CMake/Conan build
+    deliberately covers ONLY the pure-logic library and its Catch2 tests
+    (the #361 two-build split): src/main.cpp needs the Tizen native SDK
+    and .tpk packaging is the Tizen Studio CLI's job — a manual,
+    login-gated GUI installer no GitHub-hosted runner can provision.
+    Every assertion therefore reflects what can actually run on a plain
+    ubuntu runner, and the packaging gap is documented in YAML comments
+    rather than emitted as steps that can never pass (the Kotlin
+    no-emulator / Swift Periphery precedent).
+    """
+
+    @pytest.fixture
+    def cpp_workflow(self) -> CIWorkflow:
+        """Render the deterministic C/C++ reference workflow."""
+        return CIGenerator(language="cpp").generate_workflow_from_template()
+
+    def test_workflow_is_valid_yaml(self, cpp_workflow: CIWorkflow) -> None:
+        """Rendered workflow parses with yaml.safe_load and validates."""
+        parsed = yaml.safe_load(cpp_workflow.content)
+        assert cpp_workflow.is_valid
+        assert isinstance(parsed, dict)
+        assert parsed["name"] == "C/C++ Quality Checks"
+
+    def test_workflow_has_quality_and_test_jobs(self, cpp_workflow: CIWorkflow) -> None:
+        """Workflow declares exactly the quality and test jobs."""
+        parsed = yaml.safe_load(cpp_workflow.content)
+        assert set(parsed["jobs"]) == {"quality", "test"}
+
+    def test_all_jobs_run_on_pinned_ubuntu(self, cpp_workflow: CIWorkflow) -> None:
+        """Every job pins ubuntu-24.04, not ubuntu-latest.
+
+        Noble's default apt clang tooling is LLVM 18, matching the
+        mirrors-clang-format v18.1.8 rev pinned in the generated
+        .pre-commit-config.yaml — a floating ubuntu-latest could silently
+        change the clang-format/clang-tidy major and break that parity.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        for name, job in parsed["jobs"].items():
+            assert job["runs-on"] == "ubuntu-24.04", f"{name} must pin ubuntu-24.04"
+
+    def test_compiler_matrix_does_not_fail_fast(self, cpp_workflow: CIWorkflow) -> None:
+        """Matrix legs run to completion so every failing compiler is seen."""
+        parsed = yaml.safe_load(cpp_workflow.content)
+        assert parsed["jobs"]["test"]["strategy"]["fail-fast"] is False
+
+    def test_compiler_matrix_matches_language_config_versions(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """The test job matrixes over the LANGUAGE_CONFIGS compilers."""
+        parsed = yaml.safe_load(cpp_workflow.content)
+        matrix = parsed["jobs"]["test"]["strategy"]["matrix"]
+        assert matrix["compiler"] == LANGUAGE_CONFIGS["cpp"]["supported_versions"]
+
+    def test_compiler_matrix_maps_cc_and_cxx_pairs(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """Each matrix leg carries a consistent CC/CXX toolchain pair.
+
+        Both Conan (profile detect honors $CC/$CXX) and CMake read these,
+        so the whole leg — dependency build included — really uses the
+        matrix compiler instead of silently falling back to the default.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        include = parsed["jobs"]["test"]["strategy"]["matrix"]["include"]
+        pairs = {entry["compiler"]: (entry["cc"], entry["cxx"]) for entry in include}
+        assert pairs == {"gcc": ("gcc", "g++"), "clang": ("clang", "clang++")}
+        env = parsed["jobs"]["test"]["env"]
+        assert env["CC"] == "${{ matrix.cc }}"
+        assert env["CXX"] == "${{ matrix.cxx }}"
+
+    def test_checkout_action_is_pinned_to_major(self, cpp_workflow: CIWorkflow) -> None:
+        """actions/checkout is pinned to a major version."""
+        assert "actions/checkout@v4" in cpp_workflow.content
+
+    def test_quality_job_runs_generated_scripts_for_parity(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """CI runs the generated scripts instead of reimplementing them.
+
+        format.sh --check, lint.sh, test.sh --coverage, and security.sh
+        are the same gates check-all.sh chains locally — one source of
+        truth, so CI can never drift from the pre-commit/scripts parity
+        the #362 review demanded.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        quality_commands = [
+            step.get("run", "") for step in parsed["jobs"]["quality"]["steps"]
+        ]
+        assert any(
+            cmd.strip() == "./scripts/format.sh --check" for cmd in quality_commands
+        )
+        assert any(cmd.strip() == "./scripts/lint.sh" for cmd in quality_commands)
+        assert any(cmd.strip() == "./scripts/security.sh" for cmd in quality_commands)
+
+    def test_coverage_gate_delegates_to_test_script_once(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """One test.sh --coverage run gates coverage; the bound stays there.
+
+        scripts/test.sh is the single home of the >=90% line bound (CMake
+        has no canonical manifest slot for a coverage threshold), and it
+        runs ctest exactly once with instrumentation — no second
+        uninstrumented test step duplicates the suite in the quality job
+        (the Swift PR #414 no-double-test-run lesson). Run commands are
+        parsed so comments may reference the bound.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        coverage_runs = [
+            cmd for cmd in run_commands if "./scripts/test.sh --coverage" in cmd
+        ]
+        assert len(coverage_runs) == 1
+        quality_commands = [
+            step.get("run", "") for step in parsed["jobs"]["quality"]["steps"]
+        ]
+        assert not any("ctest" in cmd for cmd in quality_commands)
+        assert not any("90" in cmd for cmd in run_commands)
+
+    def test_quality_job_runs_gitleaks_at_precommit_pin(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """CI runs gitleaks at the same version pre-commit pins."""
+        content = cpp_workflow.content
+        assert "gitleaks detect" in content
+        # Parity with the rev pinned in the generated .pre-commit-config
+        # (https://github.com/gitleaks/gitleaks rev v8.18.4).
+        assert 'GITLEAKS_VERSION: "8.18.4"' in content
+
+    def test_quality_tools_are_version_pinned(self, cpp_workflow: CIWorkflow) -> None:
+        """conan/lizard/flawfinder/gitleaks are pinned, never floating.
+
+        Homebrew was removed from GitHub's Ubuntu runner images (the
+        Kotlin #421 lesson), so Python CLI tools install via pipx at
+        pinned versions and gitleaks comes from a pinned GitHub release
+        artifact — deterministically, never "latest".
+        """
+        content = cpp_workflow.content
+        assert "CONAN_VERSION" in content
+        assert "LIZARD_VERSION" in content
+        assert "FLAWFINDER_VERSION" in content
+        assert "releases/download" in content
+        assert "releases/latest" not in content
+        assert "brew install" not in content
+
+    def test_test_job_builds_and_runs_ctest_without_coverage(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """Matrix legs build and run plain ctest; coverage stays in quality.
+
+        The test job's axis is compiler compatibility — rerunning the
+        instrumented suite here would just duplicate the quality job's
+        single coverage measurement.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        test_commands = [
+            step.get("run", "") for step in parsed["jobs"]["test"]["steps"]
+        ]
+        assert any("cmake --build build" in cmd for cmd in test_commands)
+        assert any(
+            "ctest --test-dir build --output-on-failure" in cmd for cmd in test_commands
+        )
+        assert not any("--coverage" in cmd for cmd in test_commands)
+        assert not any("lcov" in cmd for cmd in test_commands)
+
+    def test_configure_uses_documented_build_dir_convention(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """Both jobs configure with the scaffold-wide `cmake -B build` flow.
+
+        The build/ directory name is load-bearing: the clang-tidy
+        pre-commit hook, scripts/lint.sh (-p build), and scripts/test.sh
+        all assume it, and the CMakeLists.txt header documents the exact
+        conan install + cmake configure invocation CI replays here.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
+        for job_name in ("quality", "test"):
+            commands = [
+                step.get("run", "") for step in parsed["jobs"][job_name]["steps"]
+            ]
+            configure = [cmd for cmd in commands if "conan install" in cmd]
+            assert len(configure) == 1, f"{job_name} must configure exactly once"
+            assert "conan profile detect --force" in configure[0]
+            assert "conan install . --output-folder=build --build=missing" in (
+                configure[0]
+            )
+            assert "cmake -B build -S ." in configure[0]
+            assert "-DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake" in configure[0]
+
+    def test_tizen_packaging_documented_not_stubbed(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """The .tpk packaging gap is YAML comments, not dead steps.
+
+        Tizen Studio is a manual, login-gated GUI installer with no
+        headless install path, so no runner can provision it — the
+        workflow documents that honestly instead of emitting `tizen
+        build-native` steps that can never pass.
+        """
+        content = cpp_workflow.content
+        assert "Tizen Studio" in content
+        parsed = yaml.safe_load(content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("tizen" in cmd for cmd in run_commands)
+        assert not any(".tpk" in cmd for cmd in run_commands)
+
+    def test_workflow_writes_nothing_to_github_env(
+        self, cpp_workflow: CIWorkflow
+    ) -> None:
+        """Nothing discovered at runtime is exported to GITHUB_ENV.
+
+        The Swift PR #414 review flagged unvalidated GITHUB_ENV writes as
+        the documented Actions env-injection vector; like the Kotlin
+        workflow, this one sidesteps the vector entirely — every value is
+        a static literal, so there is no dynamic discovery and no
+        GITHUB_ENV/GITHUB_PATH write to guard.
+        """
+        parsed = yaml.safe_load(cpp_workflow.content)
         run_commands = _all_run_commands(parsed)
         assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
         assert not any("GITHUB_PATH" in cmd for cmd in run_commands)

--- a/tests/unit/reference/test_reference_assets.py
+++ b/tests/unit/reference/test_reference_assets.py
@@ -30,7 +30,7 @@ class TestCIReferences:
         assert ci_dir.is_dir()
 
     def test_all_language_ci_workflows_exist(self, ci_dir: Path) -> None:
-        """Test that CI workflows exist for all 10 supported languages."""
+        """Test that CI workflows exist for all 11 supported languages."""
         required_workflows = [
             "python.yml",
             "typescript.yml",
@@ -42,6 +42,7 @@ class TestCIReferences:
             "ruby.yml",
             "php.yml",
             "kotlin.yml",
+            "cpp.yml",
         ]
 
         for workflow in required_workflows:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -400,12 +400,12 @@ class TestGeneratorOnlyLanguagePipelineGates:
 
 
 class TestCppPipelineGates:
-    """Pipeline steps run (or skip) correctly for cpp after #362.
+    """Pipeline steps all run for cpp after #362/#363.
 
     The #361 foundation shipped structure/dependencies/tests/readme only;
-    #362 wired the pre-commit/scripts/metrics/architecture tooling, so
-    those steps must now generate real artifacts. Only the CI step (#363)
-    still skips, with an informational message instead of a crash.
+    #362 wired the pre-commit/scripts/metrics/architecture tooling and
+    #363 completed the pipeline with the CI workflow, so every step must
+    now generate real artifacts.
     """
 
     def test_precommit_step_writes_for_cpp(self, tmp_path: Path) -> None:
@@ -437,11 +437,13 @@ class TestCppPipelineGates:
         assert (tmp_path / ".clang-format").exists()
         assert (tmp_path / ".clang-tidy").exists()
 
-    def test_ci_step_skips_cpp_without_workflow(self, tmp_path: Path) -> None:
-        """No ci.yml is written for cpp (CI generation is #363)."""
+    def test_ci_step_writes_cpp_workflow(self, tmp_path: Path) -> None:
+        """ci.yml is now generated for cpp (#363)."""
         cli_mod._generate_ci_step(tmp_path, "my-project", "cpp", None)
 
-        assert not (tmp_path / ".github" / "workflows" / "ci.yml").exists()
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "C/C++ Quality Checks" in ci_file.read_text()
 
     def test_metrics_step_writes_cpp_dashboard(self, tmp_path: Path) -> None:
         """The metrics dashboard is now generated for cpp (#362)."""


### PR DESCRIPTION
## Summary

Generates the GitHub Actions pipeline for C/C++ (Tizen native) projects — epic sub-issue; #361 foundation and #362 quality tooling merged. This is the third language CI issue and applies every accumulated lesson:

- **`LANGUAGE_CONFIGS["cpp"]`** — catch2 (the issue's GoogleTest line predates #361's justified Catch2 choice; deviation commented), linters `[clang-tidy, cppcheck]`, formatters `[clang-format]`, security `[gitleaks, flawfinder]` with single-listing (#414/#421 lesson), `supported_versions: ["gcc", "clang"]` — compilers, not standards: the scaffold pins C++17 via a plain `set()` that shadows cache entries, so a std matrix would be dishonest (commented, with C++20-readiness noted), cmake-conan.
- **`reference/ci/cpp.yml`** (modeled on the most-reviewed kotlin.yml):
  - **quality** on pinned `ubuntu-24.04` (apt clang tooling = LLVM 18, matching the pre-commit mirror rev): the job runs the **generated scripts themselves** — `format.sh --check`, `lint.sh`, `test.sh --coverage`, `security.sh` — so CI cannot drift from local gates by construction. The ≥90% bound lives only in test.sh; ctest runs exactly once. Tools version-pinned via pipx/release artifacts (verified live; Homebrew is gone from runners).
  - **test** matrix: gcc/clang with `fail-fast: false`, CC/CXX from static literals.
  - **Tizen packaging**: documented as unprovisionable on GitHub runners (login-gated GUI installer) in a prominent comment instead of dead steps — the #361 two-builds split is exactly what makes everything else runnable, honored explicitly.
  - **Zero `GITHUB_ENV`/`GITHUB_PATH` writes** — every value is a static literal, asserted by test.
- `cli.py` needed no change (the CI step keys off `LANGUAGE_CONFIGS` membership); the #361/#362 ci.yml-absence tests flipped to presence; cpp joined the e2e matrices per the kotlin precedent.

## Test plan

- TDD red-first: 15-test `TestCppReferenceTemplate` (yaml validity, job set, pinned runner, matrix/fail-fast/config parity, pinned tools, single-coverage-run, script-parity, no-GITHUB_ENV) + 6 exact-config tests + flips.
- **actionlint clean** on both the template and a rendered workflow; `bash -n` passes on all 14 run blocks.
- `./scripts/check-all.sh`: all 7 checks pass — 2352 unit tests, coverage **94.89%**. Integration + e2e green including the new cpp leg.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#364 (tests) and #365 (docs — including the generated README CI "Planned" flip, per the kotlin precedent) remain.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
