### PR TITLE
feat(java): foundation — Wear OS scaffolding with Maven pure-logic build (#366)

### DIFF
--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1623,6 +1623,10 @@ _LANG_SETUP_STEPS: dict[str, list[str]] = {
         "cmake --build build",
         "ctest --test-dir build",
     ],
+    # Plain Maven builds and tests the pure-logic half of the legacy
+    # Android Wear scaffold; the watch APK needs Android tooling
+    # (Android Studio / Gradle), which init cannot install (#366).
+    "java": ["mvn test"],
 }
 
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 import warnings
 
-from start_green_stay_green.utils.kotlin import android_package
+from start_green_stay_green.utils.java import android_package
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -18,6 +18,15 @@ from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
 from start_green_stay_green.utils.cpp import cpp_identifier
+from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
+from start_green_stay_green.utils.java import JACOCO_VERSION
+from start_green_stay_green.utils.java import JAVA_RELEASE
+from start_green_stay_green.utils.java import JUNIT4_VERSION
+from start_green_stay_green.utils.java import MAVEN_COMPILER_PLUGIN_VERSION
+from start_green_stay_green.utils.java import PMD_PLUGIN_VERSION
+from start_green_stay_green.utils.java import SPOTBUGS_PLUGIN_VERSION
+from start_green_stay_green.utils.java import SUREFIRE_VERSION
+from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.kotlin import ACTIVITY_COMPOSE_VERSION
 from start_green_stay_green.utils.kotlin import AGP_VERSION
 from start_green_stay_green.utils.kotlin import COMPOSE_BOM_VERSION
@@ -27,7 +36,6 @@ from start_green_stay_green.utils.kotlin import KONSIST_VERSION
 from start_green_stay_green.utils.kotlin import KOTLIN_VERSION
 from start_green_stay_green.utils.kotlin import KOVER_VERSION
 from start_green_stay_green.utils.kotlin import WEAR_COMPOSE_VERSION
-from start_green_stay_green.utils.kotlin import android_package
 from start_green_stay_green.utils.swift import package_swift
 
 if TYPE_CHECKING:
