### PR TITLE
feat(java): wire quality tooling across precommit/scripts/metrics/architecture (#367)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1735
+        "line_number": 1750
       }
     ]
   },
-  "generated_at": "2026-06-10T17:40:12Z"
+  "generated_at": "2026-06-10T21:13:50Z"
 }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Start Green Stay Green is a meta-tool that scaffolds new software projects with 
 
 - **Enterprise-Grade Quality**: 90%+ code coverage, mutation testing, comprehensive linting
 - **AI Integration**: Pre-configured AI subagent profiles and code review workflows
-- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), and C/C++ (Tizen)
-- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), and an include-boundary checker (C/C++)
+- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), C/C++ (Tizen), and Java (Wear OS legacy)
+- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), an include-boundary checker (C/C++), and ArchUnit (Java)
 - **Complete CI/CD**: GitHub Actions workflows with quality gates
 - **Additive Init**: Safe to re-run in existing directories — preserves your files
 - **Developer Experience**: Rich console output, interactive prompts, dry-run mode
@@ -432,6 +432,7 @@ Project names must follow these rules:
 - **Swift**: swift test (≥90% coverage via llvm-cov), SwiftLint, swift-format, Periphery
 - **Kotlin**: ./gradlew test (≥90% coverage via Kover), detekt, ktlint, OWASP dependency-check
 - **C/C++**: ctest (≥90% coverage via gcov/lcov), clang-format, clang-tidy + cppcheck, lizard, flawfinder
