### PR TITLE
test(cpp): add cpp to the two remaining stale language matrices (#364)

### DIFF
--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -92,7 +92,7 @@ class TestPreCommitGeneratorIntegration:
     def test_multiple_languages_workflow(self, mock_orchestrator: Mock) -> None:
         """Test generating configs for multiple languages."""
         generator = PreCommitGenerator(mock_orchestrator)
-        languages = ["python", "typescript", "go", "rust", "swift", "kotlin"]
+        languages = ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp"]
 
         for language in languages:
             config = GenerationConfig(

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -9,7 +9,16 @@ from start_green_stay_green.cli import _venv_activation_command
 
 # Languages exercised by the per-language common-tail tests; "java" covers
 # the unknown-language default path.
-ALL_LANGUAGES = ("python", "typescript", "go", "rust", "swift", "kotlin", "java")
+ALL_LANGUAGES = (
+    "python",
+    "typescript",
+    "go",
+    "rust",
+    "swift",
+    "kotlin",
+    "cpp",
+    "java",
+)
 
 
 class TestVenvActivationCommand:


### PR DESCRIPTION
## Summary

Survey-first execution (the same pattern as Swift #354 and Kotlin #359): #361–#363 already delivered the bulk of this issue — a 22-test cpp init integration suite (broader than kotlin's 20 and swift's 12), cpp in the multi-language parametrize list with dedicated per-pipeline-step tests, e2e matrices (#363), and the conftest extension mapping.

Exactly two stale matrices remained, both filled:
- `ALL_LANGUAGES` in `tests/unit/test_cli_setup_instructions.py` now includes cpp, enabling the parametrized common-tail assertions for cpp setup instructions.
- The multi-language workflow list in `test_precommit_integration.py` now includes cpp.

No generator bugs surfaced — the newly-enabled assertions passed on first run.

## Mutation testing (honest status)

Re-verified live: mutmut 3.6.0 still crashes on the repo's 2.x-style `[tool.mutmut]` config (`tests_dir` str-vs-list TypeError) — identical to the #359 finding. The config migration remains a separately-tracked tooling gap; no score is claimed.

## Test plan

- `./scripts/check-all.sh`: all 7 checks pass — **2354 tests**, coverage **94.89%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all 30 hooks pass.
- cpp e2e passes (structural, no compiler invocation, no skip markers).

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