@@ -74,10 +82,10 @@ class DependenciesGenerator(BaseGenerator):
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips its quality-tooling steps
-    (pre-commit, scripts, CI, architecture, metrics) for java, csharp, and
-    ruby; C/C++ quality tooling landed with #362 and only its CI step
-    (#363) still skips.
+    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
+    architecture, and metrics steps for java (#367), csharp, and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358) and
+    C/C++ (#362/#363) run the full pipeline.
 
     Attributes:
         output_dir: Directory where dependency files will be written
@@ -545,14 +553,24 @@ nursery = "warn"
 """
 
     def _generate_java_dependencies(self) -> dict[str, Path]:
-        """Generate Java dependency files.
+        """Generate the Maven manifest for the legacy Wear scaffold (#366).
+
+        Emits ``pom.xml``, the build for the PURE-LOGIC half of the
+        two-build split (``src/main/java`` + ``src/test/java``): JUnit 4
+        tests via Surefire, the JaCoCo coverage gate, and the
+        Checkstyle/PMD/SpotBugs plugins the generated CI workflow
+        (``reference/ci/java.yml``) invokes. The Wear OS app module under
+        ``app/`` needs the Android SDK and the androidx.wear AAR, which
+        plain Maven cannot consume (the android-maven-plugin is
+        unmaintained), so the APK build is deliberately NOT scaffolded —
+        the pom comment and the README disclose it, mirroring the Tizen
+        Studio precedent (#361).
 
         Returns:
             Dictionary mapping file names to file paths
         """
         files: dict[str, Path] = {}
 
-        # Generate pom.xml for Maven projects
         files["pom.xml"] = self._write_file(
             "pom.xml",
             self._java_pom_xml(),
@@ -561,12 +579,29 @@ nursery = "warn"
         return files
 
     def _java_pom_xml(self) -> str:
-        """Generate Java pom.xml content.
+        """Generate Java ``pom.xml`` content.
 
         Returns:
-            Content for pom.xml with project info and dependencies
+            Content for the pure-logic Maven build: JUnit 4 + Surefire,
+            the JaCoCo agent/report executions with a >=90% line-coverage
+            rule (configured at plugin level so the CI's standalone
+            ``mvn jacoco:check`` invocation picks it up too), and the
+            Checkstyle (google_checks), PMD, and SpotBugs plugins
+            matching the generated CI workflow's ``mvn`` commands.
         """
         return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven build for the PURE-LOGIC half of this project: src/main/java
+  and src/test/java only. It backs every mvn command in the generated
+  CI workflow (.github/workflows/ci.yml): test, jacoco:report,
+  jacoco:check, checkstyle:check, pmd:check, spotbugs:check.
+
+  THE TWO BUILDS: the Wear OS app module under app/ needs the Android
+  SDK and the androidx.wear AAR, which plain Maven cannot consume (the
+  android-maven-plugin is unmaintained). Build the watch APK with
+  Android tooling (Android Studio / Gradle) instead - this generator
+  does not scaffold that build. See the README section "The two builds".
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
@@ -579,21 +614,20 @@ nursery = "warn"
     <packaging>jar</packaging>
 
     <name>{self.config.project_name}</name>
-    <description>A quality-controlled Java project</description>
+    <description>Pure-logic build for the {self.config.project_name} \
+Wear OS app</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>{JAVA_RELEASE}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.10.0</junit.version>
     </properties>
 
     <dependencies>
-        <!-- Test dependencies -->
+        <!-- JUnit 4: the Android-ecosystem unit-test convention. -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${{junit.version}}</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>{JUNIT4_VERSION}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -603,12 +637,76 @@ nursery = "warn"
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>{MAVEN_COMPILER_PLUGIN_VERSION}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>{SUREFIRE_VERSION}</version>
+            </plugin>
+            <!-- Coverage gate: the plugin-level rules configuration is
+                 the single home of the >=90% bound, applied both to the
+                 lifecycle-bound check execution and to the CI's
+                 standalone `mvn jacoco:check` invocation. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>{JACOCO_VERSION}</version>
+                <configuration>
+                    <rules>
+                        <rule>
+                            <element>BUNDLE</element>
+                            <limits>
+                                <limit>
+                                    <counter>LINE</counter>
+                                    <value>COVEREDRATIO</value>
+                                    <minimum>0.90</minimum>
+                                </limit>
+                            </limits>
+                        </rule>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>{CHECKSTYLE_PLUGIN_VERSION}</version>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>{PMD_PLUGIN_VERSION}</version>
+            </plugin>
+            <!-- Declared so the CI's `mvn spotbugs:check` resolves: the
+                 com.github.spotbugs plugin group is not in Maven's
+                 default plugin-prefix search path. -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>{SPOTBUGS_PLUGIN_VERSION}</version>
             </plugin>
         </plugins>
     </build>

--- a/start_green_stay_green/generators/readme.py
+++ b/start_green_stay_green/generators/readme.py
@@ -19,8 +19,10 @@ from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
 from start_green_stay_green.utils.cpp import cpp_identifier
 from start_green_stay_green.utils.cpp import tizen_app_id
-from start_green_stay_green.utils.kotlin import android_package
-from start_green_stay_green.utils.kotlin import android_package_path
+from start_green_stay_green.utils.java import ANDROIDX_WEAR_VERSION
+from start_green_stay_green.utils.java import JAVA_RELEASE
+from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
 
 if TYPE_CHECKING:
@@ -67,10 +69,10 @@ class ReadmeGenerator(BaseGenerator):
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips its quality-tooling steps
-    (pre-commit, scripts, CI, architecture, metrics) for java, csharp, and
-    ruby; Kotlin (quality tooling #357, CI #358) and C/C++ (quality tooling
-    #362, CI #363) run the full pipeline.
+    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
+    architecture, and metrics steps for java (#367), csharp, and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358) and
+    C/C++ (#362/#363) run the full pipeline.
 
     Attributes:
         output_dir: Directory where README.md will be created
@@ -787,28 +789,76 @@ Generated with [Start Green Stay Green](https://github.com/Geoffe-Ga/start_green
     def _java_readme_content(self) -> str:
         """Generate Java README.md content.
 
+        Only artifacts the scaffold actually generates carry a checkmark:
+        the legacy Android Wear app skeleton, the pure-logic Maven build
+        (JUnit 4 + Surefire, the JaCoCo coverage gate, and the
+        Checkstyle/PMD/SpotBugs plugins matching the generated CI
+        workflow), and the CI pipeline itself, which ``ci.py`` already
+        generates for java. The #367 quality tooling (pre-commit hooks,
+        quality scripts, metrics dashboard, architecture rules) stays
+        under "Planned / coming soon". The two-builds split is documented
+        explicitly: the pure logic builds and tests with plain Maven
+        anywhere, while the watch APK needs Android tooling (Android
+        Studio / Gradle) the generator does not scaffold — the Tizen
+        Studio precedent (#361).
+
         Returns:
             Content for README.md
         """
-        # Convert project name to title case for display
         display_name = self.config.project_name.replace("-", " ").title()
+        package = android_package(self.config.package_name)
+        package_path = android_package_path(self.config.package_name)
 
         return f"""# {self.config.project_name}
 
-{display_name} - A quality-controlled Java project generated with
-Start Green Stay Green.
+{display_name} - A quality-controlled Java Wear OS (legacy Android Wear)
+project generated with Start Green Stay Green.
 
 ## Description
 
-This project was generated with maximum quality standards from day one, including:
+This Java scaffold is the foundation of a quality-controlled legacy
+Android Wear watch-app project — the maintenance path for existing Java
+watch apps. The following are generated today:
 
-- ✅ Comprehensive testing infrastructure (JUnit with 90%+ coverage requirement)
-- ✅ Code quality tools (Checkstyle, SpotBugs, PMD)
-- ✅ Security scanning (OWASP Dependency Check)
-- ✅ Type safety (Java's strong typing system)
-- ✅ Pre-commit hooks (quality checks)
-- ✅ CI/CD pipeline (GitHub Actions)
-- ✅ AI-assisted development (Claude Code skills and subagents)
+- ✅ Wear OS app skeleton (`app/src/main/`): `AndroidManifest.xml` with
+  the watch `uses-feature` and standalone metadata, a `MainActivity`
+  rendered through an `androidx.wear.widget.BoxInsetLayout` layout
+  (androidx.wear {ANDROIDX_WEAR_VERSION}; `WearableActivity` is
+  deprecated), application ID `{package}`
+- ✅ Pure-logic class (`src/main/java/{package_path}/Greeting.java`)
+  testable without the Android SDK
+- ✅ Maven build (`pom.xml`, Java {JAVA_RELEASE}) for the pure logic:
+  JUnit 4 tests via Surefire, JaCoCo coverage gate (≥90% line), and the
+  Checkstyle/PMD/SpotBugs plugins the CI workflow invokes
+- ✅ JUnit 4 unit-test scaffold
+  (`src/test/java/{package_path}/GreetingTest.java`)
+- ✅ CI/CD pipeline (`.github/workflows/ci.yml` — JDK 17/21 matrix
+  running the same `mvn` quality goals as the local build)
+- ✅ This README
+
+**Planned / coming soon** (quality tooling, #367):
+
+- ⏳ Pre-commit hooks configuration
+- ⏳ Quality scripts (`./scripts/check-all.sh` and friends)
+- ⏳ Metrics dashboard
+- ⏳ Architecture enforcement rules
+
+## The two builds (read this first)
+
+This project deliberately splits into two builds:
+
+1. **Pure logic + unit tests — plain Maven, no Android SDK.** `pom.xml`
+   builds only `src/main/java` and `src/test/java`, so `mvn test` and
+   every CI quality goal run on any host — including the generated CI
+   pipeline's runners.
+2. **The watch app itself — Android tooling.** `app/src/main/` needs the
+   Android SDK and the androidx.wear AAR
+   (`androidx.wear:wear:{ANDROIDX_WEAR_VERSION}`), which plain Maven
+   cannot consume — the android-maven-plugin is unmaintained, so this
+   scaffold does not pretend Maven can produce the APK. Build the app
+   with Android Studio (Gradle), adding `src/main/java/` as a source
+   root so `MainActivity` resolves `Greeting`. That Gradle build is
+   **not** generated by this scaffold.
 
 ## Installation
 
@@ -817,22 +867,22 @@ This project was generated with maximum quality standards from day one, includin
 git clone <repository-url>
 cd {self.config.project_name}
 
-# Build with Maven
-mvn clean install
-
-# Install pre-commit hooks
-pre-commit install
+# Build the pure logic and run its tests (needs JDK {JAVA_RELEASE}+ and Maven)
+mvn test
 ```
 
 ## Usage
 
-Run the Hello World application:
+Run the pure-logic unit tests:
 
 ```bash
-mvn exec:java
+mvn test
 ```
 
-Expected output:
+To see the greeting on a watch, import the project into Android Studio
+and assemble the `app/` module there (see *The two builds*).
+
+Expected output (on the watch face):
 ```
 Hello from {self.config.project_name}!
 ```
@@ -841,78 +891,93 @@ Hello from {self.config.project_name}!
 
 ### Running Quality Checks
 
+These match the generated CI pipeline (`.github/workflows/ci.yml`)
+goal-for-goal:
+
 ```bash
-# Run all tests
+# Run all tests (JUnit 4 via Surefire)
 mvn test
 
-# Run tests with coverage
+# Run tests with the JaCoCo coverage report
 mvn clean test jacoco:report
 
-# Run Checkstyle
-mvn checkstyle:check
+# Enforce the >=90% line-coverage gate
+mvn jacoco:check
 
-# Run SpotBugs
-mvn spotbugs:check
+# Run Checkstyle (google_checks)
+mvn checkstyle:check
 
 # Run PMD
 mvn pmd:check
 
-# Compile project
-mvn compile
-
-# Build project
-mvn clean package
+# Run SpotBugs
+mvn spotbugs:check
 ```
 
 ### Quality Tools
 
-This project includes:
+This scaffold currently includes:
 
-- **JUnit**: Testing framework with 90%+ coverage requirement
-- **JaCoCo**: Code coverage tool
-- **Checkstyle**: Code style checker
-- **SpotBugs**: Static analysis tool for finding bugs
+- **JUnit 4**: Unit-test framework (run by Maven Surefire)
+- **JaCoCo**: Coverage gate ≥90% line coverage (`mvn jacoco:check`;
+  only the Maven-built pure-logic sources count — `app/` needs the
+  Android SDK, sits outside the Maven build, and is honestly outside
+  the coverage denominator too)
+- **Checkstyle**: Code style checker (google_checks)
 - **PMD**: Source code analyzer
-- **Maven**: Build automation and dependency management
+- **SpotBugs**: Static bytecode analysis
+- **CI pipeline**: GitHub Actions (`.github/workflows/ci.yml`) running
+  the same `mvn` goals on a JDK 17/21 matrix
+
+Pre-commit hooks, quality scripts, the metrics dashboard, and
+architecture rules are **not** generated for Java yet (#367).
 
 ### Project Structure
 
 ```
 {self.config.project_name}/
+├── pom.xml                          # Maven build (pure logic only)
 ├── src/
-│   ├── main/java/        # Application source code
-│   └── test/java/        # Test suite
-├── scripts/              # Quality control scripts
-├── .github/workflows/    # CI/CD pipelines
-├── .claude/              # AI subagents and skills
-├── pom.xml               # Maven configuration
-└── checkstyle.xml        # Checkstyle configuration
+│   ├── main/java/{package_path}/
+│   │   └── Greeting.java            # Pure logic: greet()
+│   └── test/java/{package_path}/
+│       └── GreetingTest.java        # JUnit 4 scaffold
+├── app/                             # Wear OS app (Android tooling)
+│   └── src/main/
+│       ├── AndroidManifest.xml      # Watch feature + standalone metadata
+│       ├── java/{package_path}/
+│       │   └── MainActivity.java    # BoxInsetLayout entry point
+│       └── res/layout/
+│           └── activity_main.xml    # androidx.wear.widget layout
+└── .github/workflows/
+    └── ci.yml                       # JDK 17/21 quality matrix
 ```
 
 ### Testing
 
 ```bash
-# Run all tests
+# Run all unit tests
 mvn test
 
-# Run tests with coverage report
-mvn clean test jacoco:report
+# Run a specific test class
+mvn test -Dtest=GreetingTest
 
-# View coverage report
+# View the coverage report after `mvn clean test jacoco:report`
 open target/site/jacoco/index.html
-
-# Run specific test class
-mvn test -Dtest=TestClassName
 ```
 
 ### Code Quality
 
-This project maintains MAXIMUM QUALITY standards:
+This scaffold is a MAXIMUM QUALITY Java project. Today it provides:
 
-- **Test Coverage**: ≥90% required
-- **Type Safety**: 100% compile-time type checking
-- **All Linters**: Must pass with zero violations
-- **Code Style**: Enforced by Checkstyle
+- **Java {JAVA_RELEASE} with compile-time type checking**
+  (`maven.compiler.release`)
+- **JUnit 4 test scaffold**: ready for you to add tests
+- **Coverage gate**: `mvn jacoco:check` enforces ≥90% line coverage
+- **Style and static analysis**: Checkstyle, PMD, and SpotBugs wired
+  into the pom
+- **CI enforcement**: every gate above also runs in GitHub Actions on
+  every push and pull request, on JDK 17 and 21
 
 ## License
 
@@ -921,7 +986,7 @@ MIT License
 ## Attribution
 
 Generated with [Start Green Stay Green](https://github.com/Geoffe-Ga/start_green_stay_green)
-- Maximum quality Java projects from day one.
+- Maximum quality Java Wear OS watch projects from day one.
 """
 
     def _generate_csharp_readme(self) -> Path:

--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -17,8 +17,8 @@ from start_green_stay_green.generators.base import validate_language
 from start_green_stay_green.utils.cpp import TIZEN_API_VERSION
 from start_green_stay_green.utils.cpp import cpp_identifier
 from start_green_stay_green.utils.cpp import tizen_app_id
-from start_green_stay_green.utils.kotlin import android_package
-from start_green_stay_green.utils.kotlin import android_package_path
+from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
 from start_green_stay_green.utils.swift import package_swift
 
@@ -65,9 +65,10 @@ class StructureGenerator(BaseGenerator):
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips its quality-tooling steps
-    (pre-commit, scripts, CI, architecture, metrics) for java, csharp, ruby,
-    and cpp; C/C++ tooling arrives with #362/#363.
+    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
+    architecture, and metrics steps for java (#367), csharp, and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358) and
+    C/C++ (#362/#363) run the full pipeline.
 
     Attributes:
         output_dir: Directory where structure will be created
@@ -553,71 +554,217 @@ edition = "2021"
 """
 
     def _generate_java_structure(self) -> dict[str, Path]:
-        """Generate Java project structure.
+        """Generate the Java legacy Android Wear project structure (#366).
+
+        Creates the two-build split layout proven by the C/C++ Tizen
+        scaffold (#361): the pure-logic ``Greeting`` class under
+        ``src/main/java/`` is compiled and unit-tested by the Maven build
+        (``pom.xml``, owned by
+        :class:`~start_green_stay_green.generators.dependencies.DependenciesGenerator`),
+        while the watch-app module under ``app/src/main/`` — the
+        ``AndroidManifest.xml`` with the watch ``uses-feature`` and
+        standalone metadata, a ``MainActivity`` rendered through an
+        ``androidx.wear.widget.BoxInsetLayout`` layout, and the layout
+        XML itself — needs the Android SDK and is built with Android
+        tooling (Android Studio / Gradle) the generator does not scaffold.
 
         Returns:
             Dictionary mapping file names to file paths
         """
         files: dict[str, Path] = {}
 
-        # Create src/main/java/{package_name} directory
-        java_dir = self.output_dir / "src" / "main" / "java" / self.config.package_name
-        java_dir.mkdir(parents=True, exist_ok=True)
+        package_path = android_package_path(self.config.package_name)
 
-        # Generate Main.java
-        main_key = f"src/main/java/{self.config.package_name}/Main.java"
-        files[main_key] = self._write_file(
-            java_dir / "Main.java",
-            self._java_main_java(),
+        # Pure logic: compiled and tested by the Maven build (pom.xml).
+        logic_dir = self.output_dir / "src" / "main" / "java" / package_path
+        logic_dir.mkdir(parents=True, exist_ok=True)
+        files[f"src/main/java/{package_path}/Greeting.java"] = self._write_file(
+            logic_dir / "Greeting.java",
+            self._java_greeting_java(),
         )
 
-        # Generate pom.xml
-        pom_key = "pom.xml"
-        files[pom_key] = self._write_file(
-            self.output_dir / "pom.xml",
-            self._java_pom_xml(),
+        # Wear OS app module: built with Android tooling, not Maven.
+        main_dir = self.output_dir / "app" / "src" / "main"
+        source_dir = main_dir / "java" / package_path
+        layout_dir = main_dir / "res" / "layout"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        layout_dir.mkdir(parents=True, exist_ok=True)
+
+        files["app/src/main/AndroidManifest.xml"] = self._write_file(
+            main_dir / "AndroidManifest.xml",
+            self._java_android_manifest(),
+        )
+        files[f"app/src/main/java/{package_path}/MainActivity.java"] = self._write_file(
+            source_dir / "MainActivity.java",
+            self._java_main_activity(),
+        )
+        files["app/src/main/res/layout/activity_main.xml"] = self._write_file(
+            layout_dir / "activity_main.xml",
+            self._java_activity_layout(),
         )
 
         return files
 
-    def _java_main_java(self) -> str:
-        """Generate Java Main.java content.
+    def _java_greeting_java(self) -> str:
+        """Generate the pure-logic ``Greeting.java``.
 
         Returns:
-            Content for Main.java with Hello World
+            Content for the greeting assembly class. It has no Android
+            imports, so the Maven build (``pom.xml``) compiles and
+            unit-tests it on any host — including the generated CI
+            pipeline's runners — without the Android SDK.
         """
-        return f"""package {self.config.package_name};
+        package = android_package(self.config.package_name)
+        return f"""package {package};
 
-public class Main {{
-    public static void main(String[] args) {{
-        System.out.println("Hello from {self.config.project_name}!");
+/**
+ * Assembles the greeting shown on the watch face.
+ *
+ * <p>Pure logic with no Android imports: the Maven build (pom.xml)
+ * compiles and unit-tests this class on any host without the Android
+ * SDK. The Wear OS app module under app/ consumes it too — see the
+ * README section "The two builds".</p>
+ */
+public final class Greeting {{
+
+    private Greeting() {{
+        // Static utility class: not instantiable.
+    }}
+
+    /**
+     * Returns the greeting assembled from the project name.
+     *
+     * @param projectName the name to greet from
+     * @return the assembled greeting, e.g. {{@code "Hello from wear!"}}
+     */
+    public static String greet(final String projectName) {{
+        return "Hello from " + projectName + "!";
     }}
 }}
 """
 
-    def _java_pom_xml(self) -> str:
-        """Generate Java pom.xml content.
+    def _java_android_manifest(self) -> str:
+        """Generate the legacy Android Wear ``AndroidManifest.xml``.
 
         Returns:
-            Content for pom.xml
+            Manifest content declaring the watch hardware feature (the
+            ``wear`` device profile), the wearable shared library, the
+            standalone-app metadata (installable without a phone
+            companion), and the launcher ``MainActivity``. Unlike the
+            Kotlin scaffold (#356) the ``package`` attribute is declared
+            here: no Gradle manifests are generated for the Java app
+            module (see the two-builds split), so the manifest is the
+            single home of the application ID.
         """
-        return f"""<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+        package = android_package(self.config.package_name)
+        return f"""<?xml version="1.0" encoding="utf-8"?>
+<!-- Legacy Android Wear manifest. The package attribute doubles as the
+     application ID: the generator scaffolds no Gradle build for the app
+     module (see the README section "The two builds"), so there is no
+     build.gradle namespace to declare it in. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="{package}">
 
-    <groupId>{self.config.package_name}</groupId>
-    <artifactId>{self.config.package_name}</artifactId>
-    <version>0.1.0</version>
+    <!-- Wear device profile: this app installs only on watches. -->
+    <uses-feature android:name="android.hardware.type.watch" />
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-</project>
+    <application
+        android:label="{self.config.project_name}"
+        android:theme="@android:style/Theme.DeviceDefault">
+
+        <!-- Wearable shared library (legacy Android Wear). -->
+        <uses-library
+            android:name="com.google.android.wearable"
+            android:required="true" />
+
+        <!-- Standalone Wear OS app: installable without a phone companion. -->
+        <meta-data
+            android:name="com.google.android.wearable.standalone"
+            android:value="true" />
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+"""
+
+    def _java_main_activity(self) -> str:
+        """Generate the legacy Android Wear ``MainActivity.java``.
+
+        Uses a plain :class:`android.app.Activity` rendering the
+        ``androidx.wear.widget.BoxInsetLayout`` layout — the maintained
+        view-based path for legacy Java watch apps, since
+        ``WearableActivity`` is deprecated. The greeting is assembled by
+        the pure-logic ``Greeting`` class so the generated JUnit 4
+        scaffold exercises real logic on the JVM without an emulator.
+
+        Returns:
+            Content for the Wear OS entry-point activity source file.
+        """
+        package = android_package(self.config.package_name)
+        return f"""package {package};
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+
+/**
+ * Wear OS entry point for {self.config.project_name} (legacy Android Wear).
+ *
+ * <p>Renders res/layout/activity_main.xml, whose root is an
+ * androidx.wear.widget.BoxInsetLayout — the maintained view-based
+ * layout for round watch faces (WearableActivity is deprecated).</p>
+ *
+ * <p>THE TWO BUILDS: this file needs the Android SDK and the
+ * androidx.wear AAR, so it is built with Android tooling
+ * (Android Studio / Gradle) — NOT by the Maven build, which covers
+ * only the pure logic in src/main/java/. When assembling the Android
+ * build, add src/main/java/ as a source root so this activity can
+ * resolve {{@link Greeting}}. See the README section "The two builds".</p>
+ */
+public class MainActivity extends Activity {{
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {{
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        final TextView greetingView = findViewById(R.id.greeting);
+        greetingView.setText(Greeting.greet("{self.config.project_name}"));
+    }}
+}}
+"""
+
+    def _java_activity_layout(self) -> str:
+        """Generate ``res/layout/activity_main.xml`` for the Wear app.
+
+        Returns:
+            Layout XML rooted at ``androidx.wear.widget.BoxInsetLayout``,
+            which keeps the greeting ``TextView`` inside the visible
+            square of round watch faces (``boxedEdges="all"``).
+        """
+        return """<?xml version="1.0" encoding="utf-8"?>
+<!-- Legacy Android Wear layout: BoxInsetLayout (androidx.wear.widget)
+     keeps content inside the visible square of round watch faces. -->
+<androidx.wear.widget.BoxInsetLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/greeting"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault"
+        app:boxedEdges="all" />
+</androidx.wear.widget.BoxInsetLayout>
 """
 
     def _generate_csharp_structure(self) -> dict[str, Path]:

--- a/start_green_stay_green/generators/tests_gen.py
+++ b/start_green_stay_green/generators/tests_gen.py
@@ -15,8 +15,8 @@ from start_green_stay_green.generators.base import BaseGenerator
 from start_green_stay_green.generators.base import GenerationError
 from start_green_stay_green.generators.base import validate_language
 from start_green_stay_green.utils.cpp import cpp_identifier
-from start_green_stay_green.utils.kotlin import android_package
-from start_green_stay_green.utils.kotlin import android_package_path
+from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
 
 if TYPE_CHECKING:
@@ -62,9 +62,10 @@ class TestsGenerator(BaseGenerator):
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips its quality-tooling steps
-    (pre-commit, scripts, CI, architecture, metrics) for java, csharp, ruby,
-    and cpp; C/C++ tooling arrives with #362/#363.
+    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
+    architecture, and metrics steps for java (#367), csharp, and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358) and
+    C/C++ (#362/#363) run the full pipeline.
 
     Attributes:
         output_dir: Directory where tests structure will be created
@@ -361,62 +362,70 @@ mod tests {{
 """
 
     def _generate_java_tests(self) -> dict[str, Path]:
-        """Generate Java tests structure.
+        """Generate the Java JUnit 4 unit-test scaffold (#366).
+
+        Creates ``src/test/java/<package>/GreetingTest.java``, a plain
+        JVM JUnit 4 test run by Maven Surefire (``mvn test``) against the
+        pure-logic ``Greeting`` class — no Android SDK, emulator, or
+        Robolectric needed, so it runs on any host including the
+        generated CI pipeline's runners.
 
         Returns:
             Dictionary mapping file names to file paths
         """
         files: dict[str, Path] = {}
 
-        # Create src/test/java/{package_name} directory
-        test_dir = self.output_dir / "src" / "test" / "java" / self.config.package_name
+        package_path = android_package_path(self.config.package_name)
+        test_dir = self.output_dir / "src" / "test" / "java" / package_path
         test_dir.mkdir(parents=True, exist_ok=True)
 
-        # Generate src/test/java/{package_name}/MainTest.java
-        test_main_key = f"src/test/java/{self.config.package_name}/MainTest.java"
-        files[test_main_key] = self._write_file(
-            test_dir / "MainTest.java",
-            self._java_test_main_java(),
+        test_key = f"src/test/java/{package_path}/GreetingTest.java"
+        files[test_key] = self._write_file(
+            test_dir / "GreetingTest.java",
+            self._java_greeting_test(),
         )
 
         return files
 
-    def _java_test_main_java(self) -> str:
-        """Generate Java MainTest.java content.
+    def _java_greeting_test(self) -> str:
+        """Generate the Java JUnit 4 test content.
+
+        The generated test exercises real behavior rather than comparing
+        two identical string literals: it calls the scaffold's
+        ``Greeting.greet`` concatenation logic with both the project name
+        and an arbitrary name, so the equality assertions verify the
+        assembly logic.
 
         Returns:
-            Content for MainTest.java with JUnit @Test annotation
+            Content for the JUnit 4 test class file.
         """
-        # Convert package_name to valid Java package (e.g., my_project -> my.project)
-        package_name = self.config.package_name.replace("_", ".")
+        package = android_package(self.config.package_name)
+        return f"""package {package};
 
-        return f"""package {package_name};
+import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.Test;
 
 /**
- * Tests for {self.config.project_name} main entry point
+ * Verifies the greeting assembly logic in {{@link Greeting}}.
+ *
+ * <p>Plain JVM JUnit 4 run by Maven Surefire ({{@code mvn test}}) -
+ * no Android SDK, emulator, or Robolectric needed.</p>
  */
-public class MainTest {{
+public class GreetingTest {{
 
     @Test
-    public void testMainRuns() {{
-        // Test that Main class exists and can be instantiated
-        // This verifies the Hello World entry point compiles correctly
-        assertDoesNotThrow(() -> {{
-            Main.main(new String[]{{}});
-        }}, "main() should run without throwing exceptions");
+    public void greetingIsAssembledFromProjectName() {{
+        // Greeting.greet() concatenates its argument, so this verifies
+        // real logic rather than comparing two identical literals.
+        assertEquals(
+                "Hello from {self.config.project_name}!",
+                Greeting.greet("{self.config.project_name}"));
     }}
 
     @Test
-    public void testMainMethodExists() {{
-        // Verify main method exists
-        try {{
-            Main.class.getMethod("main", String[].class);
-        }} catch (NoSuchMethodException e) {{
-            fail("main(String[] args) method should exist");
-        }}
+    public void greetingReflectsAnArbitraryName() {{
+        assertEquals("Hello from wear!", Greeting.greet("wear"));
     }}
 }}
 """

--- a/start_green_stay_green/utils/java.py
+++ b/start_green_stay_green/utils/java.py
@@ -1,0 +1,146 @@
+"""Java/Android naming helpers and Maven toolchain versions (#366).
+
+Provides a single source of truth for the Android package derived from a
+project's package name, shared by the Java and Kotlin Wear OS scaffolds:
+the structure, dependencies, and tests generators all derive source
+``package`` declarations, the manifest application ID, and the on-disk
+source paths from :func:`android_package`, so they can never drift apart.
+The Android package sanitization rules are Java's package rules (Kotlin
+packages compile to Java packages), which is why the canonical
+implementation lives here.
+
+The pinned Maven toolchain versions for the generated Java ``pom.xml``
+live here for the same reason. The pom deliberately covers only the
+PURE-LOGIC half of the legacy Android Wear scaffold (``src/main/java`` +
+``src/test/java``): the watch-app module under ``app/`` needs the Android
+SDK and the androidx.wear AAR, which plain Maven cannot consume (the
+android-maven-plugin is unmaintained), so the APK build belongs to
+Android tooling (Android Studio / Gradle) that the generator does not
+scaffold — the same two-builds split as the C/C++ Tizen scaffold (#361).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Pinned toolchain versions for the generated Maven (pom.xml) manifest.
+# JUnit 4 (not 5) matches the Android ecosystem convention shared with
+# the Kotlin Wear OS scaffold (#356).
+JUNIT4_VERSION = "4.13.2"
+MAVEN_COMPILER_PLUGIN_VERSION = "3.13.0"
+SUREFIRE_VERSION = "3.5.2"
+JACOCO_VERSION = "0.8.12"
+CHECKSTYLE_PLUGIN_VERSION = "3.6.0"
+PMD_PLUGIN_VERSION = "3.26.0"
+SPOTBUGS_PLUGIN_VERSION = "4.8.6.6"
+# Java release the pure-logic build targets; within the generated CI
+# workflow's JDK matrix (reference/ci/java.yml runs 17 and 21).
+JAVA_RELEASE = "17"
+# androidx.wear (Wearable Support Library successor) for the legacy
+# Android Wear app module. Referenced in documentation only: the AAR is
+# consumed by the Android (Gradle) build, never by the pom.
+ANDROIDX_WEAR_VERSION = "1.3.0"
+
+# Characters invalid in a lowercase Java package segment.
+_INVALID_SEGMENT_CHARS = re.compile(r"[^a-z0-9_]")
+
+# Java language keywords (plus literals) that cannot be used as a package
+# segment.
+_JAVA_KEYWORDS = frozenset(
+    {
+        "abstract",
+        "assert",
+        "boolean",
+        "break",
+        "byte",
+        "case",
+        "catch",
+        "char",
+        "class",
+        "const",
+        "continue",
+        "default",
+        "do",
+        "double",
+        "else",
+        "enum",
+        "extends",
+        "false",
+        "final",
+        "finally",
+        "float",
+        "for",
+        "goto",
+        "if",
+        "implements",
+        "import",
+        "instanceof",
+        "int",
+        "interface",
+        "long",
+        "native",
+        "new",
+        "null",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "return",
+        "short",
+        "static",
+        "strictfp",
+        "super",
+        "switch",
+        "synchronized",
+        "this",
+        "throw",
+        "throws",
+        "transient",
+        "true",
+        "try",
+        "void",
+        "volatile",
+        "while",
+    }
+)
+
+
+def android_package(package_name: str) -> str:
+    """Derive a valid Android package/namespace from a package name.
+
+    The result lives under the conventional ``com.example`` placeholder
+    namespace (users typically change the application ID before
+    publishing). The final segment is sanitized to a valid Java package
+    segment: lowercased, hyphens and other invalid characters replaced
+    with underscores, and prefixed with ``app_`` when it would start with
+    a digit or collide with a Java keyword. A name with no usable
+    characters falls back to ``app``.
+
+    Args:
+        package_name: The project's package identifier (e.g.
+            ``wrist_timer`` or ``wrist-timer``).
+
+    Returns:
+        A dotted Android package such as ``com.example.wrist_timer``.
+    """
+    segment = _INVALID_SEGMENT_CHARS.sub("_", package_name.lower().replace("-", "_"))
+    if not segment:
+        segment = "app"
+    elif segment[0].isdigit() or segment in _JAVA_KEYWORDS:
+        segment = f"app_{segment}"
+    return f"com.example.{segment}"
+
+
+def android_package_path(package_name: str) -> str:
+    """Return the source-directory path for the Android package.
+
+    Args:
+        package_name: The project's package identifier.
+
+    Returns:
+        The slash-separated form of :func:`android_package`, e.g.
+        ``com/example/wrist_timer``, for building Java
+        (``src/{main,test}/java/``, ``app/src/main/java/``) and Kotlin
+        (``app/src/{main,test}/kotlin/``) source paths.
+    """
+    return android_package(package_name).replace(".", "/")

--- a/start_green_stay_green/utils/kotlin.py
+++ b/start_green_stay_green/utils/kotlin.py
@@ -1,11 +1,15 @@
-"""Kotlin/Android naming helpers and toolchain versions for the Wear OS scaffold.
+"""Kotlin/Android toolchain versions for the Wear OS scaffold.
 
-Provides a single source of truth for the Android namespace derived from a
-project's package name, shared by the structure, dependencies, and tests
-generators so the Kotlin source ``package`` declarations, the Gradle
-``namespace``/``applicationId``, and the on-disk source paths can never
-drift apart. The pinned toolchain versions used across the generated Gradle
-manifests live here for the same reason.
+Holds the pinned toolchain versions used across the generated Gradle
+(Kotlin DSL) manifests, so the structure, dependencies, and tests
+generators share one source of truth.
+
+The Android package/namespace naming helpers
+(:func:`~start_green_stay_green.utils.java.android_package` and
+:func:`~start_green_stay_green.utils.java.android_package_path`) live in
+``utils/java.py``: the sanitization rules are Java's package rules
+(Kotlin packages compile to Java packages), and the Java Wear OS
+scaffold (#366) shares them.
 
 The scaffold deliberately does NOT generate the Gradle wrapper (``gradlew``,
 ``gradle/wrapper/gradle-wrapper.jar``): the wrapper jar is a binary artifact
@@ -14,8 +18,6 @@ document running ``gradle wrapper --gradle-version <version>`` once instead.
 """
 
 from __future__ import annotations
-
-import re
 
 # Pinned toolchain versions for the generated Gradle (Kotlin DSL) manifests.
 # Chosen as a mutually-compatible stable set: AGP 8.7 requires Gradle 8.9+,
@@ -32,106 +34,3 @@ GRADLE_WRAPPER_VERSION = "8.9"
 # (plans/architecture/ArchitectureTest.kt).
 KOVER_VERSION = "0.9.8"
 KONSIST_VERSION = "0.17.3"
-
-# Characters invalid in a lowercase Java/Kotlin package segment.
-_INVALID_SEGMENT_CHARS = re.compile(r"[^a-z0-9_]")
-
-# Java language keywords (plus literals) that cannot be used as a package
-# segment. Kotlin packages compile to Java packages, so the Java rules apply.
-_JAVA_KEYWORDS = frozenset(
-    {
-        "abstract",
-        "assert",
-        "boolean",
-        "break",
-        "byte",
-        "case",
-        "catch",
-        "char",
-        "class",
-        "const",
-        "continue",
-        "default",
-        "do",
-        "double",
-        "else",
-        "enum",
-        "extends",
-        "false",
-        "final",
-        "finally",
-        "float",
-        "for",
-        "goto",
-        "if",
-        "implements",
-        "import",
-        "instanceof",
-        "int",
-        "interface",
-        "long",
-        "native",
-        "new",
-        "null",
-        "package",
-        "private",
-        "protected",
-        "public",
-        "return",
-        "short",
-        "static",
-        "strictfp",
-        "super",
-        "switch",
-        "synchronized",
-        "this",
-        "throw",
-        "throws",
-        "transient",
-        "true",
-        "try",
-        "void",
-        "volatile",
-        "while",
-    }
-)
-
-
-def android_package(package_name: str) -> str:
-    """Derive a valid Android package/namespace from a package name.
-
-    The result lives under the conventional ``com.example`` placeholder
-    namespace (users typically change the ``applicationId`` before
-    publishing). The final segment is sanitized to a valid Java package
-    segment: lowercased, hyphens and other invalid characters replaced
-    with underscores, and prefixed with ``app_`` when it would start with
-    a digit or collide with a Java keyword. A name with no usable
-    characters falls back to ``app``.
-
-    Args:
-        package_name: The project's package identifier (e.g.
-            ``wrist_timer`` or ``wrist-timer``).
-
-    Returns:
-        A dotted Android package such as ``com.example.wrist_timer``.
-    """
-    segment = _INVALID_SEGMENT_CHARS.sub("_", package_name.lower().replace("-", "_"))
-    if not segment:
-        segment = "app"
-    elif segment[0].isdigit() or segment in _JAVA_KEYWORDS:
-        segment = f"app_{segment}"
-    return f"com.example.{segment}"
-
-
-def android_package_path(package_name: str) -> str:
-    """Return the Kotlin source-directory path for the Android package.
-
-    Args:
-        package_name: The project's package identifier.
-
-    Returns:
-        The slash-separated form of :func:`android_package`, e.g.
-        ``com/example/wrist_timer``, for building
-        ``app/src/{main,test}/kotlin/`` paths.
-    """
-    return android_package(package_name).replace(".", "/")

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -3,12 +3,14 @@
 Tests the complete sgsg init flow for supported languages, verifying
 that the CLI produces valid project structures end-to-end.
 
-Note: java, csharp, and ruby are supported at the generator level but
-the quality-tooling pipeline steps (PreCommitGenerator, scripts, CI)
-skip them (#356). Kotlin completed the pipeline with #357/#358, and
-C/C++ followed with #362 (quality tooling) and #363 (CI workflow), so
-both join CLI_SUPPORTED_LANGUAGES below (test_language_generators.py
-covers the generator-only languages).
+Note: java, csharp, and ruby are supported at the generator level
+(java's scaffold is the Wear OS foundation, #366) and get a CI workflow
+via ci.py, but the remaining quality-tooling pipeline steps
+(PreCommitGenerator, scripts, metrics, architecture) skip them — #367
+tracks java. Kotlin completed the pipeline with #357/#358, and C/C++
+followed with #362 (quality tooling) and #363 (CI workflow), so both
+join CLI_SUPPORTED_LANGUAGES below (test_java_init_integration.py and
+test_language_generators.py cover the generator-only languages).
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.

--- a/tests/integration/generators/test_java_init_integration.py
+++ b/tests/integration/generators/test_java_init_integration.py
@@ -1,0 +1,310 @@
+"""Integration tests for ``sgsg init --language java`` (#366).
+
+Runs the full init flow once via the Typer CliRunner and asserts the
+generated Java (Wear OS, legacy Android Wear) project tree, the Maven
+manifest, and the Android XML files. The AI orchestrator is patched to
+``None`` so no real Anthropic API calls are made (Issue #196); the null
+keyring backend is enforced globally by ``tests/conftest.py``.
+
+These tests are structural only — they never invoke Maven, a JDK, or
+the Android SDK — so they pass on CI runners where none of those are
+installed, mirroring ``test_cpp_init_integration.py`` (#361).
+
+Foundation-stage boundaries: the CI workflow IS generated (ci.py has
+had a java config all along), while the #367 quality tooling
+(pre-commit config, quality scripts, metrics dashboard, architecture
+rules) is not — init must skip those steps with informational messages
+and the README must keep them under "Planned / coming soon".
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from defusedxml import ElementTree as DefusedElementTree
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green.cli import app
+from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
+
+# Project name chosen to exercise the hyphen sanitization path:
+# wrist-timer -> package com.example.wrist_timer.
+_PROJECT_NAME = "wrist-timer"
+_PACKAGE = android_package("wrist_timer")
+_PACKAGE_PATH = android_package_path("wrist_timer")
+
+
+@pytest.fixture(scope="module")
+def java_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Run ``sgsg init --language java`` once and return the project root.
+
+    Args:
+        tmp_path_factory: Pytest factory for a module-scoped temp directory.
+
+    Returns:
+        Path to the generated project directory.
+    """
+    output_dir = tmp_path_factory.mktemp("java-init")
+    runner = CliRunner()
+    with patch(
+        "start_green_stay_green.cli._initialize_orchestrator", return_value=None
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                _PROJECT_NAME,
+                "--language",
+                "java",
+                "--output-dir",
+                str(output_dir),
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0, f"sgsg init failed for java: {result.output}"
+    return output_dir / _PROJECT_NAME
+
+
+class TestJavaInitTree:
+    """Assert the generated legacy Android Wear project tree."""
+
+    def test_project_directory_created(self, java_project: Path) -> None:
+        """Init creates the project directory."""
+        assert java_project.is_dir()
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "pom.xml",
+            f"src/main/java/{_PACKAGE_PATH}/Greeting.java",
+            f"src/test/java/{_PACKAGE_PATH}/GreetingTest.java",
+            "app/src/main/AndroidManifest.xml",
+            f"app/src/main/java/{_PACKAGE_PATH}/MainActivity.java",
+            "app/src/main/res/layout/activity_main.xml",
+            "README.md",
+            # The CI workflow is real today: ci.py has a java config and
+            # reference/ci/java.yml backs it.
+            ".github/workflows/ci.yml",
+        ],
+    )
+    def test_expected_file_generated(
+        self, java_project: Path, relative_path: str
+    ) -> None:
+        """Every expected java project file exists and is non-empty."""
+        file_path = java_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # #367 quality tooling must not be scaffolded yet.
+            ".pre-commit-config.yaml",
+            "scripts/check-all.sh",
+            "scripts/test.sh",
+            "plans/architecture",
+            # The metrics dashboard is opt-in and unsupported for java.
+            "docs/metrics.json",
+            # No Gradle manifests: the Android build is deliberately not
+            # scaffolded (the two-builds split).
+            "build.gradle",
+            "settings.gradle",
+            "app/build.gradle",
+            # The pre-#366 generic scaffold is gone.
+            "src/main/java/wrist_timer/Main.java",
+            "src/test/java/wrist_timer/MainTest.java",
+        ],
+    )
+    def test_out_of_scope_artifact_not_generated(
+        self, java_project: Path, relative_path: str
+    ) -> None:
+        """The scaffold must not emit #367 tooling or Gradle manifests."""
+        assert not (java_project / relative_path).exists()
+
+
+class TestJavaInitManifests:
+    """Assert the Maven manifest and the Android XML files."""
+
+    def test_pom_is_well_formed_xml(self, java_project: Path) -> None:
+        """pom.xml parses as XML rooted at the Maven project element."""
+        root = DefusedElementTree.fromstring((java_project / "pom.xml").read_text())
+        assert root.tag == "{http://maven.apache.org/POM/4.0.0}project"
+
+    def test_pom_builds_and_gates_the_pure_logic(self, java_project: Path) -> None:
+        """The pom wires JUnit 4, Surefire, and the JaCoCo 90% gate."""
+        pom = (java_project / "pom.xml").read_text()
+        assert "<artifactId>wrist-timer</artifactId>" in pom
+        assert "<artifactId>junit</artifactId>" in pom
+        assert "<artifactId>maven-surefire-plugin</artifactId>" in pom
+        assert "<minimum>0.90</minimum>" in pom
+
+    def test_pom_backs_every_ci_quality_goal(self, java_project: Path) -> None:
+        """The plugins behind the generated CI's mvn goals are declared.
+
+        reference/ci/java.yml invokes checkstyle:check, pmd:check,
+        spotbugs:check, jacoco:report, and jacoco:check — each needs its
+        plugin in the pom (the spotbugs and jacoco prefixes do not
+        resolve from Maven's default plugin groups).
+        """
+        pom = (java_project / "pom.xml").read_text()
+        assert "<artifactId>maven-checkstyle-plugin</artifactId>" in pom
+        assert "<artifactId>maven-pmd-plugin</artifactId>" in pom
+        assert "<artifactId>spotbugs-maven-plugin</artifactId>" in pom
+        assert "<artifactId>jacoco-maven-plugin</artifactId>" in pom
+
+    def test_pom_documents_android_tooling_split(self, java_project: Path) -> None:
+        """The pom discloses that the APK build is Android tooling's job."""
+        pom = (java_project / "pom.xml").read_text()
+        assert "THE TWO BUILDS" in pom
+        assert "Android Studio" in pom
+
+    def test_android_manifest_is_well_formed_xml(self, java_project: Path) -> None:
+        """AndroidManifest.xml parses with a manifest root."""
+        manifest_path = java_project / "app" / "src" / "main" / "AndroidManifest.xml"
+        root = DefusedElementTree.fromstring(manifest_path.read_text())
+        assert root.tag == "manifest"
+        assert root.get("package") == _PACKAGE
+
+    def test_android_manifest_declares_wear_watch_app(self, java_project: Path) -> None:
+        """The manifest declares the watch feature and standalone flag."""
+        manifest = (
+            java_project / "app" / "src" / "main" / "AndroidManifest.xml"
+        ).read_text()
+        assert '<uses-feature android:name="android.hardware.type.watch" />' in (
+            manifest
+        )
+        assert "com.google.android.wearable.standalone" in manifest
+        assert 'android:name="com.google.android.wearable"' in manifest
+
+    def test_layout_is_well_formed_box_inset_layout(self, java_project: Path) -> None:
+        """activity_main.xml parses and roots at BoxInsetLayout."""
+        layout_path = (
+            java_project
+            / "app"
+            / "src"
+            / "main"
+            / "res"
+            / "layout"
+            / "activity_main.xml"
+        )
+        root = DefusedElementTree.fromstring(layout_path.read_text())
+        assert root.tag == "androidx.wear.widget.BoxInsetLayout"
+
+    def test_ci_workflow_parses_and_runs_maven_goals(self, java_project: Path) -> None:
+        """ci.yml parses as YAML and gates via the pom-backed mvn goals."""
+        content = (java_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "Java Quality Checks"
+        assert "mvn checkstyle:check" in content
+        assert "mvn jacoco:check" in content
+
+
+class TestJavaInitSources:
+    """Assert the generated Java source and test files."""
+
+    def test_pure_logic_unit_is_android_free(self, java_project: Path) -> None:
+        """Greeting.java has no Android dependencies (Maven-buildable)."""
+        source = (
+            java_project / "src" / "main" / "java" / _PACKAGE_PATH / "Greeting.java"
+        ).read_text()
+        assert f"package {_PACKAGE};" in source
+        assert '"Hello from " + projectName + "!"' in source
+        assert "import android" not in source
+        assert "androidx" not in source
+
+    def test_main_activity_uses_wear_widget_layout(self, java_project: Path) -> None:
+        """MainActivity renders the BoxInsetLayout and the greeting."""
+        source = (
+            java_project
+            / "app"
+            / "src"
+            / "main"
+            / "java"
+            / _PACKAGE_PATH
+            / "MainActivity.java"
+        ).read_text()
+        assert "public class MainActivity extends Activity" in source
+        assert "setContentView(R.layout.activity_main);" in source
+        assert f'Greeting.greet("{_PROJECT_NAME}")' in source
+        assert "extends WearableActivity" not in source
+
+    def test_generated_test_uses_junit4_against_greet(self, java_project: Path) -> None:
+        """The JUnit 4 scaffold exercises the Greeting.greet logic."""
+        source = (
+            java_project / "src" / "test" / "java" / _PACKAGE_PATH / "GreetingTest.java"
+        ).read_text()
+        assert "import org.junit.Test;" in source
+        assert f'Greeting.greet("{_PROJECT_NAME}")' in source
+        assert f'"Hello from {_PROJECT_NAME}!"' in source
+        assert "jupiter" not in source
+
+
+class TestJavaInitReadme:
+    """Assert the generated README stays truthful (#366 boundaries)."""
+
+    def test_readme_targets_legacy_android_wear(self, java_project: Path) -> None:
+        """README documents the Wear OS (legacy Android Wear) scaffold."""
+        readme = (java_project / "README.md").read_text()
+        assert "Wear OS" in readme
+        assert "legacy Android Wear" in readme
+
+    def test_readme_advertises_generated_ci_pipeline(self, java_project: Path) -> None:
+        """README documents the generated CI pipeline as real.
+
+        The ci.yml the README advertises must actually exist next to it
+        — the truthfulness contract from #365.
+        """
+        readme = (java_project / "README.md").read_text()
+        assert ".github/workflows/ci.yml" in readme
+        assert (java_project / ".github" / "workflows" / "ci.yml").is_file()
+
+    def test_readme_keeps_367_tooling_under_planned(self, java_project: Path) -> None:
+        """README lists the #367 quality tooling as planned, not real."""
+        readme = (java_project / "README.md").read_text()
+        assert "Planned / coming soon" in readme
+        assert "#367" in readme
+
+    def test_readme_documents_android_tooling_gap(self, java_project: Path) -> None:
+        """README explains that the APK build needs Android Studio/Gradle."""
+        readme = (java_project / "README.md").read_text()
+        assert "## The two builds" in readme
+        assert "Android Studio" in readme
+
+
+class TestJavaInitConsoleOutput:
+    """Assert init's console output reflects the #366 boundaries."""
+
+    def test_init_skips_only_the_367_steps(self, tmp_path: Path) -> None:
+        """Init skips pre-commit/scripts/architecture but generates CI.
+
+        The #367 quality tooling must be announced as unavailable while
+        the CI pipeline (real since ci.py gained its java config) is
+        generated without a skip notice.
+        """
+        runner = CliRunner()
+        with patch(
+            "start_green_stay_green.cli._initialize_orchestrator",
+            return_value=None,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "init",
+                    "--project-name",
+                    "skip-check",
+                    "--language",
+                    "java",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--no-interactive",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Pre-commit config unavailable for java" in result.output
+        assert "Quality scripts unavailable for java" in result.output
+        assert "Architecture rules unavailable for java" in result.output
+        assert "CI pipeline unavailable for java" not in result.output
+        assert "Generated CI pipeline" in result.output

--- a/tests/integration/generators/test_kotlin_init_integration.py
+++ b/tests/integration/generators/test_kotlin_init_integration.py
@@ -26,7 +26,7 @@ from typer.testing import CliRunner
 import yaml
 
 from start_green_stay_green.cli import app
-from start_green_stay_green.utils.kotlin import android_package_path
+from start_green_stay_green.utils.java import android_package_path
 
 # Project name chosen to exercise the hyphen-to-underscore Android
 # package conversion (wear-timer -> com.example.wear_timer).

--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import tempfile
 import tomllib
 
+from defusedxml import ElementTree as DefusedElementTree
 import pytest
 
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
@@ -12,12 +13,19 @@ from start_green_stay_green.generators.dependencies import DependencyConfig
 from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
+from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
+from start_green_stay_green.utils.java import JACOCO_VERSION
+from start_green_stay_green.utils.java import JAVA_RELEASE
+from start_green_stay_green.utils.java import JUNIT4_VERSION
+from start_green_stay_green.utils.java import PMD_PLUGIN_VERSION
+from start_green_stay_green.utils.java import SPOTBUGS_PLUGIN_VERSION
+from start_green_stay_green.utils.java import SUREFIRE_VERSION
+from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.kotlin import AGP_VERSION
 from start_green_stay_green.utils.kotlin import JUNIT_VERSION
 from start_green_stay_green.utils.kotlin import KONSIST_VERSION
 from start_green_stay_green.utils.kotlin import KOTLIN_VERSION
 from start_green_stay_green.utils.kotlin import KOVER_VERSION
-from start_green_stay_green.utils.kotlin import android_package
 from start_green_stay_green.utils.swift import package_swift
 
 # Expected primary dependency file per language
@@ -347,7 +355,7 @@ class TestMultiLanguageDependencies:
 
             content = files["pom.xml"].read_text()
             assert "<project" in content
-            assert "junit" in content.lower() or "test" in content.lower()
+            assert "junit" in content.lower()
 
     def test_csharp_csproj_has_project(self) -> None:
         """Test C# .csproj contains Project element."""
@@ -577,6 +585,105 @@ class TestKotlinDependencies:
                 f'testImplementation("com.lemonappdev:konsist:{KONSIST_VERSION}")'
                 in content
             )
+
+
+class TestJavaDependencies:
+    """Test the Java Maven (pure-logic) manifest generation (#366)."""
+
+    @staticmethod
+    def _pom(tmpdir: str) -> str:
+        """Generate the java dependency files and return the pom content.
+
+        Args:
+            tmpdir: Directory to generate into.
+
+        Returns:
+            The generated ``pom.xml`` content.
+        """
+        config = DependencyConfig(
+            project_name="wrist-timer",
+            language="java",
+            package_name="wrist_timer",
+        )
+        files = DependenciesGenerator(Path(tmpdir), config).generate()
+        pom_path: Path = files["pom.xml"]
+        return pom_path.read_text()
+
+    def test_pom_is_well_formed_xml_with_maven_namespace(self) -> None:
+        """pom.xml parses as XML rooted at the Maven project element."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = DefusedElementTree.fromstring(self._pom(tmpdir))
+            assert root.tag == "{http://maven.apache.org/POM/4.0.0}project"
+
+    def test_pom_names_project_under_com_example(self) -> None:
+        """The artifact is the project name under the com.example group."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<groupId>com.example</groupId>" in content
+            assert "<artifactId>wrist-timer</artifactId>" in content
+
+    def test_pom_targets_pinned_java_release(self) -> None:
+        """The compiler release matches the pinned Java version."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            release = f"<maven.compiler.release>{JAVA_RELEASE}"
+            assert f"{release}</maven.compiler.release>" in content
+
+    def test_pom_manages_junit4_test_dependency(self) -> None:
+        """JUnit 4 (the Android-ecosystem convention) is test-scoped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<artifactId>junit</artifactId>" in content
+            assert f"<version>{JUNIT4_VERSION}</version>" in content
+            assert "<scope>test</scope>" in content
+            # The old JUnit 5 (jupiter) manifest is gone.
+            assert "jupiter" not in content
+
+    def test_pom_wires_surefire_and_compiler_plugins(self) -> None:
+        """Surefire (mvn test) and the compiler plugin are pinned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<artifactId>maven-surefire-plugin</artifactId>" in content
+            assert f"<version>{SUREFIRE_VERSION}</version>" in content
+
+    def test_pom_carries_the_jacoco_coverage_gate(self) -> None:
+        """The JaCoCo plugin enforces the >=90% line-coverage bound.
+
+        The rules live at plugin level so the CI's standalone
+        ``mvn jacoco:check`` invocation (reference/ci/java.yml) applies
+        them too, not just the lifecycle-bound check execution.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<artifactId>jacoco-maven-plugin</artifactId>" in content
+            assert f"<version>{JACOCO_VERSION}</version>" in content
+            assert "<goal>prepare-agent</goal>" in content
+            assert "<minimum>0.90</minimum>" in content
+
+    def test_pom_declares_every_ci_quality_plugin(self) -> None:
+        """Checkstyle, PMD, and SpotBugs back the CI's mvn goals.
+
+        reference/ci/java.yml runs checkstyle:check, pmd:check, and
+        spotbugs:check; the spotbugs prefix only resolves when the
+        plugin is declared in the pom.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<artifactId>maven-checkstyle-plugin</artifactId>" in content
+            assert f"<version>{CHECKSTYLE_PLUGIN_VERSION}</version>" in content
+            assert "<configLocation>google_checks.xml</configLocation>" in content
+            assert "<artifactId>maven-pmd-plugin</artifactId>" in content
+            assert f"<version>{PMD_PLUGIN_VERSION}</version>" in content
+            assert "<artifactId>spotbugs-maven-plugin</artifactId>" in content
+            assert f"<version>{SPOTBUGS_PLUGIN_VERSION}</version>" in content
+
+    def test_pom_documents_two_builds_split(self) -> None:
+        """The pom discloses that the APK build is Android tooling's job."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "THE TWO BUILDS" in content
+            assert "Android Studio" in content
+            assert "android-maven-plugin is unmaintained" in content
 
 
 class TestCppDependencies:

--- a/tests/unit/generators/test_readme.py
+++ b/tests/unit/generators/test_readme.py
@@ -15,7 +15,7 @@ EXPECTED_COMMANDS: dict[str, list[str]] = {
     "typescript": ["npm install", "npm test"],
     "go": ["go build", "go test"],
     "rust": ["cargo build", "cargo test"],
-    "java": ["mvn compile", "mvn test"],
+    "java": ["mvn test", "mvn jacoco:check"],
     "csharp": ["dotnet build", "dotnet test"],
     "ruby": ["bundle install", "rspec"],
     "swift": ["swift build", "swift test"],
@@ -547,6 +547,81 @@ class TestKotlinReadme:
         with tempfile.TemporaryDirectory() as tmpdir:
             content = self._readme_content(tmpdir)
             assert "./scripts/check-all.sh" in content
+
+
+class TestJavaReadme:
+    """Test the Java legacy Android Wear README content (#366)."""
+
+    @staticmethod
+    def _readme_content(tmpdir: str) -> str:
+        """Generate the java README and return its text.
+
+        Args:
+            tmpdir: Directory to generate into.
+
+        Returns:
+            The rendered README.md content.
+        """
+        config = ReadmeConfig(
+            project_name="test-project",
+            language="java",
+            package_name="test_project",
+        )
+        files = ReadmeGenerator(Path(tmpdir), config).generate()
+        readme_path: Path = files["README.md"]
+        return readme_path.read_text()
+
+    def test_java_readme_targets_legacy_android_wear(self) -> None:
+        """README documents the Wear OS (legacy Android Wear) target."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "Wear OS" in content
+            assert "legacy Android Wear" in content
+            assert "androidx.wear" in content
+
+    def test_java_readme_documents_two_builds_split(self) -> None:
+        """README explains that the APK build needs Android tooling."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "## The two builds" in content
+            assert "Android Studio" in content
+            assert "android-maven-plugin is unmaintained" in content
+
+    def test_java_readme_documents_maven_usage(self) -> None:
+        """README documents the pure-logic Maven commands."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "mvn test" in content
+            assert "mvn jacoco:check" in content
+            assert "mvn checkstyle:check" in content
+            assert "mvn pmd:check" in content
+            assert "mvn spotbugs:check" in content
+
+    def test_java_readme_advertises_only_generated_artifacts(self) -> None:
+        """README keeps the #367 quality tooling under a Planned section.
+
+        Pre-commit hooks, quality scripts, the metrics dashboard, and
+        architecture rules are not generated for java yet, so they must
+        not carry a checkmark; the CI workflow IS generated (ci.py) and
+        may be advertised as real.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "Planned / coming soon" in content
+            assert "#367" in content
+            assert ".github/workflows/ci.yml" in content
+            # No checkmarked claims for the not-yet-generated tooling.
+            assert "✅ Pre-commit hooks" not in content
+            assert "✅ Quality scripts" not in content
+            # The old overclaiming boilerplate is gone.
+            assert "OWASP" not in content
+            assert "checkstyle.xml" not in content
+
+    def test_java_readme_names_the_sanitized_application_id(self) -> None:
+        """README surfaces the com.example application ID."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "com.example.test_project" in content
 
 
 class TestCppReadme:

--- a/tests/unit/generators/test_structure.py
+++ b/tests/unit/generators/test_structure.py
@@ -33,7 +33,7 @@ EXPECTED_ENTRY_POINTS: dict[str, str] = {
     "typescript": "src/index.ts",
     "go": "cmd/test_project/main.go",
     "rust": "src/main.rs",
-    "java": "src/main/java/test_project/Main.java",
+    "java": "app/src/main/java/com/example/test_project/MainActivity.java",
     "csharp": "src/Program.cs",
     "ruby": "lib/test_project.rb",
     "swift": "Sources/test_project/TestProjectApp.swift",
@@ -54,7 +54,10 @@ EXPECTED_CONFIG_FILES: dict[str, list[str]] = {
     ],
     "go": ["go.mod"],
     "rust": ["Cargo.toml"],
-    "java": ["pom.xml"],
+    # The Maven manifest (pom.xml) is owned by DependenciesGenerator for
+    # java (#366); the structure scaffold ships only sources and the
+    # Android manifest/layout XML.
+    "java": [],
     "csharp": [],
     "ruby": ["Gemfile"],
     "swift": ["Package.swift"],
@@ -321,11 +324,13 @@ class TestMultiLanguageStructure:
             assert entry_path.exists()
             content = entry_path.read_text()
             assert len(content) > 0, f"Entry point empty for {lang}"
-            # Should contain hello/print message
+            # Should contain hello/print message (or assemble it via the
+            # scaffold's greet()/greeting() pure-logic function).
             assert (
                 "hello" in content.lower()
                 or "print" in content.lower()
                 or "fmt" in content.lower()
+                or "greet" in content.lower()
             )
 
     @pytest.mark.parametrize("lang", SUPPORTED_LANGUAGES)
@@ -421,8 +426,8 @@ class TestMultiLanguageStructure:
             assert "[package]" in content
             assert "test-project" in content
 
-    def test_java_creates_pom_xml(self) -> None:
-        """Test Java generates pom.xml."""
+    def test_java_creates_pure_logic_greeting(self) -> None:
+        """Java generates the Maven-buildable pure-logic Greeting class."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config = StructureConfig(
                 project_name="test-project",
@@ -432,9 +437,11 @@ class TestMultiLanguageStructure:
             generator = StructureGenerator(Path(tmpdir), config)
             files = generator.generate()
 
-            assert "pom.xml" in files
-            content = files["pom.xml"].read_text()
-            assert "<project" in content
+            key = "src/main/java/com/example/test_project/Greeting.java"
+            assert key in files
+            content = files[key].read_text()
+            assert "package com.example.test_project;" in content
+            assert 'return "Hello from " + projectName + "!";' in content
 
     def test_csharp_creates_program_cs(self) -> None:
         """Test C# generates Program.cs source file."""
@@ -679,6 +686,170 @@ class TestKotlinStructure:
             assert "settings.gradle.kts" not in files
             assert "build.gradle.kts" not in files
             assert "app/build.gradle.kts" not in files
+
+
+class TestJavaStructure:
+    """Test the Java legacy Android Wear structure generation (#366)."""
+
+    def test_java_creates_android_manifest(self) -> None:
+        """Java generates an AndroidManifest.xml for the app module."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            manifest_key = "app/src/main/AndroidManifest.xml"
+            assert manifest_key in files
+            content = files[manifest_key].read_text()
+            assert "<manifest" in content
+            assert "MainActivity" in content
+
+    def test_java_manifest_declares_wear_device_profile(self) -> None:
+        """The manifest requires the watch hardware feature (Wear OS)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            content = files["app/src/main/AndroidManifest.xml"].read_text()
+            assert (
+                '<uses-feature android:name="android.hardware.type.watch" />' in content
+            )
+
+    def test_java_manifest_declares_standalone_wear_app(self) -> None:
+        """The manifest marks the app standalone (no phone companion)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            content = files["app/src/main/AndroidManifest.xml"].read_text()
+            assert "com.google.android.wearable.standalone" in content
+            assert 'android:value="true"' in content
+
+    def test_java_manifest_declares_package_application_id(self) -> None:
+        """The manifest carries the sanitized package as application ID.
+
+        Unlike the Kotlin scaffold there are no Gradle manifests for the
+        Java app module, so the manifest is the single home of the ID.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="wrist-timer",
+                language="java",
+                package_name="wrist-timer",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            content = files["app/src/main/AndroidManifest.xml"].read_text()
+            root = DefusedElementTree.fromstring(content)
+            assert root.tag == "manifest"
+            assert root.get("package") == "com.example.wrist_timer"
+
+    def test_java_manifest_is_well_formed_xml(self) -> None:
+        """The generated AndroidManifest.xml parses as XML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            content = files["app/src/main/AndroidManifest.xml"].read_text()
+            root = DefusedElementTree.fromstring(content)
+            assert root.tag == "manifest"
+
+    def test_java_creates_wear_main_activity(self) -> None:
+        """Java generates a legacy Wear MainActivity (no WearableActivity)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            key = "app/src/main/java/com/example/test_project/MainActivity.java"
+            assert key in files
+            content = files[key].read_text()
+            assert "package com.example.test_project;" in content
+            assert "public class MainActivity extends Activity" in content
+            assert "setContentView(R.layout.activity_main);" in content
+            assert 'Greeting.greet("test-project")' in content
+            assert "extends WearableActivity" not in content
+
+    def test_java_main_activity_documents_two_builds_split(self) -> None:
+        """MainActivity discloses that the APK build is Android tooling's."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            key = "app/src/main/java/com/example/test_project/MainActivity.java"
+            content = files[key].read_text()
+            assert "Android Studio" in content
+            assert "Maven" in content
+
+    def test_java_creates_box_inset_layout(self) -> None:
+        """The layout XML roots at androidx.wear.widget.BoxInsetLayout."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            key = "app/src/main/res/layout/activity_main.xml"
+            assert key in files
+            content = files[key].read_text()
+            root = DefusedElementTree.fromstring(content)
+            assert root.tag == "androidx.wear.widget.BoxInsetLayout"
+            assert 'android:id="@+id/greeting"' in content
+            assert 'app:boxedEdges="all"' in content
+
+    def test_java_pure_logic_unit_is_android_free(self) -> None:
+        """Greeting.java has no Android imports (Maven-buildable)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            content = files[
+                "src/main/java/com/example/test_project/Greeting.java"
+            ].read_text()
+            assert "import android" not in content
+            assert "public final class Greeting" in content
+            assert 'return "Hello from " + projectName + "!";' in content
+
+    def test_java_does_not_write_maven_manifest(self) -> None:
+        """pom.xml belongs to DependenciesGenerator, not structure (#366)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            files = StructureGenerator(Path(tmpdir), config).generate()
+
+            assert "pom.xml" not in files
+            assert not (Path(tmpdir) / "pom.xml").exists()
 
 
 class TestCppStructure:

--- a/tests/unit/generators/test_tests_generator.py
+++ b/tests/unit/generators/test_tests_generator.py
@@ -16,7 +16,7 @@ EXPECTED_TEST_FILES: dict[str, list[str]] = {
     "typescript": ["tests/index.test.ts"],
     "go": ["cmd/test_project/main_test.go"],
     "rust": ["tests/integration_test.rs"],
-    "java": ["src/test/java/test_project/MainTest.java"],
+    "java": ["src/test/java/com/example/test_project/GreetingTest.java"],
     "csharp": ["tests/MainTests.cs"],
     "ruby": ["spec/test_project_spec.rb", "spec/spec_helper.rb"],
     "swift": ["Tests/test_projectTests/test_projectTests.swift"],
@@ -354,7 +354,7 @@ class TestMultiLanguageTests:
             assert "#[test]" in content
 
     def test_java_test_has_test_annotation(self) -> None:
-        """Test Java test file has @Test annotation."""
+        """Test Java test file has the JUnit 4 @Test annotation."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config = Config(
                 project_name="test-project",
@@ -364,8 +364,40 @@ class TestMultiLanguageTests:
             generator = Generator(Path(tmpdir), config)
             files = generator.generate()
 
-            content = files["src/test/java/test_project/MainTest.java"].read_text()
+            content = files[
+                "src/test/java/com/example/test_project/GreetingTest.java"
+            ].read_text()
             assert "@Test" in content
+            # JUnit 4 (org.junit), matching the pom — not JUnit 5 (jupiter).
+            assert "import org.junit.Test;" in content
+            assert "import static org.junit.Assert.assertEquals;" in content
+            assert "jupiter" not in content
+
+    def test_java_test_exercises_the_greeting_logic(self) -> None:
+        """The Java scaffold test verifies real concatenation logic.
+
+        It must compare ``Greeting.greet()`` output against expected
+        literals — for both the project name and an arbitrary name — so
+        the assertions are not tautological.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="java",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files[
+                "src/test/java/com/example/test_project/GreetingTest.java"
+            ].read_text()
+            assert "package com.example.test_project;" in content
+            assert '"Hello from test-project!"' in content
+            assert 'Greeting.greet("test-project")' in content
+            assert 'assertEquals("Hello from wear!", Greeting.greet("wear"));' in (
+                content
+            )
 
     def test_csharp_test_has_fact_attribute(self) -> None:
         """Test C# test file has [Fact] attribute."""

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -7,8 +7,9 @@ import pytest
 from start_green_stay_green.cli import _get_setup_instructions
 from start_green_stay_green.cli import _venv_activation_command
 
-# Languages exercised by the per-language common-tail tests; "java" covers
-# the unknown-language default path.
+# Languages exercised by the per-language common-tail tests. The
+# unknown-language default path is covered separately with "ruby"
+# (java gained its own Maven step with #366).
 ALL_LANGUAGES = (
     "python",
     "typescript",
@@ -209,6 +210,16 @@ class TestGetSetupInstructions:
         test_idx = instructions.index("ctest --test-dir build")
         assert conan_idx < instructions.index(configure_cmds[0]) < build_idx < test_idx
         assert not any("tizen" in c for c in instructions)
+
+    def test_java_runs_the_pure_logic_maven_tests(self) -> None:
+        """java setup runs mvn test — what the generated pom can do (#366).
+
+        The watch APK build needs Android tooling (Android Studio /
+        Gradle) that init cannot install, so no Gradle/APK step appears.
+        """
+        instructions = _get_setup_instructions(("java",), Path("/home/user/wear-proj"))
+        assert "mvn test" in instructions
+        assert not any("gradle" in c for c in instructions)
 
     def test_unknown_language_has_sensible_default(self) -> None:
         """Unknown languages should still get pre-commit + check-all."""

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -324,10 +324,11 @@ class TestGeneratorOnlyLanguagePipelineGates:
     """Pipeline steps skip gracefully for generator-only languages (#356).
 
     java/csharp/ruby have structure/dependencies/tests/readme generators
-    but no quality-tooling support — instead of crashing init, the tooling
-    steps must no-op with an informational message. Kotlin graduated from
-    this set when #357 wired its pre-commit/scripts/metrics/architecture
-    tooling and #358 wired its CI workflow.
+    (java's are the Wear OS scaffold, #366) and a CI workflow via ci.py,
+    but no pre-commit/scripts/metrics/architecture support (#367 for
+    java) — instead of crashing init, those tooling steps must no-op
+    with an informational message. Kotlin graduated from this set when
+    #357 wired its quality tooling and #358 wired its CI workflow.
     """
 
     def test_precommit_step_writes_for_kotlin(self, tmp_path: Path) -> None:
@@ -337,6 +338,28 @@ class TestGeneratorOnlyLanguagePipelineGates:
         config = tmp_path / ".pre-commit-config.yaml"
         assert config.exists()
         assert "ktlint" in config.read_text()
+
+    def test_precommit_step_skips_java_without_writing(self, tmp_path: Path) -> None:
+        """Pre-commit config stays out of scope for java until #367."""
+        cli_mod._generate_precommit_step(tmp_path, "my-project", "java")
+
+        assert not (tmp_path / ".pre-commit-config.yaml").exists()
+
+    def test_scripts_step_skips_java_without_python_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        """java must not receive the Python-fallback quality scripts."""
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "java")
+
+        assert not (tmp_path / "scripts").exists()
+
+    def test_ci_step_writes_java_workflow(self, tmp_path: Path) -> None:
+        """The java CI workflow is generated (ci.py has a java config)."""
+        cli_mod._generate_ci_step(tmp_path, "my-project", "java", None)
+
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "Java Quality Checks" in ci_file.read_text()
 
     def test_precommit_step_skips_ruby_without_writing(self, tmp_path: Path) -> None:
         """No .pre-commit-config.yaml is written and no error is raised."""

--- a/tests/unit/utils/test_java.py
+++ b/tests/unit/utils/test_java.py
@@ -1,11 +1,17 @@
-"""Unit tests for the shared Kotlin/Android naming helpers."""
+"""Unit tests for the shared Java/Android naming helpers.
+
+The Android package sanitization rules are Java's package rules, so the
+canonical implementation lives in ``utils/java.py`` (#366) and is shared
+by the Java and Kotlin Wear OS scaffolds. These tests moved here from
+``test_kotlin.py`` together with the implementation.
+"""
 
 from __future__ import annotations
 
 import pytest
 
-from start_green_stay_green.utils.kotlin import android_package
-from start_green_stay_green.utils.kotlin import android_package_path
+from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
 
 
 class TestAndroidPackage:
@@ -49,7 +55,7 @@ class TestAndroidPackagePath:
     """Tests for :func:`android_package_path`."""
 
     def test_returns_slash_separated_source_path(self) -> None:
-        """The path form swaps dots for slashes (Kotlin source layout)."""
+        """The path form swaps dots for slashes (Java source layout)."""
         assert android_package_path("wrist_timer") == "com/example/wrist_timer"
 
     def test_matches_android_package_segments(self) -> None:


### PR DESCRIPTION
## Summary

Foundation sub-issue of the **Java (Wear OS, legacy Android Wear)** epic — different from prior foundations because Java was already partially wired (registered, with generic scaffolding and a real ci.py/reference workflow). This upgrades the generic scaffold to a Wear OS app with an honest Maven story:

- **Two-builds split (the Tizen/cpp precedent)**: `pom.xml` builds and gates the **pure-logic** portion only — Greeting + JUnit 4 tests, Surefire, JaCoCo ≥90% line gate at plugin level (so the existing CI's standalone `mvn jacoco:check` resolves), plus Checkstyle/PMD/SpotBugs, making every `mvn` goal in the pre-existing `reference/ci/java.yml` actually resolvable (the old pom couldn't resolve the goals the old README advertised). The watch app lives at the Gradle-conventional `app/src/main/` and is never Maven-compiled: android-maven-plugin is unmaintained and androidx.wear ships AARs Maven can't consume — documented in the pom, the MainActivity javadoc, and the README.
- **Wear OS scaffold**: AndroidManifest with the watch `uses-feature`, wearable `uses-library`, and standalone metadata; `MainActivity extends Activity` over an `androidx.wear.widget.BoxInsetLayout` (WearableActivity is deprecated — disclosed); pure-logic `Greeting.java` with real JUnit tests (no tautologies).
- **New `utils/java.py`** as the canonical home of `android_package` (they're Java's package rules; `utils/kotlin.py` slimmed to Gradle pins, importers repointed) plus pinned Maven toolchain versions.
- **README truthfulness**: CI is checkmarked (it's real and pre-existing); #367's quality tooling stays under "Planned / coming soon"; the init console skip-notices are pinned by tests.

## Test plan

- New 35-test `test_java_init_integration.py` (tree, defusedxml validity of pom/manifest/layout, absence of #367 artifacts and Gradle manifests, README truthfulness); ~30 new unit tests and ~10 updated pins (intent preserved, assertions moved to the new truth); `test_java.py` utils suite.
- `./scripts/check-all.sh`: all 7 checks pass — **2381 unit+integration tests, 23 e2e**, coverage **94.93%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all 30 hooks pass. Real `init -l java` smoke run completes end-to-end.

## Boundaries

#367 (quality tooling), #368 (tests/coverage — incl. java's e2e matrix entry and a flagged `fail_ci_if_error: true` codecov step without a token in the pre-existing java.yml), #369 (docs) remain.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