+- **Java**: mvn test (≥90% coverage via JaCoCo), google-java-format, Checkstyle + PMD, SpotBugs, OWASP dependency-check
 
 See the [CLI Reference](docs/CLI_REFERENCE.md#--language---l-text-optional) for the
 full per-language toolchain table and prerequisites.
@@ -762,6 +763,7 @@ All contributions must:
 - ✅ Swift (watchOS) language support — scaffold, quality tooling, CI, tests (#351, #352, #353, #354)
 - ✅ Kotlin (Wear OS) language support — scaffold, quality tooling, CI, tests (#356, #357, #358, #359)
 - ✅ C/C++ (Tizen native) language support — scaffold, quality tooling, CI, tests (#361, #362, #363, #364)
+- ✅ Java (Wear OS legacy) scaffold + CI and quality tooling (#366, #367)
 
 ### Planned
 

--- a/docs/GENERATOR_GUIDE.md
+++ b/docs/GENERATOR_GUIDE.md
@@ -83,7 +83,7 @@ output_path.write_text(yaml_content)
 
 **Configuration Options**:
 - `project_name`: Name of the project
-- `language`: python, typescript, go, rust, swift, kotlin, or cpp
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, or java
 - `language_config`: Language-specific settings (dict)
 
 **Output**: `.pre-commit-config.yaml` with hooks for:
@@ -138,7 +138,7 @@ scripts = generator.generate()
 - `complexity.sh` - Code complexity analysis
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin, cpp
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java
 - `package_name`: Python package name (snake_case)
 
 ### CIGenerator (AI-powered)
@@ -178,7 +178,7 @@ workflows_dir.mkdir(parents=True, exist_ok=True)
 - Documentation validation
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin (cpp CI lands with #363)
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java
 
 ### SkillsGenerator
 
@@ -375,6 +375,7 @@ generator.generate(language="python", project_name="my-app")
 - Swift: SwiftLint custom rules
 - Kotlin: Konsist architecture test
 - C/C++: include-boundary checker (stdlib Python script)
+- Java: ArchUnit architecture test
 
 ### GitHubActionsReviewGenerator (AI-powered)
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1275,7 +1275,7 @@ def _generate_architecture_step(
     if language not in supported:
         # The generator only supports these languages; surface a dim info
         # line so users understand why no architecture rules were generated
-        # for, e.g., a Java project rather than seeing silence.
+        # for, e.g., a C# project rather than seeing silence.
         console.print(
             f"[dim]Architecture rules unavailable for {language} "
             f"(supported: {', '.join(sorted(supported))})[/dim]"

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -944,10 +944,10 @@ def _scripts_dir_has_other_language(scripts_dir: Path, language: str) -> bool:
 
 # Languages with native quality-script templates in ScriptsGenerator.
 # The generator falls back to *Python* scripts for anything else, which
-# would be wrong for e.g. a Java project, so the init pipeline skips
+# would be wrong for e.g. a C# project, so the init pipeline skips
 # the step instead.
 _SCRIPTS_STEP_LANGUAGES: frozenset[str] = frozenset(
-    {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp"}
+    {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java"}
 )
 
 
@@ -962,7 +962,7 @@ def _generate_scripts_step(
 
     If scripts/ already contains scripts from a different language,
     automatically uses scripts/{language}/ subdirectory to avoid conflicts.
-    Languages without native script templates (java, csharp, ruby)
+    Languages without native script templates (csharp, ruby)
     are skipped with an informational message instead of receiving the
     generator's Python fallback.
 
@@ -1010,7 +1010,7 @@ def _generate_precommit_step(
 ) -> None:
     """Generate pre-commit configuration, merging with existing if present.
 
-    Languages PreCommitGenerator does not support yet (java, csharp, ruby)
+    Languages PreCommitGenerator does not support yet (csharp, ruby)
     are skipped with an informational message instead of aborting the
     whole init run.
     """
@@ -1256,13 +1256,22 @@ def _generate_architecture_step(
     Architecture configuration is fully deterministic (import-linter for
     Python, dependency-cruiser for TypeScript, go-arch-lint for Go,
     cargo-deny for Rust, SwiftLint custom rules for Swift, a Konsist test
-    for Kotlin, an include-boundary checker for C/C++). Runs regardless
-    of API key availability; only Python, TypeScript, Go, Rust, Swift,
-    Kotlin, and C/C++ projects produce output. The previous
-    ``orchestrator`` argument was unused and has been removed from this
-    private helper.
+    for Kotlin, an include-boundary checker for C/C++, an ArchUnit test
+    for Java). Runs regardless of API key availability; only Python,
+    TypeScript, Go, Rust, Swift, Kotlin, C/C++, and Java projects produce
+    output. The previous ``orchestrator`` argument was unused and has
+    been removed from this private helper.
     """
-    supported = {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp"}
+    supported = {
+        "python",
+        "typescript",
+        "go",
+        "rust",
+        "swift",
+        "kotlin",
+        "cpp",
+        "java",
+    }
     if language not in supported:
         # The generator only supports these languages; surface a dim info
         # line so users understand why no architecture rules were generated
@@ -1425,7 +1434,7 @@ def _generate_metrics_dashboard_step(
 ) -> None:
     """Generate live metrics dashboard and workflow.
 
-    Languages MetricsGenerator does not support yet (java, csharp, ruby)
+    Languages MetricsGenerator does not support yet (csharp, ruby)
     are skipped with an informational message instead of aborting init
     when ``--enable-live-dashboard`` is passed.
     """

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import warnings
 
 from start_green_stay_green.utils.java import android_package
+from start_green_stay_green.utils.java import android_package_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -157,17 +158,19 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         display_name="C/C++",
     ),
     "java": _LanguageTooling(
-        # ArchUnit is the canonical Java architecture-testing library
-        # (JUnit-based, the Konsist analogue for Java). Its 'config' is
-        # a test compiled into the project: the Maven run command takes
-        # no config-file flag (run_cmd carries no {config_file}
-        # placeholder), and the one-time wiring step — copy the template
-        # into src/test/java — lives in install_cmd. The archunit test
-        # dependency is already declared in the generated pom.xml
-        # (the #357 manifest-touch precedent).
+        # ArchUnit's 'config' is a test compiled into the project, so
+        # run_cmd carries no {config_file} placeholder and the one-time
+        # wiring lives in install_cmd. The {package_path} placeholder is
+        # resolved per-project by _resolved_install_cmd: javac requires
+        # the file to sit in its package-matching directory (unlike
+        # kotlinc, which tolerates the flat copy the Kotlin entry uses).
         tool="ArchUnit",
         config_file="ArchitectureTest.java",
-        install_cmd="cp plans/architecture/ArchitectureTest.java src/test/java/",
+        install_cmd=(
+            "mkdir -p src/test/java/{package_path} && "
+            "cp plans/architecture/ArchitectureTest.java "
+            "src/test/java/{package_path}/"
+        ),
         run_cmd="mvn test -Dtest=ArchitectureTest",
         docs_url="https://www.archunit.org/",
         display_name="Java",
@@ -977,8 +980,11 @@ if __name__ == "__main__":
 //
 // Wiring (one-time): this file is a template parked in
 // plans/architecture; it only enforces once it lives in a test source
-// set. Copy it in and run:
-//   cp plans/architecture/ArchitectureTest.java src/test/java/
+// set. javac requires the file to sit in the directory matching its
+// declared package, so copy it in and run:
+//   mkdir -p src/test/java/{namespace.replace(".", "/")}/architecture
+//   cp plans/architecture/ArchitectureTest.java \\
+//       src/test/java/{namespace.replace(".", "/")}/architecture/
 //   mvn test -Dtest=ArchitectureTest
 // The archunit test dependency is already declared in pom.xml.
 //
@@ -1066,7 +1072,7 @@ public class ArchitectureTest {{
 
         tooling = _LANGUAGE_TOOLING[language]
         tool = tooling.tool
-        install_cmd = tooling.install_cmd
+        install_cmd = self._resolved_install_cmd(language, project_name)
         # Manual invocation runs from the config directory, so the bare
         # config filename is correct here (no plans/architecture/ prefix).
         run_cmd = tooling.run_cmd.format(config_file=tooling.config_file)
@@ -1170,9 +1176,7 @@ Add to CI pipeline:
         readme_path.write_text(readme_content)
         return readme_path
 
-    def _generate_run_script(
-        self, language: str, project_name: str  # noqa: ARG002
-    ) -> Path:
+    def _generate_run_script(self, language: str, project_name: str) -> Path:
         """Generate executable run-check.sh script.
 
         Args:
@@ -1184,7 +1188,7 @@ Add to CI pipeline:
         """
         script_path = self.output_dir / "run-check.sh"
 
-        script_content = self._build_run_script(language)
+        script_content = self._build_run_script(language, project_name)
 
         script_path.write_text(script_content)
 
@@ -1194,7 +1198,30 @@ Add to CI pipeline:
         return script_path
 
     @staticmethod
-    def _build_run_script(language: str) -> str:
+    def _resolved_install_cmd(language: str, project_name: str) -> str:
+        """Resolve the install command's per-project placeholders.
+
+        Java's install command carries a ``{package_path}`` placeholder:
+        javac requires ``ArchitectureTest.java`` to live in the directory
+        matching its declared package, which derives from the project
+        name. Languages without the placeholder return their command
+        unchanged.
+
+        Args:
+            language: Target language.
+            project_name: Name of the project.
+
+        Returns:
+            The install command with any placeholders resolved.
+        """
+        install_cmd = _LANGUAGE_TOOLING[language].install_cmd
+        if "{package_path}" not in install_cmd:
+            return install_cmd
+        package_path = android_package_path(project_name) + "/architecture"
+        return install_cmd.replace("{package_path}", package_path)
+
+    @staticmethod
+    def _build_run_script(language: str, project_name: str) -> str:
         """Build the run-check.sh contents for a language.
 
         Derives the command and the binary-availability guard from the
@@ -1203,11 +1230,16 @@ Add to CI pipeline:
 
         Args:
             language: Target language.
+            project_name: Name of the project (resolves the install
+                command's per-project placeholders).
 
         Returns:
             The shell script source for run-check.sh.
         """
         tooling = _LANGUAGE_TOOLING[language]
+        install_cmd = ArchitectureEnforcementGenerator._resolved_install_cmd(
+            language, project_name
+        )
         # The first token of run_cmd is the binary to probe with command -v.
         binary = tooling.run_cmd.split()[0]
         # Fill the {config_file} placeholder with the path-prefixed config so
@@ -1223,7 +1255,7 @@ set -euo pipefail
 echo "🏛️  Checking {tooling.display_name} architecture with {tooling.tool}..."
 
 if ! command -v {binary} &> /dev/null; then
-    echo "❌ {tooling.tool} not found. Install with: {tooling.install_cmd}"
+    echo "❌ {tooling.tool} not found. Install with: {install_cmd}"
     exit 1
 fi
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -2,8 +2,8 @@
 
 Generates architecture validation configuration for import-linter (Python),
 dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust),
-SwiftLint custom rules (Swift), Konsist (Kotlin), and a stdlib-Python
-include-boundary checker (C/C++).
+SwiftLint custom rules (Swift), Konsist (Kotlin), a stdlib-Python
+include-boundary checker (C/C++), and ArchUnit (Java).
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ class ArchitectureResult:
         output_dir: Directory containing generated files.
         files_created: List of files created.
         language: Target language (python, typescript, go, rust, swift,
-            kotlin, cpp).
+            kotlin, cpp, java).
     """
 
     output_dir: Path
@@ -156,6 +156,22 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         docs_url="check_architecture.py (see its header comment)",
         display_name="C/C++",
     ),
+    "java": _LanguageTooling(
+        # ArchUnit is the canonical Java architecture-testing library
+        # (JUnit-based, the Konsist analogue for Java). Its 'config' is
+        # a test compiled into the project: the Maven run command takes
+        # no config-file flag (run_cmd carries no {config_file}
+        # placeholder), and the one-time wiring step — copy the template
+        # into src/test/java — lives in install_cmd. The archunit test
+        # dependency is already declared in the generated pom.xml
+        # (the #357 manifest-touch precedent).
+        tool="ArchUnit",
+        config_file="ArchitectureTest.java",
+        install_cmd="cp plans/architecture/ArchitectureTest.java src/test/java/",
+        run_cmd="mvn test -Dtest=ArchitectureTest",
+        docs_url="https://www.archunit.org/",
+        display_name="Java",
+    ),
 }
 
 
@@ -165,8 +181,9 @@ class ArchitectureEnforcementGenerator:
     Generates import-linter config for Python, dependency-cruiser
     config for TypeScript, go-arch-lint config for Go, cargo-deny
     config for Rust, SwiftLint custom rules for Swift, a Konsist
-    test for Kotlin, and a runnable include-boundary checker for C/C++
-    to enforce layer separation and prevent circular dependencies.
+    test for Kotlin, a runnable include-boundary checker for C/C++,
+    and an ArchUnit test for Java to enforce layer separation and
+    prevent circular dependencies.
 
     Attributes:
         orchestrator: AI orchestrator for content generation.
@@ -214,7 +231,7 @@ class ArchitectureEnforcementGenerator:
 
         Args:
             language: Target language (python, typescript, go, rust,
-                swift, kotlin, cpp).
+                swift, kotlin, cpp, java).
             project_name: Name of the project.
 
         Returns:
@@ -241,6 +258,7 @@ class ArchitectureEnforcementGenerator:
             "swift": self._generate_swift_config,
             "kotlin": partial(self._generate_kotlin_config, project_name),
             "cpp": self._generate_cpp_config,
+            "java": partial(self._generate_java_config, project_name),
         }
         files_created = config_builders[language]()
 
@@ -919,6 +937,121 @@ if __name__ == "__main__":
         config_path.write_text(config_content)
         return [config_path]
 
+    def _generate_java_config(self, project_name: str) -> list[Path]:
+        """Generate the ArchUnit architecture test for Java.
+
+        ArchUnit is the canonical Java architecture-testing library
+        (JUnit-based), so layer rules are expressed as an ArchUnit test
+        over the compiled classes — the Java analogue of the Kotlin
+        Konsist test. The emitted file is a template parked in
+        ``plans/architecture``: it only enforces once copied into the
+        ``src/test/java`` source set (the archunit dependency is already
+        declared in the generated ``pom.xml``). The test documents that
+        wiring step and ArchUnit's enforcement limits explicitly,
+        mirroring the Konsist, Rust ``deny.toml``, and Swift custom-rule
+        gap notes, and runs with optional layers (warn-first) plus a
+        documented tighten-me switch. Unlike Gradle/Cargo, Maven does
+        not reject package cycles, so an explicit slices rule enforces
+        cycle freedom inside the test. The dependency matrix mirrors the
+        Go config: presentation -> application -> domain, with
+        infrastructure allowed to depend on domain only.
+
+        Args:
+            project_name: Name of the project; layer packages derive
+                from its sanitized Android namespace so the test stays
+                in sync with the scaffolded sources.
+
+        Returns:
+            List of files created.
+        """
+        config_path = self.output_dir / "ArchitectureTest.java"
+
+        namespace = android_package(project_name)
+        config_content = f"""\
+// ArchUnit architecture test enforcing layered architecture.
+//
+// ArchUnit (https://www.archunit.org/) is the canonical Java
+// architecture-testing library: layer rules are expressed as a JUnit
+// test over the compiled classes — the Java analogue of the Kotlin
+// Konsist test.
+//
+// Wiring (one-time): this file is a template parked in
+// plans/architecture; it only enforces once it lives in a test source
+// set. Copy it in and run:
+//   cp plans/architecture/ArchitectureTest.java src/test/java/
+//   mvn test -Dtest=ArchitectureTest
+// The archunit test dependency is already declared in pom.xml.
+//
+// Enforcement limits (documented, not hidden):
+//   - ArchUnit analyzes compiled bytecode (target/classes), so the
+//     classes must compile first (mvn test does); dependencies created
+//     via reflection or dependency-injection wiring are invisible, and
+//     the Android app/ module sits outside the Maven build entirely.
+//   - Layers are defined by the package convention below
+//     ({namespace}.<layer>..); code outside those packages is
+//     unchecked.
+//   - withOptionalLayers(true) is the pragmatic warn-first default: a
+//     layer whose package does not exist yet passes. Tighten by
+//     switching to withOptionalLayers(false) once every layer package
+//     exists.
+//   - Unlike Gradle project graphs or Cargo crate graphs, javac and
+//     Maven do NOT reject circular package dependencies, so cycle
+//     prevention cannot be attributed to the build system: the slices
+//     rule below enforces it inside this test.
+//
+// Dependency matrix (mirrors the Go go-arch-lint config):
+//   presentation -> application, domain
+//   application  -> domain
+//   infrastructure -> domain
+//   domain       -> (nothing)
+package {namespace}.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.library.Architectures;
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
+import org.junit.Test;
+
+public class ArchitectureTest {{
+
+  private static final String BASE_PACKAGE = "{namespace}";
+
+  private JavaClasses projectClasses() {{
+    return new ClassFileImporter().importPackages(BASE_PACKAGE);
+  }}
+
+  @Test
+  public void layersDependOnlyInward() {{
+    Architectures.layeredArchitecture()
+        .consideringOnlyDependenciesInLayers()
+        .withOptionalLayers(true)
+        .layer("Domain").definedBy(BASE_PACKAGE + ".domain..")
+        .layer("Application").definedBy(BASE_PACKAGE + ".application..")
+        .layer("Presentation").definedBy(BASE_PACKAGE + ".presentation..")
+        .layer("Infrastructure").definedBy(BASE_PACKAGE + ".infrastructure..")
+        .whereLayer("Presentation").mayNotBeAccessedByAnyLayer()
+        .whereLayer("Application").mayOnlyBeAccessedByLayers("Presentation")
+        .whereLayer("Infrastructure").mayNotBeAccessedByAnyLayer()
+        .whereLayer("Domain")
+        .mayOnlyBeAccessedByLayers(
+            "Application", "Presentation", "Infrastructure")
+        .check(projectClasses());
+  }}
+
+  @Test
+  public void layerPackagesAreFreeOfCycles() {{
+    SlicesRuleDefinition.slices()
+        .matching(BASE_PACKAGE + ".(*)..")
+        .should()
+        .beFreeOfCycles()
+        .check(projectClasses());
+  }}
+}}
+"""
+
+        config_path.write_text(config_content)
+        return [config_path]
+
     def _generate_readme(self, language: str, project_name: str) -> Path:
         """Generate README with usage instructions.
 
@@ -1006,6 +1139,7 @@ Edit the configuration file:
 - Swift: `.swiftlint-architecture.yml`
 - Kotlin: `ArchitectureTest.kt`
 - C/C++: `check_architecture.py` (the ALLOWED_DEPENDENCIES matrix at the top)
+- Java: `ArchitectureTest.java` (the layered-architecture rules in the test)
 
 See documentation:
 - Python: https://import-linter.readthedocs.io/
@@ -1015,6 +1149,7 @@ See documentation:
 - Swift: https://realm.github.io/SwiftLint/custom_rules.html
 - Kotlin: https://docs.konsist.lemonappdev.com/
 - C/C++: the header comment in check_architecture.py (self-documented)
+- Java: https://www.archunit.org/
 
 ## Integration
 

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -639,7 +639,10 @@ Wear OS app</description>
         <!-- ArchUnit backs the architecture test template parked in
              plans/architecture/ArchitectureTest.java; declared here so
              the template compiles the moment it is copied into
-             src/test/java (see plans/architecture/README.md). -->
+             src/test/java (see plans/architecture/README.md). The base
+             artifact (not archunit-junit4) is deliberate: the template
+             uses plain @Test methods with explicit ClassFileImporter
+             calls, so the JUnit-runner integration adds nothing. -->
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit</artifactId>
@@ -717,11 +720,10 @@ Wear OS app</description>
                 <version>{PMD_PLUGIN_VERSION}</version>
                 <configuration>
                     <rulesets>
-                        <!-- The plugin's stock rules, kept explicitly so
-                             adding the companion below does not silently
-                             drop them. -->
-                        <ruleset>rulesets/java/maven-pmd-plugin-default.xml\
-</ruleset>
+                        <!-- PMD 7's category path for the curated
+                             baseline rules (the pre-7 rulesets/java/*
+                             paths no longer resolve). -->
+                        <ruleset>category/java/quickstart.xml</ruleset>
                         <!-- Companion at the project root (written by the
                              scripts generator): the SINGLE home of the
                              cyclomatic-complexity <= 10 gate, shared by

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -18,7 +18,9 @@ from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
 from start_green_stay_green.utils.cpp import cpp_identifier
+from start_green_stay_green.utils.java import ARCHUNIT_VERSION
 from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
+from start_green_stay_green.utils.java import DEPENDENCY_CHECK_PLUGIN_VERSION
 from start_green_stay_green.utils.java import JACOCO_VERSION
 from start_green_stay_green.utils.java import JAVA_RELEASE
 from start_green_stay_green.utils.java import JUNIT4_VERSION
@@ -83,9 +85,9 @@ class DependenciesGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for java (#367), csharp, and ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358) and
-    C/C++ (#362/#363) run the full pipeline.
+    architecture, and metrics steps for csharp and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358),
+    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
 
     Attributes:
         output_dir: Directory where dependency files will be written
@@ -585,9 +587,13 @@ nursery = "warn"
             Content for the pure-logic Maven build: JUnit 4 + Surefire,
             the JaCoCo agent/report executions with a >=90% line-coverage
             rule (configured at plugin level so the CI's standalone
-            ``mvn jacoco:check`` invocation picks it up too), and the
-            Checkstyle (google_checks), PMD, and SpotBugs plugins
-            matching the generated CI workflow's ``mvn`` commands.
+            ``mvn jacoco:check`` invocation picks it up too), the
+            Checkstyle (google_checks), PMD (stock rules plus the
+            pmd-ruleset.xml complexity companion), SpotBugs, and OWASP
+            dependency-check plugins matching the generated CI workflow
+            and quality scripts' ``mvn`` commands, and the test-scoped
+            ArchUnit dependency backing the architecture test template
+            (#367).
         """
         return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!--
@@ -628,6 +634,16 @@ Wear OS app</description>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>{JUNIT4_VERSION}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- ArchUnit backs the architecture test template parked in
+             plans/architecture/ArchitectureTest.java; declared here so
+             the template compiles the moment it is copied into
+             src/test/java (see plans/architecture/README.md). -->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit</artifactId>
+            <version>{ARCHUNIT_VERSION}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -699,14 +715,45 @@ Wear OS app</description>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>{PMD_PLUGIN_VERSION}</version>
+                <configuration>
+                    <rulesets>
+                        <!-- The plugin's stock rules, kept explicitly so
+                             adding the companion below does not silently
+                             drop them. -->
+                        <ruleset>rulesets/java/maven-pmd-plugin-default.xml\
+</ruleset>
+                        <!-- Companion at the project root (written by the
+                             scripts generator): the SINGLE home of the
+                             cyclomatic-complexity <= 10 gate, shared by
+                             scripts/lint.sh, the pre-commit PMD hook, and
+                             CI. -->
+                        <ruleset>pmd-ruleset.xml</ruleset>
+                    </rulesets>
+                </configuration>
             </plugin>
             <!-- Declared so the CI's `mvn spotbugs:check` resolves: the
                  com.github.spotbugs plugin group is not in Maven's
-                 default plugin-prefix search path. -->
+                 default plugin-prefix search path. NOTE: spotbugs:check
+                 silently skips without compiled classes - run
+                 `mvn compile spotbugs:check` (scripts/security.sh and
+                 the pre-commit hook do). -->
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>{SPOTBUGS_PLUGIN_VERSION}</version>
+            </plugin>
+            <!-- Declared so `mvn dependency-check:check` resolves (the
+                 org.owasp group is also outside Maven's default
+                 plugin-prefix search path). The CVSS >= 7 failure bound
+                 lives here; scripts/security.sh invokes the goal and
+                 documents the NVD_API_KEY requirement. -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>{DEPENDENCY_CHECK_PLUGIN_VERSION}</version>
+                <configuration>
+                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -495,6 +495,22 @@ LANGUAGE_TOOLS: dict[str, dict[str, str]] = {
         "security": "cppcheck + flawfinder",
         "dependency_check": "conan audit",
     },
+    # Java (#367): every gate is a Maven goal backed by the #366 pom.
+    # Coverage is the pom's JaCoCo plugin (the >=90% bound lives at
+    # plugin level in pom.xml); PMD's CyclomaticComplexity rule (via the
+    # pmd-ruleset.xml companion) owns the <=10 complexity gate, so
+    # Checkstyle does not duplicate it. pitest is a periodic mutation
+    # gate like mull/muter, not a per-commit hook. Each tool appears in
+    # exactly one category: SpotBugs owns security (scripts/security.sh)
+    # and OWASP dependency-check owns dependency CVE scanning.
+    "java": {
+        "coverage": "JaCoCo (mvn jacoco:check)",
+        "mutation": "pitest",
+        "complexity": "PMD (CyclomaticComplexity, pmd-ruleset.xml)",
+        "documentation": "javadoc",
+        "security": "SpotBugs (mvn spotbugs:check)",
+        "dependency_check": "OWASP dependency-check (mvn dependency-check:check)",
+    },
 }
 
 

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -26,7 +26,7 @@ class GenerationConfig:
     Attributes:
         project_name: Name of the project.
         language: Programming language (python, typescript, go, rust,
-            swift, kotlin, cpp).
+            swift, kotlin, cpp, java).
         language_config: Additional language-specific configuration.
     """
 
@@ -509,6 +509,120 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         ],
         "default_language_version": {},
     },
+    "java": {
+        "hooks": [
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v4.5.0",
+                "hooks": [
+                    {"id": "trailing-whitespace"},
+                    {"id": "end-of-file-fixer"},
+                    {"id": "check-yaml"},
+                    {"id": "check-json"},
+                    # AndroidManifest.xml and the res/layout XML are the
+                    # scaffold's Android surface, so XML well-formedness
+                    # is gated here (the tizen-manifest.xml precedent).
+                    {"id": "check-xml"},
+                    {"id": "check-added-large-files", "args": ["--maxkb=500"]},
+                    {"id": "check-case-conflict"},
+                    {"id": "check-merge-conflict"},
+                    {"id": "check-symlinks"},
+                    {"id": "detect-private-key"},
+                    {"id": "fix-byte-order-marker"},
+                    {"id": "mixed-line-ending", "args": ["--fix=lf"]},
+                    {"id": "no-commit-to-branch", "args": ["--branch", "main"]},
+                ],
+            },
+            # google-java-format runs as a `repo: local` system hook
+            # (the Swift/Kotlin precedent): unlike clang-format there is
+            # no official pre-commit mirror — the only hook repos are
+            # unofficial wrappers that download release jars at runtime.
+            # Install with: `brew install google-java-format` (macOS) or
+            # grab the all-deps release jar from
+            # https://github.com/google/google-java-format/releases and
+            # wrap it in a `google-java-format` launcher script.
+            #
+            # checkstyle/pmd/spotbugs invoke the Maven goals the #366 pom
+            # already pins and configures (google_checks, the
+            # pmd-ruleset.xml CCN companion, SpotBugs). Maven-goal hooks
+            # are slower than native binaries but zero-install and
+            # cannot version-drift from the build: pom.xml is the single
+            # source of tool truth, locally, in pre-commit, and in CI.
+            {
+                "repo": "local",
+                "hooks": [
+                    {
+                        "id": "google-java-format",
+                        "name": "google-java-format",
+                        # --replace rewrites files in place; unformatted
+                        # files still fail the hook via the diff.
+                        "entry": "google-java-format --replace",
+                        "language": "system",
+                        "types": ["java"],
+                    },
+                    {
+                        "id": "checkstyle",
+                        "name": "Checkstyle (mvn)",
+                        # Reads the google_checks configLocation pinned
+                        # in pom.xml.
+                        "entry": "mvn -q checkstyle:check",
+                        "language": "system",
+                        "types": ["java"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                    {
+                        "id": "pmd",
+                        "name": "PMD (mvn)",
+                        # Reads the pom's rulesets: the maven-pmd-plugin
+                        # defaults plus the pmd-ruleset.xml companion
+                        # (cyclomatic complexity <=10 gate) that
+                        # scripts/lint.sh shares.
+                        "entry": "mvn -q pmd:check",
+                        "language": "system",
+                        "types": ["java"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                    {
+                        "id": "spotbugs",
+                        "name": "SpotBugs (mvn)",
+                        # SpotBugs reads bytecode and `mvn spotbugs:check`
+                        # silently skips when target/classes is empty, so
+                        # the compile phase runs first or the gate would
+                        # be a no-op.
+                        "entry": "mvn -q compile spotbugs:check",
+                        "language": "system",
+                        "types": ["java"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                ],
+            },
+            {
+                "repo": "https://github.com/gitleaks/gitleaks",
+                "rev": "v8.18.4",
+                "hooks": [
+                    {"id": "gitleaks"},
+                ],
+            },
+            {
+                "repo": "https://github.com/shellcheck-py/shellcheck-py",
+                "rev": "v0.9.0.6",
+                "hooks": [
+                    {"id": "shellcheck"},
+                ],
+            },
+            {
+                "repo": "https://github.com/Yelp/detect-secrets",
+                "rev": "v1.4.0",
+                "hooks": [
+                    {
+                        "id": "detect-secrets",
+                        "args": ["--baseline", ".secrets.baseline"],
+                    },
+                ],
+            },
+        ],
+        "default_language_version": {},
+    },
     "cpp": {
         "hooks": [
             {
@@ -634,7 +748,7 @@ class PreCommitGenerator(BaseGenerator):
     Includes formatting, linting, security, and general file quality checks.
 
     Supports: Python, TypeScript, Go, Rust, Swift, Kotlin, C/C++ (cpp),
-    and other languages.
+    Java, and other languages.
 
     Attributes:
         orchestrator: Optional AI orchestrator for enhanced generation.

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -554,9 +554,14 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
                     {
                         "id": "google-java-format",
                         "name": "google-java-format",
-                        # --replace rewrites files in place; unformatted
-                        # files still fail the hook via the diff.
-                        "entry": "google-java-format --replace",
+                        # Check-mode: --replace exits 0 whether or not it
+                        # changed files, so it can never fail a commit.
+                        # --dry-run --set-exit-if-changed fails the hook
+                        # on unformatted files; scripts/format.sh keeps
+                        # --replace for the fixing path.
+                        "entry": (
+                            "google-java-format --dry-run" " --set-exit-if-changed"
+                        ),
                         "language": "system",
                         "types": ["java"],
                     },
@@ -968,12 +973,7 @@ class PreCommitGenerator(BaseGenerator):
             >>> len(hooks) > 0
             True
         """
-        if language not in LANGUAGE_CONFIGS:
-            msg = (
-                f"Unsupported language: {language}. "
-                f"Supported languages: {', '.join(LANGUAGE_CONFIGS.keys())}"
-            )
-            raise ValueError(msg)
+        self._validate_language_supported(language)
         # Cast to satisfy mypy strict mode - dict access returns Any
         return cast("list[dict[str, Any]]", LANGUAGE_CONFIGS[language]["hooks"])
 
@@ -1006,12 +1006,7 @@ class PreCommitGenerator(BaseGenerator):
             >>> count > 20
             True
         """
-        if language not in LANGUAGE_CONFIGS:
-            msg = (
-                f"Unsupported language: {language}. "
-                f"Supported languages: {', '.join(LANGUAGE_CONFIGS.keys())}"
-            )
-            raise ValueError(msg)
+        self._validate_language_supported(language)
 
         hooks_config = LANGUAGE_CONFIGS[language]["hooks"]
         return self._sum_hooks_in_repos(hooks_config)

--- a/start_green_stay_green/generators/readme.py
+++ b/start_green_stay_green/generators/readme.py
@@ -70,9 +70,9 @@ class ReadmeGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for java (#367), csharp, and ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358) and
-    C/C++ (#362/#363) run the full pipeline.
+    architecture, and metrics steps for csharp and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358),
+    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
 
     Attributes:
         output_dir: Directory where README.md will be created
@@ -789,18 +789,17 @@ Generated with [Start Green Stay Green](https://github.com/Geoffe-Ga/start_green
     def _java_readme_content(self) -> str:
         """Generate Java README.md content.
 
-        Only artifacts the scaffold actually generates carry a checkmark:
-        the legacy Android Wear app skeleton, the pure-logic Maven build
-        (JUnit 4 + Surefire, the JaCoCo coverage gate, and the
-        Checkstyle/PMD/SpotBugs plugins matching the generated CI
-        workflow), and the CI pipeline itself, which ``ci.py`` already
-        generates for java. The #367 quality tooling (pre-commit hooks,
-        quality scripts, metrics dashboard, architecture rules) stays
-        under "Planned / coming soon". The two-builds split is documented
-        explicitly: the pure logic builds and tests with plain Maven
-        anywhere, while the watch APK needs Android tooling (Android
-        Studio / Gradle) the generator does not scaffold — the Tizen
-        Studio precedent (#361).
+        Only artifacts the scaffold actually generates carry a checkmark.
+        With the #367 quality toolchain (google-java-format, Maven-goal
+        pre-commit hooks, quality scripts, the JaCoCo coverage gate, the
+        pmd-ruleset.xml complexity companion, and the ArchUnit
+        architecture test) joining the #366 foundation and its CI
+        pipeline, every roadmap item is real and the 'Planned / coming
+        soon' section is gone (the Kotlin #360 / C/C++ #365 precedent).
+        The two-builds split is documented explicitly: the pure logic
+        builds and tests with plain Maven anywhere, while the watch APK
+        needs Android tooling (Android Studio / Gradle) the generator
+        does not scaffold — the Tizen Studio precedent (#361).
 
         Returns:
             Content for README.md
@@ -816,9 +815,9 @@ project generated with Start Green Stay Green.
 
 ## Description
 
-This Java scaffold is the foundation of a quality-controlled legacy
-Android Wear watch-app project — the maintenance path for existing Java
-watch apps. The following are generated today:
+This Java scaffold is a quality-controlled legacy Android Wear
+watch-app project — the maintenance path for existing Java watch apps.
+The following are generated today:
 
 - ✅ Wear OS app skeleton (`app/src/main/`): `AndroidManifest.xml` with
   the watch `uses-feature` and standalone metadata, a `MainActivity`
@@ -829,19 +828,22 @@ watch apps. The following are generated today:
   testable without the Android SDK
 - ✅ Maven build (`pom.xml`, Java {JAVA_RELEASE}) for the pure logic:
   JUnit 4 tests via Surefire, JaCoCo coverage gate (≥90% line), and the
-  Checkstyle/PMD/SpotBugs plugins the CI workflow invokes
+  Checkstyle/PMD/SpotBugs/dependency-check plugins every quality gate
+  invokes
 - ✅ JUnit 4 unit-test scaffold
   (`src/test/java/{package_path}/GreetingTest.java`)
+- ✅ Code quality tools (google-java-format + Checkstyle + PMD, with
+  the complexity gate in `pmd-ruleset.xml`)
+- ✅ Pre-commit hooks (format, Maven-goal linters, secret scanning via
+  gitleaks + detect-secrets)
+- ✅ Quality scripts (`./scripts/check-all.sh` with the ≥90% JaCoCo
+  coverage gate)
+- ✅ Security scanning (SpotBugs + OWASP dependency-check via
+  `./scripts/security.sh`)
+- ✅ Architecture enforcement (ArchUnit test, `plans/architecture/`)
 - ✅ CI/CD pipeline (`.github/workflows/ci.yml` — JDK 17/21 matrix
   running the same `mvn` quality goals as the local build)
 - ✅ This README
-
-**Planned / coming soon** (quality tooling, #367):
-
-- ⏳ Pre-commit hooks configuration
-- ⏳ Quality scripts (`./scripts/check-all.sh` and friends)
-- ⏳ Metrics dashboard
-- ⏳ Architecture enforcement rules
 
 ## The two builds (read this first)
 
@@ -849,7 +851,7 @@ This project deliberately splits into two builds:
 
 1. **Pure logic + unit tests — plain Maven, no Android SDK.** `pom.xml`
    builds only `src/main/java` and `src/test/java`, so `mvn test` and
-   every CI quality goal run on any host — including the generated CI
+   every quality goal run on any host — including the generated CI
    pipeline's runners.
 2. **The watch app itself — Android tooling.** `app/src/main/` needs the
    Android SDK and the androidx.wear AAR
@@ -869,6 +871,12 @@ cd {self.config.project_name}
 
 # Build the pure logic and run its tests (needs JDK {JAVA_RELEASE}+ and Maven)
 mvn test
+
+# Install the formatter (the linters are Maven plugins — no installs)
+brew install google-java-format
+
+# Install the pre-commit hooks
+pre-commit install
 ```
 
 ## Usage
@@ -891,52 +899,59 @@ Hello from {self.config.project_name}!
 
 ### Running Quality Checks
 
-These match the generated CI pipeline (`.github/workflows/ci.yml`)
-goal-for-goal:
-
 ```bash
-# Run all tests (JUnit 4 via Surefire)
-mvn test
+# Run every quality gate (format, lint, tests + coverage, security)
+./scripts/check-all.sh
 
-# Run tests with the JaCoCo coverage report
-mvn clean test jacoco:report
-
-# Enforce the >=90% line-coverage gate
-mvn jacoco:check
-
-# Run Checkstyle (google_checks)
-mvn checkstyle:check
-
-# Run PMD
-mvn pmd:check
-
-# Run SpotBugs
-mvn spotbugs:check
+# Or invoke the underlying Maven goals directly — the same goals the
+# scripts, the pre-commit hooks, and CI run (pom.xml is the single
+# source of tool versions and thresholds):
+mvn test                          # JUnit 4 via Surefire
+mvn clean test jacoco:report      # tests + coverage report
+mvn jacoco:check                  # enforce the >=90% line bound
+mvn checkstyle:check              # Checkstyle (google_checks)
+mvn pmd:check                     # PMD + pmd-ruleset.xml CCN <=10 gate
+mvn compile spotbugs:check        # SpotBugs (needs compiled classes)
 ```
+
+> **Note:** CI runs these same gates on every push and pull request via
+> the generated GitHub Actions pipeline (see *Quality Tools* below).
 
 ### Quality Tools
 
 This scaffold currently includes:
 
 - **JUnit 4**: Unit-test framework (run by Maven Surefire)
-- **JaCoCo**: Coverage gate ≥90% line coverage (`mvn jacoco:check`;
-  only the Maven-built pure-logic sources count — `app/` needs the
-  Android SDK, sits outside the Maven build, and is honestly outside
-  the coverage denominator too)
-- **Checkstyle**: Code style checker (google_checks)
-- **PMD**: Source code analyzer
-- **SpotBugs**: Static bytecode analysis
+- **google-java-format**: Formatting (`./scripts/format.sh`; Google
+  style, no config file by design)
+- **Checkstyle**: Code style checker (google_checks, `./scripts/lint.sh`)
+- **PMD**: Source analysis + cyclomatic complexity ≤10
+  (`pmd-ruleset.xml` is the single home of the bound)
+- **JaCoCo**: Coverage gate ≥90% line coverage
+  (`./scripts/test.sh --coverage`; the bound lives in `pom.xml`. Only
+  the Maven-built pure-logic sources count — `app/` needs the Android
+  SDK, sits outside the Maven build, and is honestly outside the
+  coverage denominator too)
+- **SpotBugs**: Static bytecode analysis (`./scripts/security.sh`)
+- **OWASP dependency-check**: Dependency CVE scan
+  (`./scripts/security.sh`; needs an NVD API key — the script explains)
+- **Pre-commit hooks**: google-java-format, Checkstyle/PMD/SpotBugs as
+  Maven goals, gitleaks, detect-secrets
+- **Architecture rules**: ArchUnit test (`plans/architecture/`; copy
+  into `src/test/java/` to enforce — the README there explains)
 - **CI pipeline**: GitHub Actions (`.github/workflows/ci.yml`) running
   the same `mvn` goals on a JDK 17/21 matrix
-
-Pre-commit hooks, quality scripts, the metrics dashboard, and
-architecture rules are **not** generated for Java yet (#367).
 
 ### Project Structure
 
 ```
 {self.config.project_name}/
 ├── pom.xml                          # Maven build (pure logic only)
+├── pmd-ruleset.xml                  # Complexity gate (CCN <=10)
+├── .pre-commit-config.yaml          # Format/lint/secret-scan hooks
+├── scripts/                         # check-all, format, lint, test,
+│                                    # security
+├── plans/architecture/              # ArchUnit test template
 ├── src/
 │   ├── main/java/{package_path}/
 │   │   └── Greeting.java            # Pure logic: greet()
@@ -973,9 +988,14 @@ This scaffold is a MAXIMUM QUALITY Java project. Today it provides:
 - **Java {JAVA_RELEASE} with compile-time type checking**
   (`maven.compiler.release`)
 - **JUnit 4 test scaffold**: ready for you to add tests
-- **Coverage gate**: `mvn jacoco:check` enforces ≥90% line coverage
-- **Style and static analysis**: Checkstyle, PMD, and SpotBugs wired
-  into the pom
+- **Coverage gate**: `./scripts/test.sh --coverage` enforces ≥90% line
+  coverage via JaCoCo (`mvn jacoco:check`; the bound lives in `pom.xml`)
+- **Complexity gate**: PMD fails on cyclomatic complexity >10
+  (`pmd-ruleset.xml`)
+- **Formatting & static analysis**: google-java-format, Checkstyle,
+  PMD, and SpotBugs, locally and in pre-commit
+- **Architecture enforcement**: ArchUnit layer rules
+  (`plans/architecture/`)
 - **CI enforcement**: every gate above also runs in GitHub Actions on
   every push and pull request, on JDK 17 and 21
 

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -4701,10 +4701,13 @@ fi
 echo "=== Running Tests (mvn) ==="
 
 if $COVERAGE; then
-    # jacoco:check applies the plugin-level rules from pom.xml (the
-    # single home of the >=90% line bound); jacoco:report emits
-    # target/site/jacoco/ for the metrics dashboard and CI upload.
-    mvn clean test jacoco:report jacoco:check || \\
+    # `mvn clean verify` runs the full lifecycle, so the pom's bound
+    # jacoco executions (prepare-agent -> report -> check) fire in
+    # order. Invoking jacoco:check as a standalone goal can silently
+    # pass against an empty report when the agent binding is missing —
+    # the same silent no-op class as the SpotBugs compile guard. The
+    # >=90% line bound lives only in pom.xml.
+    mvn clean verify || \\
         { echo "✗ Tests or coverage gate failed" >&2; exit 1; }
 else
     mvn test || { echo "✗ Tests failed" >&2; exit 1; }
@@ -4843,9 +4846,12 @@ exit 0
     <rule ref="category/java/design.xml/CyclomaticComplexity">
         <properties>
             <!-- Reports at complexity >= 11, i.e. every method must
-                 stay <= 10. The class-level report stays at PMD's
-                 default. -->
+                 stay <= 10. classReportLevel is pinned explicitly:
+                 PMD 7's CyclomaticComplexity has two independent
+                 thresholds, and leaving the class level implicit
+                 invites surprise class-level violations. -->
             <property name="methodReportLevel" value="11" />
+            <property name="classReportLevel" value="80" />
         </properties>
     </rule>
 </ruleset>
@@ -4956,15 +4962,16 @@ cmd_list() {{
         echo "Running: gh ${{args[*]}}"
     fi
 
-    local fmt="%-12s %-30s %-20s %-12s %-18s %s\\n"
-    printf "$fmt" "ID" "BRANCH" "WORKFLOW" \\
+    # Literal format string at each call site: a variable format
+    # trips shellcheck SC2059 in generated projects' own hooks.
+    printf '%-12s %-30s %-20s %-12s %-18s %s\\n' "ID" "BRANCH" "WORKFLOW" \\
         "STATUS" "CONCLUSION" "CREATED"
-    printf "$fmt" "----" "------" "--------" \\
+    printf '%-12s %-30s %-20s %-12s %-18s %s\\n' "----" "------" "--------" \\
         "------" "----------" "-------"
 
     gh "${{args[@]}}" | while IFS=$'\\t' \\
         read -r id branch_name workflow status conclusion created; do
-        printf "$fmt" "$id" "$branch_name" \\
+        printf '%-12s %-30s %-20s %-12s %-18s %s\\n' "$id" "$branch_name" \\
             "$workflow" "$status" "$conclusion" "$created"
     done
 }}

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -1,8 +1,8 @@
 """Scripts directory generator.
 
 Generates quality control scripts adapted to target project languages and structure.
-Supports Python, TypeScript, Go, Rust, Swift, Kotlin, C/C++, and other
-languages with appropriate tooling.
+Supports Python, TypeScript, Go, Rust, Swift, Kotlin, C/C++, Java, and
+other languages with appropriate tooling.
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ class ScriptConfig:
 
     Attributes:
         language: Programming language (python, typescript, go, rust,
-            swift, kotlin, cpp, etc.)
+            swift, kotlin, cpp, java, etc.)
         package_name: Name of the main package/module
         supports_pytest: Whether project uses pytest for testing
         supports_coverage: Whether project uses coverage reporting
@@ -205,6 +205,7 @@ class ScriptsGenerator:
             "swift": self._generate_swift_scripts,
             "kotlin": self._generate_kotlin_scripts,
             "cpp": self._generate_cpp_scripts,
+            "java": self._generate_java_scripts,
         }
         # Fallback to Python scripts for unknown languages.
         builder = builders.get(self.config.language, self._generate_python_scripts)
@@ -480,6 +481,50 @@ class ScriptsGenerator:
         # project root, not added to the scripts dict (not executables).
         self._write_companion_config(".clang-format", _CLANG_FORMAT_CONFIG_TEMPLATE)
         self._write_companion_config(".clang-tidy", _CLANG_TIDY_CONFIG_TEMPLATE)
+
+        return scripts
+
+    def _generate_java_scripts(self) -> dict[str, Path]:
+        """Generate Java-specific quality control scripts (#367).
+
+        Emits check/format/lint/test/security scripts plus a companion
+        ``pmd-ruleset.xml`` at the project root (the single home of the
+        cyclomatic-complexity <=10 gate) so the lint script, the
+        pre-commit PMD hook, and the pom's PMD plugin all share one
+        ruleset. Unlike prior languages, most of the heavy tooling
+        already lives in the #366 pom (Surefire, JaCoCo with the >=90%
+        bound, Checkstyle, PMD, SpotBugs, dependency-check), so these
+        scripts mostly invoke the Maven goals the pom pins rather than
+        standalone binaries.
+
+        Returns:
+            Dictionary mapping script names to file paths
+        """
+        scripts: dict[str, Path] = {}
+
+        scripts["check-all.sh"] = self._write_script(
+            "check-all.sh",
+            self._java_check_all_script(),
+        )
+        scripts["format.sh"] = self._write_script(
+            "format.sh",
+            self._java_format_script(),
+        )
+        scripts["lint.sh"] = self._write_script(
+            "lint.sh",
+            self._java_lint_script(),
+        )
+        scripts["test.sh"] = self._write_script(
+            "test.sh",
+            self._java_test_script(),
+        )
+        scripts["security.sh"] = self._write_script(
+            "security.sh",
+            self._java_security_script(),
+        )
+        # Companion PMD ruleset — written at the project root, not
+        # added to the scripts dict (it isn't an executable).
+        self._write_companion_config("pmd-ruleset.xml", self._PMD_RULESET_TEMPLATE)
 
         return scripts
 
@@ -4308,6 +4353,502 @@ flawfinder --error-level=4 --minlevel=1 src inc tests || \\
 
 echo "✓ Security checks passed"
 exit 0
+"""
+
+    # Java script generators
+
+    def _java_check_all_script(self) -> str:
+        """Generate Java check-all.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Format check (google-java-format)
+  2. Static analysis + complexity <=10 (Checkstyle + PMD via Maven)
+  3. Tests + coverage >=90% (mvn test + JaCoCo)
+  4. Security (SpotBugs + OWASP dependency-check via Maven)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+
+    echo "Running: $check_name"
+    # "${@}" is safe under set -u even when no extra args remain
+    # (unlike a named local array, which needs the
+    # ${args[@]+"${args[@]}"} guard the python template uses).
+    if "$SCRIPT_DIR/$script" "${@}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+run_check "Format" "format.sh"
+run_check "Linting" "lint.sh"
+run_check "Tests" "test.sh" --coverage
+run_check "Security" "security.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    exit 1
+else
+    echo "✓ All quality checks passed!"
+    exit 0
+fi
+"""
+
+    def _java_format_script(self) -> str:
+        """Generate Java format.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/format.sh - Format Java code
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+# Default (no flags) writes formatting in place, same as --fix; use
+# --check for a non-mutating verification pass.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format Java code using google-java-format — the same binary the
+pre-commit hook invokes, so the two can never disagree.
+
+Covers the Maven sources (src/) and the Android app module (app/);
+google-java-format takes no config file, so Google style is the single,
+unconfigurable standard (Checkstyle's google_checks accepts it).
+
+OPTIONS:
+    --fix       Apply formatting (default, writes in place)
+    --check     Check only, fail if formatting needed
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v google-java-format &> /dev/null; then
+    echo "✗ google-java-format not found" >&2
+    echo "  Install with: brew install google-java-format (macOS)" >&2
+    echo "  or wrap the all-deps release jar from" >&2
+    echo "  https://github.com/google/google-java-format/releases" >&2
+    echo "  in a 'google-java-format' launcher on your PATH" >&2
+    exit 1
+fi
+
+echo "=== Formatting (google-java-format) ==="
+
+# find -exec ... + propagates a non-zero exit status when any
+# google-java-format invocation fails, so violations fail the script.
+# Fixing is the default; an explicit --fix overrides --check.
+if $CHECK && ! $FIX; then
+    find src app -type f -name '*.java' \\
+        -exec google-java-format --dry-run --set-exit-if-changed {} + || \\
+        { echo "✗ Format check failed" >&2; exit 1; }
+    echo "✓ Code formatting check passed"
+else
+    find src app -type f -name '*.java' \\
+        -exec google-java-format --replace {} + || \\
+        { echo "✗ Formatting failed" >&2; exit 1; }
+    echo "✓ Code formatted successfully"
+fi
+exit 0
+"""
+
+    def _java_lint_script(self) -> str:
+        """Generate Java lint.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/lint.sh - Static analysis: Checkstyle + PMD (via Maven)
+# Usage: ./scripts/lint.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run static analysis via the Maven goals the pom pins and configures
+(pom.xml is the single source of tool versions and configuration):
+  - Checkstyle (google_checks): mvn -q checkstyle:check
+  - PMD: mvn -q pmd:check — runs the maven-pmd-plugin default rules
+    plus the pmd-ruleset.xml companion at the project root, the single
+    home of the CyclomaticComplexity <=10 gate (PMD reports methods at
+    complexity >= 11).
+
+SpotBugs deliberately lives in scripts/security.sh (bytecode analysis,
+needs a compile pass) so the two scripts never double-report.
+
+Install: brew install maven (macOS) / apt-get install maven (Debian)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           Static-analysis or complexity issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v mvn &> /dev/null; then
+    echo "✗ mvn not found - the lint goals are Maven goals" >&2
+    echo "  Install with: brew install maven (macOS)" >&2
+    echo "             or: apt-get install maven (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Static Analysis (Checkstyle + PMD) ==="
+
+echo "--- Checkstyle (google_checks, pinned in pom.xml) ---"
+mvn -q checkstyle:check || \\
+    { echo "✗ Checkstyle found issues" >&2; exit 1; }
+
+echo "--- PMD (default rules + pmd-ruleset.xml CCN <=10 gate) ---"
+mvn -q pmd:check || \\
+    { echo "✗ PMD found issues" >&2; exit 1; }
+
+echo "✓ Linting checks passed"
+exit 0
+"""
+
+    def _java_test_script(self) -> str:
+        """Generate Java test.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/test.sh - Run Java tests via Maven
+# Usage: ./scripts/test.sh [--coverage] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+COVERAGE=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run the JUnit 4 unit tests (mvn test, via Surefire).
+
+Only the pure-logic Maven build is measured: the app/ module needs the
+Android SDK, sits outside the Maven build, and is therefore honestly
+outside the coverage denominator too (see "The two builds" in the
+README).
+
+OPTIONS:
+    --coverage  Enforce >=90% line coverage via JaCoCo
+                (the bound lives in pom.xml — the jacoco-maven-plugin
+                rules block is its single home; this script never
+                restates the number)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All tests passed (and coverage met, with --coverage)
+    1           Test failures or coverage below threshold
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v mvn &> /dev/null; then
+    echo "✗ mvn not found - the test suite runs via Maven" >&2
+    echo "  Install with: brew install maven (macOS)" >&2
+    echo "             or: apt-get install maven (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Running Tests (mvn) ==="
+
+if $COVERAGE; then
+    # jacoco:check applies the plugin-level rules from pom.xml (the
+    # single home of the >=90% line bound); jacoco:report emits
+    # target/site/jacoco/ for the metrics dashboard and CI upload.
+    mvn clean test jacoco:report jacoco:check || \\
+        { echo "✗ Tests or coverage gate failed" >&2; exit 1; }
+else
+    mvn test || { echo "✗ Tests failed" >&2; exit 1; }
+fi
+
+echo "✓ Tests passed"
+exit 0
+"""
+
+    def _java_security_script(self) -> str:
+        """Generate Java security.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/security.sh - Security checks for Java
+# Usage: ./scripts/security.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run security checks.
+
+Division of labor:
+  - Secret scanning (gitleaks + detect-secrets) runs in pre-commit.
+  - Checkstyle and PMD source analysis run in lint.sh.
+  - This script runs SpotBugs (static bytecode analysis) and OWASP
+    dependency-check CVE scanning, both via the Maven plugins pinned
+    in pom.xml — no extra installs.
+
+dependency-check needs an NVD API key (free:
+https://nvd.nist.gov/developers/request-an-api-key); without one the
+NVD download is throttled to impracticality, so the scan is skipped
+with a warning until NVD_API_KEY is exported.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           No issues found (or dependency-check skipped; see above)
+    1           SpotBugs findings or vulnerable dependencies (CVSS >= 7)
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v mvn &> /dev/null; then
+    echo "✗ mvn not found - the security goals are Maven goals" >&2
+    echo "  Install with: brew install maven (macOS)" >&2
+    echo "             or: apt-get install maven (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Security (SpotBugs + OWASP dependency-check) ==="
+
+echo "--- SpotBugs (static bytecode analysis) ---"
+# spotbugs:check silently skips when target/classes is empty, so the
+# compile phase runs first or the gate would be a no-op.
+mvn -q compile spotbugs:check || \\
+    { echo "✗ SpotBugs found issues" >&2; exit 1; }
+
+echo "--- OWASP dependency-check (CVE scan) ---"
+# Pragmatic default: a missing NVD API key warns instead of failing so
+# a fresh clone passes check-all.sh out of the box (the CVSS>=7 failure
+# bound lives in pom.xml). Tighten by replacing the warning block with
+# 'exit 1' once NVD_API_KEY is exported everywhere (including CI).
+if [ -z "${NVD_API_KEY:-}" ]; then
+    echo "⚠ NVD_API_KEY not set - skipping dependency CVE scan" >&2
+    echo "⚠ Request a free key:" >&2
+    echo "⚠   https://nvd.nist.gov/developers/request-an-api-key" >&2
+    echo "⚠ then export NVD_API_KEY before rerunning" >&2
+else
+    mvn -q -DnvdApiKey="$NVD_API_KEY" dependency-check:check || \\
+        { echo "✗ dependency-check found vulnerable dependencies" >&2; exit 1; }
+fi
+
+echo "✓ Security checks passed"
+exit 0
+"""
+
+    # PMD companion ruleset template. Shared by scripts/lint.sh, the
+    # pre-commit PMD hook, and CI — all three run `mvn pmd:check`, and
+    # pom.xml layers this file on top of the maven-pmd-plugin default
+    # rules. This file is the SINGLE home of the Java
+    # cyclomatic-complexity bound (mirroring the <=10 gate radon/eslint/
+    # gocyclo/clippy/SwiftLint/detekt/lizard apply for the other
+    # languages); neither the scripts nor the pom restate the number.
+    _PMD_RULESET_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  PMD companion ruleset generated by Start Green Stay Green.
+
+  Shared by scripts/lint.sh, the pre-commit PMD hook, and CI: all three
+  run `mvn pmd:check`, and pom.xml layers this file on top of the
+  maven-pmd-plugin default rules (kept explicitly there so adding this
+  companion does not silently drop the stock analysis).
+
+  Complexity gate: PMD reports methods whose cyclomatic complexity is
+  >= methodReportLevel, so 11 reports 11+ and enforces the <= 10
+  ceiling the other supported languages gate on. This file is the
+  single home of that bound.
+-->
+<ruleset name="start-green-stay-green"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+         https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Cyclomatic-complexity ceiling for generated Java projects:
+        methods report at complexity 11 and above, enforcing a ceiling
+        of 10 (see the comment above for the off-by-one mapping).
+    </description>
+    <rule ref="category/java/design.xml/CyclomaticComplexity">
+        <properties>
+            <!-- Reports at complexity >= 11, i.e. every method must
+                 stay <= 10. The class-level report stays at PMD's
+                 default. -->
+            <property name="methodReportLevel" value="11" />
+        </properties>
+    </rule>
+</ruleset>
 """
 
     # Language-agnostic script generators

--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -66,9 +66,9 @@ class StructureGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for java (#367), csharp, and ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358) and
-    C/C++ (#362/#363) run the full pipeline.
+    architecture, and metrics steps for csharp and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358),
+    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
 
     Attributes:
         output_dir: Directory where structure will be created

--- a/start_green_stay_green/generators/tests_gen.py
+++ b/start_green_stay_green/generators/tests_gen.py
@@ -63,9 +63,9 @@ class TestsGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for java (#367), csharp, and ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358) and
-    C/C++ (#362/#363) run the full pipeline.
+    architecture, and metrics steps for csharp and ruby —
+    the CI workflow step covers every language. Kotlin (#357/#358),
+    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
 
     Attributes:
         output_dir: Directory where tests structure will be created

--- a/start_green_stay_green/utils/java.py
+++ b/start_green_stay_green/utils/java.py
@@ -33,6 +33,14 @@ JACOCO_VERSION = "0.8.12"
 CHECKSTYLE_PLUGIN_VERSION = "3.6.0"
 PMD_PLUGIN_VERSION = "3.26.0"
 SPOTBUGS_PLUGIN_VERSION = "4.8.6.6"
+# ArchUnit backs the generated architecture test (#367); test-scoped in
+# the pom so the plans/architecture template compiles once copied into
+# src/test/java (the Konsist manifest-touch precedent from #357).
+ARCHUNIT_VERSION = "1.4.1"
+# OWASP dependency-check Maven plugin (#367); declared in the pom so
+# `mvn dependency-check:check` resolves without the org.owasp group
+# being in Maven's default plugin-prefix search path.
+DEPENDENCY_CHECK_PLUGIN_VERSION = "12.1.3"
 # Java release the pure-logic build targets; within the generated CI
 # workflow's JDK matrix (reference/ci/java.yml runs 17 and 21).
 JAVA_RELEASE = "17"

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -3,14 +3,13 @@
 Tests the complete sgsg init flow for supported languages, verifying
 that the CLI produces valid project structures end-to-end.
 
-Note: java, csharp, and ruby are supported at the generator level
-(java's scaffold is the Wear OS foundation, #366) and get a CI workflow
-via ci.py, but the remaining quality-tooling pipeline steps
-(PreCommitGenerator, scripts, metrics, architecture) skip them — #367
-tracks java. Kotlin completed the pipeline with #357/#358, and C/C++
-followed with #362 (quality tooling) and #363 (CI workflow), so both
-join CLI_SUPPORTED_LANGUAGES below (test_java_init_integration.py and
-test_language_generators.py cover the generator-only languages).
+Note: csharp and ruby are supported at the generator level, but the
+quality-tooling pipeline steps (PreCommitGenerator, scripts, metrics,
+architecture) skip them. Kotlin completed the pipeline with #357/#358,
+C/C++ followed with #362 (quality tooling) and #363 (CI workflow), and
+Java with #366 (Wear OS foundation + CI) and #367 (quality tooling), so
+all three join CLI_SUPPORTED_LANGUAGES below
+(test_language_generators.py covers the generator-only languages).
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.
@@ -35,6 +34,7 @@ CLI_SUPPORTED_LANGUAGES = (
     "swift",
     "kotlin",
     "cpp",
+    "java",
 )
 
 # Expected key files per language that sgsg init should create
@@ -98,6 +98,16 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "tests/test_greeting.cpp",
         ".clang-format",
         ".clang-tidy",
+        ".github/workflows/ci.yml",
+        "README.md",
+    ],
+    "java": [
+        "pom.xml",
+        "pmd-ruleset.xml",
+        "src/main/java/com/example/test_project/Greeting.java",
+        "src/test/java/com/example/test_project/GreetingTest.java",
+        "app/src/main/AndroidManifest.xml",
+        "app/src/main/java/com/example/test_project/MainActivity.java",
         ".github/workflows/ci.yml",
         "README.md",
     ],

--- a/tests/integration/generators/test_java_init_integration.py
+++ b/tests/integration/generators/test_java_init_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``sgsg init --language java`` (#366).
+"""Integration tests for ``sgsg init --language java`` (#366/#367).
 
 Runs the full init flow once via the Typer CliRunner and asserts the
 generated Java (Wear OS, legacy Android Wear) project tree, the Maven
@@ -10,11 +10,10 @@ These tests are structural only — they never invoke Maven, a JDK, or
 the Android SDK — so they pass on CI runners where none of those are
 installed, mirroring ``test_cpp_init_integration.py`` (#361).
 
-Foundation-stage boundaries: the CI workflow IS generated (ci.py has
-had a java config all along), while the #367 quality tooling
-(pre-commit config, quality scripts, metrics dashboard, architecture
-rules) is not — init must skip those steps with informational messages
-and the README must keep them under "Planned / coming soon".
+With #367 the quality toolchain (pre-commit config, quality scripts,
+the pmd-ruleset.xml companion, architecture rules) is generated for
+java alongside the #366 foundation and its CI workflow, so this suite
+locks in the presence of every pipeline artifact.
 """
 
 from pathlib import Path
@@ -101,12 +100,31 @@ class TestJavaInitTree:
     @pytest.mark.parametrize(
         "relative_path",
         [
-            # #367 quality tooling must not be scaffolded yet.
+            # Quality tooling (#367) is now generated alongside the
+            # foundation scaffold.
             ".pre-commit-config.yaml",
+            "pmd-ruleset.xml",
             "scripts/check-all.sh",
+            "scripts/format.sh",
+            "scripts/lint.sh",
             "scripts/test.sh",
-            "plans/architecture",
-            # The metrics dashboard is opt-in and unsupported for java.
+            "scripts/security.sh",
+            "plans/architecture/ArchitectureTest.java",
+            "plans/architecture/run-check.sh",
+        ],
+    )
+    def test_quality_tooling_artifact_generated(
+        self, java_project: Path, relative_path: str
+    ) -> None:
+        """#367 quality-tooling artifacts exist and are non-empty."""
+        file_path = java_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # The metrics dashboard is opt-in (--enable-live-dashboard).
             "docs/metrics.json",
             # No Gradle manifests: the Android build is deliberately not
             # scaffolded (the two-builds split).
@@ -121,8 +139,48 @@ class TestJavaInitTree:
     def test_out_of_scope_artifact_not_generated(
         self, java_project: Path, relative_path: str
     ) -> None:
-        """The scaffold must not emit #367 tooling or Gradle manifests."""
+        """The scaffold must not emit opt-in artifacts or Gradle manifests."""
         assert not (java_project / relative_path).exists()
+
+
+class TestJavaInitQualityTooling:
+    """Assert the generated quality-tooling configs are valid (#367)."""
+
+    def test_precommit_config_parses_and_includes_java_hooks(
+        self, java_project: Path
+    ) -> None:
+        """.pre-commit-config.yaml parses and wires the Java toolchain."""
+        content = (java_project / ".pre-commit-config.yaml").read_text()
+        parsed = yaml.safe_load(
+            "\n".join(line for line in content.split("\n") if not line.startswith("#"))
+        )
+        local_repo = next(
+            repo for repo in parsed["repos"] if repo.get("repo") == "local"
+        )
+        hook_ids = {hook["id"] for hook in local_repo["hooks"]}
+        assert {"google-java-format", "checkstyle", "pmd", "spotbugs"} <= hook_ids
+
+    def test_pmd_ruleset_parses_and_gates_complexity(self, java_project: Path) -> None:
+        """pmd-ruleset.xml parses as XML and carries the CCN rule."""
+        content = (java_project / "pmd-ruleset.xml").read_text()
+        root = DefusedElementTree.fromstring(content)
+        assert root.tag.endswith("ruleset")
+        assert "CyclomaticComplexity" in content
+
+    def test_check_all_script_runs_the_java_toolchain(self, java_project: Path) -> None:
+        """check-all.sh chains format, lint, coverage-gated tests, security."""
+        content = (java_project / "scripts" / "check-all.sh").read_text()
+        assert 'run_check "Tests" "test.sh" --coverage' in content
+
+    def test_architecture_test_defines_the_layer_matrix(
+        self, java_project: Path
+    ) -> None:
+        """The ArchUnit template derives its layers from the project name."""
+        source = (
+            java_project / "plans" / "architecture" / "ArchitectureTest.java"
+        ).read_text()
+        assert f"package {_PACKAGE}.architecture;" in source
+        assert "Architectures.layeredArchitecture()" in source
 
 
 class TestJavaInitManifests:
@@ -261,11 +319,21 @@ class TestJavaInitReadme:
         assert ".github/workflows/ci.yml" in readme
         assert (java_project / ".github" / "workflows" / "ci.yml").is_file()
 
-    def test_readme_keeps_367_tooling_under_planned(self, java_project: Path) -> None:
-        """README lists the #367 quality tooling as planned, not real."""
+    def test_readme_advertises_367_tooling_as_real(self, java_project: Path) -> None:
+        """README advertises the now-generated #367 quality tooling.
+
+        Every artifact the README checkmarks must exist next to it —
+        the truthfulness contract; the 'Planned / coming soon' section
+        is gone because every roadmap item is generated.
+        """
         readme = (java_project / "README.md").read_text()
-        assert "Planned / coming soon" in readme
-        assert "#367" in readme
+        assert "Planned / coming soon" not in readme
+        assert "./scripts/check-all.sh" in readme
+        assert (java_project / "scripts" / "check-all.sh").is_file()
+        assert "plans/architecture" in readme
+        assert (
+            java_project / "plans" / "architecture" / "ArchitectureTest.java"
+        ).is_file()
 
     def test_readme_documents_android_tooling_gap(self, java_project: Path) -> None:
         """README explains that the APK build needs Android Studio/Gradle."""
@@ -275,14 +343,14 @@ class TestJavaInitReadme:
 
 
 class TestJavaInitConsoleOutput:
-    """Assert init's console output reflects the #366 boundaries."""
+    """Assert init's console output reflects the #367 wiring."""
 
-    def test_init_skips_only_the_367_steps(self, tmp_path: Path) -> None:
-        """Init skips pre-commit/scripts/architecture but generates CI.
+    def test_init_skips_no_pipeline_steps(self, tmp_path: Path) -> None:
+        """Init prints no skip notice for any java pipeline step.
 
-        The #367 quality tooling must be announced as unavailable while
-        the CI pipeline (real since ci.py gained its java config) is
-        generated without a skip notice.
+        The pre-commit, scripts, and architecture steps gained java
+        support with #367 (CI has been real since #366), so every
+        "unavailable" notice must be gone.
         """
         runner = CliRunner()
         with patch(
@@ -303,8 +371,8 @@ class TestJavaInitConsoleOutput:
                 ],
             )
         assert result.exit_code == 0
-        assert "Pre-commit config unavailable for java" in result.output
-        assert "Quality scripts unavailable for java" in result.output
-        assert "Architecture rules unavailable for java" in result.output
+        assert "Pre-commit config unavailable for java" not in result.output
+        assert "Quality scripts unavailable for java" not in result.output
+        assert "Architecture rules unavailable for java" not in result.output
         assert "CI pipeline unavailable for java" not in result.output
         assert "Generated CI pipeline" in result.output

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -1152,6 +1152,229 @@ class TestArchitectureEnforcementGeneratorCpp:
         assert result.language == "cpp"
 
 
+class TestArchitectureEnforcementGeneratorJava:
+    """Test Java-specific architecture rules (#367)."""
+
+    @staticmethod
+    def _generate(tmp_path: Path, project_name: str = "my-app") -> Path:
+        """Generate the Java architecture config and return its directory."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+        generator.generate(language="java", project_name=project_name)
+        return output_dir
+
+    def test_generate_java_creates_archunit_test(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test generating the ArchUnit architecture test for Java."""
+        output_dir = self._generate(tmp_path)
+
+        # Should create the ArchUnit test template
+        config_file = output_dir / "ArchitectureTest.java"
+        assert config_file.exists()
+
+        # Should create README and run script
+        assert (output_dir / "README.md").exists()
+        assert (output_dir / "run-check.sh").exists()
+
+    def test_java_config_is_structurally_valid_java(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """ArchitectureTest.java must be structurally valid Java source.
+
+        There is no Java parser in the test environment, so validity is
+        checked structurally (the Kotlin precedent): balanced braces/
+        parentheses, a package declaration first, imports before the
+        class, and no unrendered template placeholders.
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        code_lines = [
+            line
+            for line in source.splitlines()
+            if line.strip() and not line.lstrip().startswith(("//", "*", "/*"))
+        ]
+        code = "\n".join(code_lines)
+
+        assert code.count("{") == code.count("}")
+        assert code.count("(") == code.count(")")
+        # The first statement must be the package declaration, followed by
+        # the imports, then the class.
+        assert code_lines[0].startswith("package ")
+        assert code_lines[0].rstrip().endswith(";")
+        import_lines = [line for line in code_lines if line.startswith("import ")]
+        assert import_lines
+        assert all(line.rstrip().endswith(";") for line in import_lines)
+        assert code.index("package ") < code.index("import ")
+        assert code.index("import ") < code.index("public class ArchitectureTest")
+        assert "@Test" in code
+        # No unrendered Python format placeholders may survive.
+        assert "{namespace}" not in source
+
+    def test_java_config_uses_archunit_api(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test drives ArchUnit's layered-architecture API."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert "import com.tngtech.archunit.core.domain.JavaClasses;" in source
+        assert "import com.tngtech.archunit.core.importer.ClassFileImporter;" in source
+        assert "import com.tngtech.archunit.library.Architectures;" in source
+        assert "Architectures.layeredArchitecture()" in source
+        assert ".consideringOnlyDependenciesInLayers()" in source
+
+    def test_java_config_enforces_layer_separation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test Java config defines all four layers with inward deps."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        for layer in ("Domain", "Application", "Presentation", "Infrastructure"):
+            assert f'.layer("{layer}")' in source
+        assert '.whereLayer("Presentation").mayNotBeAccessedByAnyLayer()' in source
+        assert (
+            '.whereLayer("Application").mayOnlyBeAccessedByLayers("Presentation")'
+            in source
+        )
+        assert '.whereLayer("Infrastructure").mayNotBeAccessedByAnyLayer()' in source
+        assert (
+            '"Application", "Presentation", "Infrastructure"' in source
+        ), "Domain must be accessible from the three outer layers only"
+
+    def test_java_config_checks_package_cycles(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test adds a slices cycle rule — Maven cannot do it.
+
+        Unlike Gradle project graphs or Cargo crate graphs, javac and
+        Maven accept circular package dependencies, so cycle prevention
+        must be enforced by ArchUnit itself rather than attributed to
+        the build system (the inverse of the Kotlin/Rust notes).
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert ".beFreeOfCycles()" in source
+        assert "SlicesRuleDefinition.slices()" in source
+        assert "do NOT reject" in source
+
+    def test_java_config_derives_layer_packages_from_project_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Layer packages come from the shared Android namespace helper.
+
+        A hyphenated project name must produce the sanitized namespace
+        (my-app -> com.example.my_app), keeping the architecture test in
+        sync with the scaffolded sources.
+        """
+        output_dir = self._generate(tmp_path, project_name="my-app")
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert '"com.example.my_app"' in source
+        assert "package com.example.my_app.architecture;" in source
+
+    def test_java_config_documents_bytecode_analysis_limits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test documents what ArchUnit cannot enforce.
+
+        ArchUnit analyzes compiled bytecode; the generated test must
+        disclose that reflection/DI wiring is invisible and that the
+        classes must be compiled first (mirroring the Konsist, Rust
+        deny.toml, and Swift regex-rule gap notes).
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert "reflection" in source
+        assert "bytecode" in source
+        assert "target/classes" in source
+
+    def test_java_config_documents_wiring_requirement(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test discloses it only enforces once wired into src/test/java."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert "src/test/java" in source
+        assert "cp plans/architecture/ArchitectureTest.java" in source
+
+    def test_java_config_documents_optional_layers_default(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The warn-first optional-layers default carries a tighten-me note."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.java").read_text()
+        assert ".withOptionalLayers(true)" in source
+        assert "withOptionalLayers(false)" in source
+
+    def test_java_readme_mentions_archunit(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Java README references the ArchUnit tooling."""
+        output_dir = self._generate(tmp_path)
+
+        readme = (output_dir / "README.md").read_text()
+        assert "ArchUnit" in readme
+
+    def test_java_run_script_probes_maven(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Java run-check.sh probes the mvn binary."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "command -v mvn" in script
+
+    def test_java_run_script_runs_architecture_test(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Java run-check.sh runs the ArchUnit test via Maven."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "-Dtest=ArchitectureTest" in script
+
+    def test_java_run_script_uses_display_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the Java run-check.sh announces the 'Java' display name."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "Checking Java architecture" in script
+
+    def test_java_result_reports_java_language(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the result object records the Java language."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        result = generator.generate(language="java", project_name="my-app")
+
+        assert result.language == "java"
+
+
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
 
@@ -1201,6 +1424,7 @@ class TestLanguageTooling:
             ("swift", "Swift"),
             ("kotlin", "Kotlin"),
             ("cpp", "C/C++"),
+            ("java", "Java"),
         ],
     )
     def test_each_tooling_carries_a_display_name(
@@ -1231,6 +1455,18 @@ class TestLanguageTooling:
         surface to users.
         """
         tooling = _LANGUAGE_TOOLING["kotlin"]
+        assert "{config_file}" not in tooling.run_cmd
+        assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
+
+    def test_java_install_cmd_carries_the_config_path(self) -> None:
+        """Java references its config via install_cmd, not run_cmd (#367).
+
+        ArchUnit's 'config' is a JUnit test compiled into the project —
+        the Konsist precedent — so the Maven run command takes no
+        config-file flag and the wiring step (copying the template into
+        src/test/java) lives in install_cmd.
+        """
+        tooling = _LANGUAGE_TOOLING["java"]
         assert "{config_file}" not in tooling.run_cmd
         assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
 

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -1470,16 +1470,43 @@ class TestLanguageTooling:
         assert "{config_file}" not in tooling.run_cmd
         assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
 
+    def test_java_install_cmd_resolves_package_matched_path(self) -> None:
+        """Java's install command targets the package-matching directory.
+
+        javac requires ArchitectureTest.java to live in the directory
+        matching its declared package; a flat copy into src/test/java/
+        is a guaranteed compile error (kotlinc tolerates the flat copy,
+        javac does not).
+        """
+        cmd = ArchitectureEnforcementGenerator._resolved_install_cmd(
+            "java", "my-watch-app"
+        )
+        assert "mkdir -p src/test/java/com/example/my_watch_app/architecture" in cmd
+        assert "src/test/java/com/example/my_watch_app/architecture/" in cmd
+        assert "{package_path}" not in cmd
+
+    def test_non_java_install_cmds_pass_through_unchanged(self) -> None:
+        """Languages without the placeholder return their command as-is."""
+        for language in ("python", "kotlin", "cpp"):
+            cmd = ArchitectureEnforcementGenerator._resolved_install_cmd(
+                language, "my-app"
+            )
+            assert cmd == _LANGUAGE_TOOLING[language].install_cmd
+
     def test_build_run_script_uses_display_name_not_a_dict(self) -> None:
         """_build_run_script reads display_name from the dataclass."""
         for language in _LANGUAGE_TOOLING:
-            script = ArchitectureEnforcementGenerator._build_run_script(language)
+            script = ArchitectureEnforcementGenerator._build_run_script(
+                language, "my-app"
+            )
             assert _LANGUAGE_TOOLING[language].display_name in script
 
     def test_build_run_script_prefixes_config_via_template(self) -> None:
         """The plans/architecture prefix is inserted via the template."""
         for language, tooling in _LANGUAGE_TOOLING.items():
-            script = ArchitectureEnforcementGenerator._build_run_script(language)
+            script = ArchitectureEnforcementGenerator._build_run_script(
+                language, "my-app"
+            )
             assert f"plans/architecture/{tooling.config_file}" in script
 
     def test_template_prefix_immune_to_substring_collision(self) -> None:

--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -13,7 +13,9 @@ from start_green_stay_green.generators.dependencies import DependencyConfig
 from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
+from start_green_stay_green.utils.java import ARCHUNIT_VERSION
 from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
+from start_green_stay_green.utils.java import DEPENDENCY_CHECK_PLUGIN_VERSION
 from start_green_stay_green.utils.java import JACOCO_VERSION
 from start_green_stay_green.utils.java import JAVA_RELEASE
 from start_green_stay_green.utils.java import JUNIT4_VERSION
@@ -684,6 +686,50 @@ class TestJavaDependencies:
             assert "THE TWO BUILDS" in content
             assert "Android Studio" in content
             assert "android-maven-plugin is unmaintained" in content
+
+    def test_pom_manages_archunit_test_dependency(self) -> None:
+        """ArchUnit is test-scoped so the architecture test compiles (#367).
+
+        The #357 manifest-touch precedent: the architecture template in
+        plans/architecture only compiles once copied into src/test/java,
+        and that copy needs the archunit dependency already declared.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<groupId>com.tngtech.archunit</groupId>" in content
+            assert "<artifactId>archunit</artifactId>" in content
+            assert f"<version>{ARCHUNIT_VERSION}</version>" in content
+
+    def test_pom_pmd_plugin_layers_the_ccn_companion_ruleset(self) -> None:
+        """The PMD plugin keeps its default rules and adds pmd-ruleset.xml.
+
+        The companion ruleset (written by the scripts generator) is the
+        single home of the <=10 cyclomatic-complexity bound; the default
+        maven-pmd-plugin ruleset is kept explicitly so adding the
+        companion does not silently drop the stock analysis.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert (
+                "<ruleset>rulesets/java/maven-pmd-plugin-default.xml</ruleset>"
+                in content
+            )
+            assert "<ruleset>pmd-ruleset.xml</ruleset>" in content
+
+    def test_pom_declares_owasp_dependency_check_plugin(self) -> None:
+        """dependency-check-maven is pinned with the CVSS>=7 failure gate.
+
+        Declared in the pom (rather than a brew-installed CLI) so
+        ``mvn dependency-check:check`` resolves with zero extra installs
+        — the org.owasp group is not in Maven's default plugin-prefix
+        search path.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._pom(tmpdir)
+            assert "<groupId>org.owasp</groupId>" in content
+            assert "<artifactId>dependency-check-maven</artifactId>" in content
+            assert f"<version>{DEPENDENCY_CHECK_PLUGIN_VERSION}</version>" in content
+            assert "<failBuildOnCVSS>7</failBuildOnCVSS>" in content
 
 
 class TestCppDependencies:

--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -701,19 +701,17 @@ class TestJavaDependencies:
             assert f"<version>{ARCHUNIT_VERSION}</version>" in content
 
     def test_pom_pmd_plugin_layers_the_ccn_companion_ruleset(self) -> None:
-        """The PMD plugin keeps its default rules and adds pmd-ruleset.xml.
+        """The PMD plugin layers quickstart baseline + pmd-ruleset.xml.
 
         The companion ruleset (written by the scripts generator) is the
-        single home of the <=10 cyclomatic-complexity bound; the default
-        maven-pmd-plugin ruleset is kept explicitly so adding the
-        companion does not silently drop the stock analysis.
+        single home of the <=10 cyclomatic-complexity bound; the PMD 7
+        ``category/java/quickstart.xml`` baseline is referenced
+        explicitly (pre-7 ``rulesets/java/*`` paths no longer resolve)
+        so adding the companion does not silently drop stock analysis.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             content = self._pom(tmpdir)
-            assert (
-                "<ruleset>rulesets/java/maven-pmd-plugin-default.xml</ruleset>"
-                in content
-            )
+            assert "<ruleset>category/java/quickstart.xml</ruleset>" in content
             assert "<ruleset>pmd-ruleset.xml</ruleset>" in content
 
     def test_pom_declares_owasp_dependency_check_plugin(self) -> None:

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -185,8 +185,48 @@ class TestLanguageTools:
             "swift",
             "kotlin",
             "cpp",
+            "java",
         }
         assert required_languages.issubset(set(LANGUAGE_TOOLS.keys()))
+
+    def test_java_tools(self) -> None:
+        """Test Java tool mappings (#367).
+
+        Each tool appears in exactly one category: the pom's JaCoCo
+        plugin owns coverage (the >=90% bound lives in pom.xml), PMD's
+        CyclomaticComplexity rule owns complexity, SpotBugs owns
+        security, and pitest is a periodic mutation gate like mull/muter.
+        """
+        tools = LANGUAGE_TOOLS["java"]
+        assert tools["coverage"] == "JaCoCo (mvn jacoco:check)"
+        assert tools["mutation"] == "pitest"
+        assert tools["complexity"] == "PMD (CyclomaticComplexity, pmd-ruleset.xml)"
+        assert tools["documentation"] == "javadoc"
+        assert tools["security"] == "SpotBugs (mvn spotbugs:check)"
+        assert tools["dependency_check"] == (
+            "OWASP dependency-check (mvn dependency-check:check)"
+        )
+
+    def test_java_tools_do_not_double_list_across_categories(self) -> None:
+        """No Java tool is claimed by two metric categories.
+
+        The review lesson from the CI generator: listing one tool under
+        two categories overstates the toolchain. Coverage/complexity/
+        security/docs must each name disjoint tools.
+        """
+        tools = LANGUAGE_TOOLS["java"]
+        names_per_category = {
+            "coverage": {"JaCoCo"},
+            "complexity": {"PMD"},
+            "security": {"SpotBugs"},
+            "documentation": {"javadoc"},
+        }
+        for category, names in names_per_category.items():
+            for other_category, other_names in names_per_category.items():
+                if category != other_category:
+                    assert names.isdisjoint(other_names)
+            for name in names:
+                assert name in tools[category]
 
     def test_cpp_tools(self) -> None:
         """Test C/C++ tool mappings (#362).
@@ -830,6 +870,26 @@ class TestMetricsConfigGeneration:
             == "lcov (cmake -DENABLE_COVERAGE=ON + ctest)"
         )
         assert metrics["cyclomatic_complexity"]["tool"] == "lizard (CCN)"
+        assert metrics["code_coverage"]["threshold"] == 90
+        assert metrics["cyclomatic_complexity"]["threshold"] == 10
+
+    def test_generate_metrics_config_java_tools(self) -> None:
+        """Java metric config reports JaCoCo coverage and PMD CCN (#367)."""
+        config = MetricsGenerationConfig(
+            language="java",
+            project_name="wrist-timer",
+        )
+        generator = MetricsGenerator(None, config)
+
+        metrics_config = generator._generate_metrics_config()
+        metrics = metrics_config["metrics"]
+
+        assert metrics_config["language"] == "java"
+        assert metrics["code_coverage"]["tool"] == "JaCoCo (mvn jacoco:check)"
+        assert (
+            metrics["cyclomatic_complexity"]["tool"]
+            == "PMD (CyclomaticComplexity, pmd-ruleset.xml)"
+        )
         assert metrics["code_coverage"]["threshold"] == 90
         assert metrics["cyclomatic_complexity"]["threshold"] == 10
 

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -835,6 +835,170 @@ class TestGenerateWithCpp:
         assert any("shellcheck-py" in url for url in repo_urls)
 
 
+class TestGenerateWithJava:
+    """Test content generation for Java projects (#367)."""
+
+    @staticmethod
+    def _parsed_repos(generator: PreCommitGenerator) -> list[dict[str, Any]]:
+        """Generate the java config and return its parsed repos list."""
+        config = GenerationConfig(
+            project_name="java-project",
+            language="java",
+            language_config={},
+        )
+        result = generator.generate(config)
+        yaml_content = "\n".join(
+            line for line in result["content"].split("\n") if not line.startswith("#")
+        )
+        parsed = yaml.safe_load(yaml_content)
+        return list(parsed["repos"])
+
+    def test_generate_java_returns_dict(self, mock_orchestrator: Mock) -> None:
+        """Test generate returns dict for java."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        config = GenerationConfig(
+            project_name="java-project",
+            language="java",
+            language_config={},
+        )
+        result = generator.generate(config)
+        assert isinstance(result, dict)
+        assert result["content"]
+
+    def test_generate_java_content_is_valid_yaml(self, mock_orchestrator: Mock) -> None:
+        """Generated java pre-commit config must be parseable YAML."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        assert isinstance(repos, list)
+        assert repos
+
+    def test_generate_java_includes_google_java_format(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """google-java-format runs as a local system hook.
+
+        Unlike clang-format, google-java-format has no official
+        pre-commit mirror (the only hook repos are unofficial wrappers
+        that download release jars at runtime), so the formatter probes
+        the installed binary — the Swift/Kotlin precedent.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(
+            (repo for repo in repos if repo.get("repo") == "local"),
+            None,
+        )
+        assert local_repo is not None
+        hook_ids = [hook.get("id", "") for hook in local_repo.get("hooks", [])]
+        assert "google-java-format" in hook_ids
+
+    def test_java_google_java_format_hook_formats_in_place(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """The formatter hook rewrites files (--replace) like ktlint --format."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        formatter = next(
+            hook
+            for hook in local_repo["hooks"]
+            if hook.get("id") == "google-java-format"
+        )
+        assert "--replace" in formatter["entry"]
+        assert formatter["types"] == ["java"]
+
+    @pytest.mark.parametrize("hook_id", ["checkstyle", "pmd", "spotbugs"])
+    def test_generate_java_includes_maven_goal_linters(
+        self, mock_orchestrator: Mock, hook_id: str
+    ) -> None:
+        """Checkstyle/PMD/SpotBugs run as Maven goals the pom resolves.
+
+        The #366 pom already pins and configures all three plugins, so
+        the hooks invoke `mvn -q <prefix>:check` — slower than native
+        binaries but zero-install and impossible to version-drift from
+        the build (single source of tool truth: pom.xml).
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        hook = next(
+            (h for h in local_repo["hooks"] if h.get("id") == hook_id),
+            None,
+        )
+        assert hook is not None, f"missing {hook_id} hook"
+        assert hook["entry"].startswith("mvn -q ")
+        assert f"{hook_id}:check" in hook["entry"]
+        assert hook["pass_filenames"] is False
+        assert hook["types"] == ["java"]
+
+    def test_java_spotbugs_hook_compiles_first(self, mock_orchestrator: Mock) -> None:
+        """The SpotBugs hook compiles before analyzing.
+
+        SpotBugs reads bytecode and `mvn spotbugs:check` silently skips
+        when target/classes is empty, so the entry must run the compile
+        phase first or the gate is a no-op.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        spotbugs = next(
+            hook for hook in local_repo["hooks"] if hook.get("id") == "spotbugs"
+        )
+        assert "compile" in spotbugs["entry"]
+        assert spotbugs["entry"].index("compile") < spotbugs["entry"].index(
+            "spotbugs:check"
+        )
+
+    def test_java_local_hooks_use_system_language(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Local java hooks invoke system binaries (mvn / brew CLIs)."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        local_repo = next(repo for repo in repos if repo.get("repo") == "local")
+        for hook in local_repo["hooks"]:
+            assert hook["language"] == "system", f"{hook['id']} not language: system"
+            assert hook["types"] == ["java"], f"{hook['id']} missing java types"
+
+    def test_generate_java_includes_check_xml(self, mock_orchestrator: Mock) -> None:
+        """AndroidManifest.xml/layout XML well-formedness is gated via check-xml."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        standard_repo = next(
+            repo for repo in repos if "pre-commit-hooks" in repo.get("repo", "")
+        )
+        hook_ids = [hook.get("id", "") for hook in standard_repo.get("hooks", [])]
+        assert "check-xml" in hook_ids
+
+    def test_generate_java_includes_gitleaks(self, mock_orchestrator: Mock) -> None:
+        """Test generated java config includes the gitleaks secrets hook."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        gitleaks_repo = next(
+            (repo for repo in repos if "gitleaks/gitleaks" in repo.get("repo", "")),
+            None,
+        )
+        assert gitleaks_repo is not None
+        hook_ids = [hook.get("id", "") for hook in gitleaks_repo.get("hooks", [])]
+        assert "gitleaks" in hook_ids
+
+    def test_generate_java_includes_detect_secrets(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """java keeps the detect-secrets hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("Yelp/detect-secrets" in url for url in repo_urls)
+
+    def test_generate_java_includes_shellcheck(self, mock_orchestrator: Mock) -> None:
+        """java keeps the shellcheck hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("shellcheck-py" in url for url in repo_urls)
+
+
 class TestValidateLanguage:
     """Test language validation functionality."""
 
@@ -875,6 +1039,11 @@ class TestValidateLanguage:
         """Test validate_language returns True for cpp."""
         generator = PreCommitGenerator(mock_orchestrator)
         assert generator.validate_language("cpp")
+
+    def test_validate_language_java_returns_true(self, mock_orchestrator: Mock) -> None:
+        """Test validate_language returns True for java (#367)."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        assert generator.validate_language("java")
 
     def test_validate_language_rust_returns_true(self, mock_orchestrator: Mock) -> None:
         """Test validate_language returns True for Rust."""
@@ -967,11 +1136,19 @@ class TestGetSupportedLanguages:
         result = generator.get_supported_languages()
         assert "cpp" in result
 
+    def test_get_supported_languages_includes_java(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test get_supported_languages includes java (#367)."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.get_supported_languages()
+        assert "java" in result
+
     def test_get_supported_languages_exact_count(self, mock_orchestrator: Mock) -> None:
         """Test get_supported_languages returns expected count."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_supported_languages()
-        assert len(result) == 7
+        assert len(result) == 8
 
     def test_get_supported_languages_no_duplicates(
         self, mock_orchestrator: Mock
@@ -1041,6 +1218,14 @@ class TestGetLanguageHooks:
         """Test get_language_hooks returns list for cpp."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_language_hooks("cpp")
+        assert isinstance(result, list)
+
+    def test_get_language_hooks_java_returns_list(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test get_language_hooks returns list for java (#367)."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.get_language_hooks("java")
         assert isinstance(result, list)
 
     def test_get_language_hooks_unsupported_raises_error(

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -892,10 +892,16 @@ class TestGenerateWithJava:
         hook_ids = [hook.get("id", "") for hook in local_repo.get("hooks", [])]
         assert "google-java-format" in hook_ids
 
-    def test_java_google_java_format_hook_formats_in_place(
+    def test_java_google_java_format_hook_fails_on_unformatted(
         self, mock_orchestrator: Mock
     ) -> None:
-        """The formatter hook rewrites files (--replace) like ktlint --format."""
+        """The formatter hook is check-mode and fails on unformatted files.
+
+        ``--replace`` exits 0 whether or not it changed anything, so it
+        can never fail a commit; the hook must use
+        ``--dry-run --set-exit-if-changed`` (scripts/format.sh keeps the
+        fixing path).
+        """
         generator = PreCommitGenerator(mock_orchestrator)
         repos = self._parsed_repos(generator)
         local_repo = next(repo for repo in repos if repo.get("repo") == "local")
@@ -904,7 +910,8 @@ class TestGenerateWithJava:
             for hook in local_repo["hooks"]
             if hook.get("id") == "google-java-format"
         )
-        assert "--replace" in formatter["entry"]
+        assert "--dry-run --set-exit-if-changed" in formatter["entry"]
+        assert "--replace" not in formatter["entry"]
         assert formatter["types"] == ["java"]
 
     @pytest.mark.parametrize("hook_id", ["checkstyle", "pmd", "spotbugs"])

--- a/tests/unit/generators/test_readme.py
+++ b/tests/unit/generators/test_readme.py
@@ -595,27 +595,36 @@ class TestJavaReadme:
             assert "mvn jacoco:check" in content
             assert "mvn checkstyle:check" in content
             assert "mvn pmd:check" in content
-            assert "mvn spotbugs:check" in content
+            # The honest SpotBugs invocation compiles first:
+            # spotbugs:check silently skips without compiled classes.
+            assert "mvn compile spotbugs:check" in content
 
-    def test_java_readme_advertises_only_generated_artifacts(self) -> None:
-        """README keeps the #367 quality tooling under a Planned section.
+    def test_java_readme_advertises_the_wired_quality_tooling(self) -> None:
+        """README advertises the #367 quality tooling as real.
 
-        Pre-commit hooks, quality scripts, the metrics dashboard, and
-        architecture rules are not generated for java yet, so they must
-        not carry a checkmark; the CI workflow IS generated (ci.py) and
-        may be advertised as real.
+        With the #367 toolchain (google-java-format, Maven-goal
+        pre-commit hooks, quality scripts, PMD complexity gate, ArchUnit
+        architecture test) and the #366 CI pipeline both generated,
+        every roadmap item is real and the 'Planned / coming soon'
+        section is gone — the Kotlin (#360) / C/C++ (#365) precedent.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             content = self._readme_content(tmpdir)
-            assert "Planned / coming soon" in content
-            assert "#367" in content
+            assert "Planned / coming soon" not in content
             assert ".github/workflows/ci.yml" in content
-            # No checkmarked claims for the not-yet-generated tooling.
-            assert "✅ Pre-commit hooks" not in content
-            assert "✅ Quality scripts" not in content
-            # The old overclaiming boilerplate is gone.
-            assert "OWASP" not in content
-            assert "checkstyle.xml" not in content
+            assert "✅ Pre-commit hooks" in content
+            assert "✅ Quality scripts" in content
+            assert "./scripts/check-all.sh" in content
+            assert "google-java-format" in content
+            assert "ArchUnit" in content
+            assert "plans/architecture" in content
+            assert "pmd-ruleset.xml" in content
+
+    def test_java_readme_documents_coverage_denominator_limit(self) -> None:
+        """README discloses that app/ sits outside the coverage denominator."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "coverage denominator" in content
 
     def test_java_readme_names_the_sanitized_application_id(self) -> None:
         """README surfaces the com.example application ID."""

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -1330,19 +1330,24 @@ class TestScriptsGeneratorJavaGeneration:
             assert "command -v mvn" in content
 
     def test_java_test_script_enforces_coverage_via_pom_jacoco_gate(self) -> None:
-        """Coverage mode runs jacoco:check; the >=90% bound stays in the pom.
+        """Coverage mode runs the full lifecycle; the bound stays in the pom.
 
-        Unlike the cpp THRESHOLD=90 (CMake has no manifest home for the
-        bound), Maven does: the JaCoCo plugin rules in pom.xml are the
-        single source of the coverage bound, so the script must invoke
-        the gate without restating the number.
+        ``mvn clean verify`` fires the pom's bound jacoco executions
+        (prepare-agent -> report -> check) in order; invoking
+        ``jacoco:check`` as a standalone goal can silently pass against
+        an empty report. Unlike the cpp THRESHOLD=90 (CMake has no
+        manifest home for the bound), the JaCoCo plugin rules in pom.xml
+        are the single source of the coverage bound, so the script must
+        not restate the number.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             scripts = self._generate(tmpdir)
 
             content = scripts["test.sh"].read_text()
-            assert "jacoco:report" in content
-            assert "jacoco:check" in content
+            assert "mvn clean verify" in content
+            # No standalone goal invocation remains in the command line
+            # (the string may still appear in explanatory comments).
+            assert "mvn clean test jacoco:report jacoco:check" not in content
             assert "pom.xml" in content
             assert "THRESHOLD=" not in content
 

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import tempfile
 
+from defusedxml import ElementTree as DefusedElementTree
 import pytest
 import yaml
 
@@ -1215,6 +1216,242 @@ class TestScriptsGeneratorCppGeneration:
             assert existing_tidy.read_text() == "Checks: bugprone-*\n"
 
 
+class TestScriptsGeneratorJavaGeneration:
+    """Test Java script generation (#367)."""
+
+    @staticmethod
+    def _generate(tmpdir: str) -> dict[str, Path]:
+        """Generate java scripts into ``tmpdir`` and return the mapping."""
+        config = ScriptConfig(
+            language="java",
+            package_name="my_wear_app",
+        )
+        generator = ScriptsGenerator(Path(tmpdir), config)
+        return generator.generate()
+
+    def test_generate_java_scripts_creates_files(self) -> None:
+        """Test generate creates the full java script set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            assert "check-all.sh" in scripts
+            assert "format.sh" in scripts
+            assert "lint.sh" in scripts
+            assert "test.sh" in scripts
+            assert "security.sh" in scripts
+
+    def test_java_shell_scripts_pass_bash_syntax_check(self) -> None:
+        """Every generated java shell script parses under bash -n.
+
+        The #362 lesson: this literal syntax check caught a real
+        template-escaping bug in the cpp scripts, so every new language
+        gets it from day one.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            for name, path in scripts.items():
+                if not name.endswith(".sh"):
+                    continue
+                bash = shutil.which("bash")
+                assert bash is not None, "bash not found on PATH"
+                result = subprocess.run(  # noqa: S603  # Issue #367: bash -n on generated content, no untrusted input
+                    [bash, "-n", str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, f"{name}: {result.stderr}"
+
+    def test_java_format_script_uses_google_java_format(self) -> None:
+        """format.sh formats in place and verifies with --dry-run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "google-java-format" in content
+            assert "--replace" in content
+            assert "--dry-run --set-exit-if-changed" in content
+
+    def test_java_format_script_requires_the_formatter(self) -> None:
+        """format.sh fails with install instructions when the tool is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "command -v google-java-format" in content
+            assert "brew install google-java-format" in content
+
+    def test_java_lint_script_runs_pom_backed_goals(self) -> None:
+        """lint.sh runs Checkstyle and PMD via the Maven goals the pom pins."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "mvn -q checkstyle:check" in content
+            assert "mvn -q pmd:check" in content
+
+    def test_java_lint_script_requires_maven(self) -> None:
+        """lint.sh fails with install instructions when mvn is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "command -v mvn" in content
+            assert "brew install maven" in content
+
+    def test_java_lint_script_documents_pmd_as_complexity_owner(self) -> None:
+        """The CCN ceiling lives once, in the pmd-ruleset.xml companion.
+
+        PMD's CyclomaticComplexity rule owns the <=10 gate (single
+        source of truth); lint.sh and the script's help text must point
+        at the companion ruleset rather than duplicating a threshold.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "pmd-ruleset.xml" in content
+            assert "CyclomaticComplexity" in content
+            # No shell-side duplicate of the bound.
+            assert "MAX_CCN" not in content
+
+    def test_java_test_script_runs_maven_tests(self) -> None:
+        """test.sh runs the JUnit 4 suite via plain `mvn test`.
+
+        The literal string `mvn test` doubles as the language marker
+        cli._scripts_dir_has_other_language probes for java.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "mvn test" in content
+            assert "command -v mvn" in content
+
+    def test_java_test_script_enforces_coverage_via_pom_jacoco_gate(self) -> None:
+        """Coverage mode runs jacoco:check; the >=90% bound stays in the pom.
+
+        Unlike the cpp THRESHOLD=90 (CMake has no manifest home for the
+        bound), Maven does: the JaCoCo plugin rules in pom.xml are the
+        single source of the coverage bound, so the script must invoke
+        the gate without restating the number.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "jacoco:report" in content
+            assert "jacoco:check" in content
+            assert "pom.xml" in content
+            assert "THRESHOLD=" not in content
+
+    def test_java_test_script_documents_app_module_coverage_limit(self) -> None:
+        """test.sh discloses that the Android app module is not measured.
+
+        app/ needs the Android SDK and sits outside the Maven build, so
+        the coverage gate honestly excludes it rather than implying
+        whole-project coverage — the cpp src/main.cpp precedent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "app/" in content
+            assert "coverage denominator" in content
+
+    def test_java_security_script_compiles_before_spotbugs(self) -> None:
+        """security.sh compiles before the SpotBugs bytecode scan.
+
+        `mvn spotbugs:check` silently skips when target/classes is
+        empty, so the script must run the compile phase first or the
+        gate is a no-op.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "mvn -q compile spotbugs:check" in content
+
+    def test_java_security_script_gates_dependency_check_on_nvd_key(self) -> None:
+        """dependency-check runs only when an NVD API key is configured.
+
+        The pom pins org.owasp:dependency-check-maven, so there is no
+        binary to install — but without an NVD API key the NVD download
+        is throttled to impracticality, so the pragmatic warn-first
+        default skips the scan with a documented tighten-me path.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "NVD_API_KEY" in content
+            assert "dependency-check:check" in content
+            assert "Tighten" in content
+
+    def test_java_security_script_documents_division_of_labor(self) -> None:
+        """security.sh discloses where the other security passes live."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "gitleaks" in content
+            assert "detect-secrets" in content
+
+    def test_java_check_all_runs_full_toolchain(self) -> None:
+        """check-all.sh runs format, lint, tests (with coverage), security."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["check-all.sh"].read_text()
+            assert 'run_check "Format" "format.sh"' in content
+            assert 'run_check "Linting" "lint.sh"' in content
+            assert 'run_check "Tests" "test.sh" --coverage' in content
+            assert 'run_check "Security" "security.sh"' in content
+
+    def test_java_writes_pmd_ruleset_companion(self) -> None:
+        """The pmd-ruleset.xml companion lands at the project root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            assert (Path(tmpdir) / "pmd-ruleset.xml").exists()
+
+    def test_pmd_ruleset_is_well_formed_xml_with_ccn_rule(self) -> None:
+        """pmd-ruleset.xml parses as XML and gates CCN at <=10.
+
+        PMD reports methods whose complexity is >= methodReportLevel,
+        so 11 reports 11+ and enforces the <=10 ceiling the other
+        languages gate on (the detekt threshold: 11 precedent).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            content = (Path(tmpdir) / "pmd-ruleset.xml").read_text()
+            root = DefusedElementTree.fromstring(content)
+            assert root.tag.endswith("ruleset")
+            assert "CyclomaticComplexity" in content
+            assert 'value="11"' in content
+            assert "methodReportLevel" in content
+
+    def test_pmd_ruleset_documents_the_threshold_mapping(self) -> None:
+        """The ruleset explains the report-at-11 == ceiling-10 mapping."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            content = (Path(tmpdir) / "pmd-ruleset.xml").read_text()
+            assert "<= 10" in content
+
+    def test_pmd_ruleset_preserves_existing_file(self) -> None:
+        """An existing user pmd-ruleset.xml is never overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing = Path(tmpdir) / "pmd-ruleset.xml"
+            existing.write_text("<ruleset />\n")
+
+            self._generate(tmpdir)
+
+            assert existing.read_text() == "<ruleset />\n"
+
+
 class TestScriptsGeneratorLanguageFallback:
     """Test language fallback behavior."""
 
@@ -1506,6 +1743,20 @@ class TestMutationKillers:
             content = scripts["lint.sh"].read_text()
             assert "clang-tidy" in content
 
+    def test_java_language_dispatches_to_java_generator(self) -> None:
+        """Test 'java' language dispatches to the Java generator (#367)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="java",
+                package_name="test",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            # Should generate java scripts with the pom-backed goals
+            content = scripts["lint.sh"].read_text()
+            assert "checkstyle:check" in content
+
     def test_generated_scripts_exact_count_python(self) -> None:
         """Test Python generator creates EXACTLY 12 scripts.
 
@@ -1536,6 +1787,32 @@ class TestMutationKillers:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ScriptConfig(
                 language="cpp",
+                package_name="test",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            assert len(scripts) == 6
+            assert sorted(scripts) == [
+                "check-all.sh",
+                "format.sh",
+                "lint.sh",
+                "pr-status.sh",
+                "security.sh",
+                "test.sh",
+            ]
+
+    def test_generated_scripts_exact_count_java(self) -> None:
+        """Test Java generator creates EXACTLY 6 scripts (#367).
+
+        Kills mutations in script count logic and catches silent script
+        additions/removals. Scripts: check-all, format, lint, test,
+        security, pr-status (the pmd-ruleset.xml companion is written
+        separately and not counted here).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="java",
                 package_name="test",
             )
             generator = ScriptsGenerator(Path(tmpdir), config)

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1504,6 +1504,21 @@ class TestGenerateSteps:
         assert mock_generator.generate.call_args.kwargs["language"] == "cpp"
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_java(self, mock_generator_class: Mock) -> None:
+        """Test _generate_architecture_step generates rules for Java."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "java")
+
+        # java now has architecture parity (#367): the generator runs.
+        mock_generator.generate.assert_called_once()
+        assert mock_generator.generate.call_args.kwargs["language"] == "java"
+
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step_skips_unsupported(
         self, mock_generator_class: Mock
     ) -> None:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -161,7 +161,8 @@ class TestMultiLanguageGeneration:
 
 
 class TestMultiLanguageArchitectureParity:
-    """Go (#341), Rust (#342), Swift (#352), Kotlin (#357), cpp (#362)."""
+    """Go (#341), Rust (#342), Swift (#352), Kotlin (#357), cpp (#362),
+    java (#367)."""
 
     def test_go_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
         """Go must emit an architecture-enforcement config like py/ts."""
@@ -198,8 +199,16 @@ class TestMultiLanguageArchitectureParity:
         config = tmp_path / "plans" / "architecture" / "check_architecture.py"
         assert config.exists(), "cpp init must emit the include-boundary checker"
 
+    def test_java_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
+        """java must emit an architecture-enforcement config like py/ts/go."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "java")
+
+        config = tmp_path / "plans" / "architecture" / "ArchitectureTest.java"
+        assert config.exists(), "java init must emit the ArchUnit test template"
+
     @pytest.mark.parametrize(
-        "language", ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp"]
+        "language",
+        ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java"],
     )
     def test_supported_languages_emit_architecture_config(
         self, tmp_path: Path, language: str
@@ -323,12 +332,12 @@ class TestSequentialLanguageDetection:
 class TestGeneratorOnlyLanguagePipelineGates:
     """Pipeline steps skip gracefully for generator-only languages (#356).
 
-    java/csharp/ruby have structure/dependencies/tests/readme generators
-    (java's are the Wear OS scaffold, #366) and a CI workflow via ci.py,
-    but no pre-commit/scripts/metrics/architecture support (#367 for
-    java) — instead of crashing init, those tooling steps must no-op
-    with an informational message. Kotlin graduated from this set when
-    #357 wired its quality tooling and #358 wired its CI workflow.
+    csharp/ruby have structure/dependencies/tests/readme generators but
+    no pre-commit/scripts/metrics/architecture support — instead of
+    crashing init, those tooling steps must no-op with an informational
+    message. Kotlin graduated from this set when #357 wired its quality
+    tooling and #358 wired its CI workflow; java graduated with #367
+    (its CI workflow has been real since #366).
     """
 
     def test_precommit_step_writes_for_kotlin(self, tmp_path: Path) -> None:
@@ -338,28 +347,6 @@ class TestGeneratorOnlyLanguagePipelineGates:
         config = tmp_path / ".pre-commit-config.yaml"
         assert config.exists()
         assert "ktlint" in config.read_text()
-
-    def test_precommit_step_skips_java_without_writing(self, tmp_path: Path) -> None:
-        """Pre-commit config stays out of scope for java until #367."""
-        cli_mod._generate_precommit_step(tmp_path, "my-project", "java")
-
-        assert not (tmp_path / ".pre-commit-config.yaml").exists()
-
-    def test_scripts_step_skips_java_without_python_fallback(
-        self, tmp_path: Path
-    ) -> None:
-        """java must not receive the Python-fallback quality scripts."""
-        cli_mod._generate_scripts_step(tmp_path, "my-project", "java")
-
-        assert not (tmp_path / "scripts").exists()
-
-    def test_ci_step_writes_java_workflow(self, tmp_path: Path) -> None:
-        """The java CI workflow is generated (ci.py has a java config)."""
-        cli_mod._generate_ci_step(tmp_path, "my-project", "java", None)
-
-        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
-        assert ci_file.exists()
-        assert "Java Quality Checks" in ci_file.read_text()
 
     def test_precommit_step_skips_ruby_without_writing(self, tmp_path: Path) -> None:
         """No .pre-commit-config.yaml is written and no error is raised."""
@@ -480,3 +467,64 @@ class TestCppPipelineGates:
 
         checker = tmp_path / "plans" / "architecture" / "check_architecture.py"
         assert checker.exists()
+
+
+class TestJavaPipelineGates:
+    """Pipeline steps all run for java after #367.
+
+    The #366 foundation shipped structure/dependencies/tests/readme plus
+    the CI workflow; #367 wired the pre-commit/scripts/metrics/
+    architecture tooling, so every step must now generate real
+    artifacts.
+    """
+
+    def test_precommit_step_writes_for_java(self, tmp_path: Path) -> None:
+        """java now generates a pre-commit config (#367)."""
+        cli_mod._generate_precommit_step(tmp_path, "my-project", "java")
+
+        config = tmp_path / ".pre-commit-config.yaml"
+        assert config.exists()
+        content = config.read_text()
+        assert "checkstyle" in content
+        assert "google-java-format" in content
+
+    def test_scripts_step_writes_java_scripts(self, tmp_path: Path) -> None:
+        """java now receives its own quality scripts (#367)."""
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "java")
+
+        test_script = tmp_path / "scripts" / "test.sh"
+        assert test_script.exists()
+        assert "mvn test" in test_script.read_text()
+
+    def test_scripts_step_writes_pmd_ruleset_at_project_root(
+        self, tmp_path: Path
+    ) -> None:
+        """The pmd-ruleset.xml companion lands at the root.
+
+        The pom's PMD plugin and lint.sh resolve the ruleset relative to
+        the project root, not the scripts directory.
+        """
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "java")
+
+        assert (tmp_path / "pmd-ruleset.xml").exists()
+
+    def test_ci_step_writes_java_workflow(self, tmp_path: Path) -> None:
+        """The java CI workflow is generated (ci.py has a java config)."""
+        cli_mod._generate_ci_step(tmp_path, "my-project", "java", None)
+
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "Java Quality Checks" in ci_file.read_text()
+
+    def test_metrics_step_writes_java_dashboard(self, tmp_path: Path) -> None:
+        """The metrics dashboard is now generated for java (#367)."""
+        cli_mod._generate_metrics_dashboard_step(tmp_path, "my-project", "java")
+
+        assert (tmp_path / "docs" / "metrics.json").exists()
+
+    def test_architecture_step_writes_java_rules(self, tmp_path: Path) -> None:
+        """Architecture rules are now generated for java (#367)."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "java")
+
+        template = tmp_path / "plans" / "architecture" / "ArchitectureTest.java"
+        assert template.exists()


### PR DESCRIPTION
## Summary

Wires the Java quality toolchain across all four generators (epic sub-issue; #366 foundation merged) — the fourth language to follow the proven shape, with a Maven twist: the #366 pom already configures the heavy tooling, so the generators mostly invoke what the pom owns.

- **precommit.py** — google-java-format as a local system hook (verified: no official pre-commit mirror exists, unlike clang-format), Maven-goal linter hooks (`checkstyle:check`, `pmd:check`, `compile spotbugs:check`) so the pom stays the single source of tool truth, plus shared hygiene/gitleaks/detect-secrets and `check-xml`. The SpotBugs hook compiles first because `spotbugs:check` silently no-ops on empty `target/classes` — a real gap also present in the pre-existing `reference/ci/java.yml`, flagged for #368 rather than scope-crept here. Config passes `pre-commit validate-config`.
- **scripts.py** — check-all/format/lint/test/security; `--coverage` runs `mvn clean test jacoco:report jacoco:check` with **the ≥90% bound living only in the pom** (no shell duplicate; comment contrasts the cpp case where CMake forced the opposite). **Complexity owner: PMD** `CyclomaticComplexity` via a companion `pmd-ruleset.xml` (`methodReportLevel=11` → ≤10 ceiling, the detekt mapping documented); Checkstyle doesn't duplicate it. OWASP dependency-check gated on `NVD_API_KEY` with warn-and-skip (throttled to impracticality without a key). All five scripts pass shellcheck and the **`bash -n` test** — the #425 lesson, now standard.
- **metrics.py** — JaCoCo, pitest (periodic), PMD complexity, javadoc, SpotBugs, dependency-check; disjointness test-locked.
- **architecture.py** — **ArchUnit 1.4.1** (verified live) `ArchitectureTest.java` in the Konsist shape, layer matrix from the shared `android_package` helper — plus an explicit `beFreeOfCycles()` rule with the inverted note: javac/Maven do NOT reject package cycles, unlike SPM/Cargo/Gradle. Structural Java parse-validation tests included.
- **dependencies.py** — pom gains the ArchUnit test dep, PMD rulesets wiring, and dependency-check-maven 12.1.3 (`failBuildOnCVSS 7`).
- **cli.py/readme.py** — gates light up; the Java README's "Planned" section is gone entirely (every roadmap item is now real).

## Test plan

- TDD: **~70 tests added/flipped** including bash -n, exact-count, structural Java validation, `TestJavaPipelineGates`, and the #366 absence→presence integration flips; java added to the e2e matrix.
- `./scripts/check-all.sh`: all 7 checks pass — **2747 tests**, coverage **94.96%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#368 (tests/coverage + the CI spotbugs compile-first fix candidate) and #369 (docs) remain.

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
