### PR TITLE
test(java): fill cross-language matrix gaps and harden the reference CI (#368)

### DIFF
--- a/reference/ci/java.yml
+++ b/reference/ci/java.yml
@@ -47,8 +47,11 @@ jobs:
 
       # The upload is best-effort: no CODECOV_TOKEN is provisioned in a
       # fresh project, and tokenless uploads are rate-limited, so a
-      # failed upload must not fail CI. The enforced >=90% coverage
-      # gate is the `mvn jacoco:check` step below, backed by the pom.
+      # failed upload must not fail CI. Java can afford this leniency
+      # because — unlike the other reference workflows, where the
+      # Codecov upload is the only coverage surface — the enforced
+      # >=90% gate is the local `mvn jacoco:check` step below, backed
+      # by the pom: Codecov here is informational, not load-bearing.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/reference/ci/java.yml
+++ b/reference/ci/java.yml
@@ -35,17 +35,25 @@ jobs:
       - name: Run PMD
         run: mvn pmd:check
 
+      # SpotBugs reads bytecode, and `mvn spotbugs:check` silently
+      # passes when target/classes is empty — compile first so the scan
+      # actually analyzes the project (parity with the generated
+      # pre-commit hook and scripts/security.sh).
       - name: Run SpotBugs
-        run: mvn spotbugs:check
+        run: mvn compile spotbugs:check
 
       - name: Run tests with JaCoCo coverage
         run: mvn clean test jacoco:report
 
+      # The upload is best-effort: no CODECOV_TOKEN is provisioned in a
+      # fresh project, and tokenless uploads are rate-limited, so a
+      # failed upload must not fail CI. The enforced >=90% coverage
+      # gate is the `mvn jacoco:check` step below, backed by the pom.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           file: ./target/site/jacoco/jacoco.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Check coverage threshold
         run: mvn jacoco:check

--- a/reference/scripts/java/lint.sh
+++ b/reference/scripts/java/lint.sh
@@ -6,5 +6,7 @@ mvn checkstyle:check
 echo "Running PMD..."
 mvn pmd:check
 echo "Running SpotBugs..."
-mvn spotbugs:check
+# SpotBugs reads bytecode; without compiled classes `mvn spotbugs:check`
+# silently passes, so compile first.
+mvn compile spotbugs:check
 echo "✓ All linters passed!"

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -108,8 +108,6 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "src/test/java/com/example/test_project/GreetingTest.java",
         "app/src/main/AndroidManifest.xml",
         "app/src/main/java/com/example/test_project/MainActivity.java",
-        # #367 quality tooling generates for java too (the PR #430
-        # review's deferred follow-up — closed by #368).
         ".pre-commit-config.yaml",
         "scripts/check-all.sh",
         ".github/workflows/ci.yml",

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -108,6 +108,10 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "src/test/java/com/example/test_project/GreetingTest.java",
         "app/src/main/AndroidManifest.xml",
         "app/src/main/java/com/example/test_project/MainActivity.java",
+        # #367 quality tooling generates for java too (the PR #430
+        # review's deferred follow-up — closed by #368).
+        ".pre-commit-config.yaml",
+        "scripts/check-all.sh",
         ".github/workflows/ci.yml",
         "README.md",
     ],

--- a/tests/integration/generators/test_java_init_integration.py
+++ b/tests/integration/generators/test_java_init_integration.py
@@ -259,6 +259,49 @@ class TestJavaInitManifests:
         assert "mvn checkstyle:check" in content
         assert "mvn jacoco:check" in content
 
+    def test_ci_workflow_compiles_before_spotbugs(self, java_project: Path) -> None:
+        """The generated workflow's SpotBugs step is never a no-op (#368).
+
+        SpotBugs reads bytecode, so a bare `mvn spotbugs:check` silently
+        passes when target/classes is empty — the generated CI must
+        compile within the same invocation, matching the pre-commit hook
+        and scripts/security.sh.
+        """
+        content = (java_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        run_commands = [
+            cmd
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if (cmd := step.get("run"))
+        ]
+        spotbugs_runs = [cmd for cmd in run_commands if "spotbugs:check" in cmd]
+        assert spotbugs_runs, "CI must run the SpotBugs gate"
+        for command in spotbugs_runs:
+            assert "compile" in command
+            assert command.index("compile") < command.index("spotbugs:check")
+
+    def test_ci_codecov_upload_cannot_fail_a_fresh_project(
+        self, java_project: Path
+    ) -> None:
+        """The Codecov upload is best-effort in generated projects (#368).
+
+        A fresh `green init` project ships no CODECOV_TOKEN secret, so
+        `fail_ci_if_error: true` would start the project red; the real
+        coverage gate is the pom-backed `mvn jacoco:check` step.
+        """
+        content = (java_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert codecov_steps, "CI must still upload coverage to Codecov"
+        for step in codecov_steps:
+            assert step["with"]["fail_ci_if_error"] is False
+
 
 class TestJavaInitSources:
     """Assert the generated Java source and test files."""

--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -92,7 +92,16 @@ class TestPreCommitGeneratorIntegration:
     def test_multiple_languages_workflow(self, mock_orchestrator: Mock) -> None:
         """Test generating configs for multiple languages."""
         generator = PreCommitGenerator(mock_orchestrator)
-        languages = ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp"]
+        languages = [
+            "python",
+            "typescript",
+            "go",
+            "rust",
+            "swift",
+            "kotlin",
+            "cpp",
+            "java",
+        ]
 
         for language in languages:
             config = GenerationConfig(

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -1373,7 +1373,7 @@ class TestCIGeneratorTemplatePath:
 
     @pytest.mark.parametrize(
         "language",
-        ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp"],
+        ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java"],
     )
     def test_generate_from_template_for_supported_language(self, language: str) -> None:
         """Each canonical language renders without an orchestrator."""
@@ -2116,6 +2116,161 @@ class TestCppReferenceTemplate:
         GITHUB_ENV/GITHUB_PATH write to guard.
         """
         parsed = yaml.safe_load(cpp_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
+        assert not any("GITHUB_PATH" in cmd for cmd in run_commands)
+
+
+class TestJavaReferenceTemplate:
+    """Tests for the Java reference CI workflow (#366/#368).
+
+    The java scaffold is a legacy Android Wear app whose Maven build
+    deliberately covers ONLY the pure-logic library and its JUnit 4
+    tests (the #366 two-builds split): the APK is Android tooling's job,
+    so every assertion reflects what `mvn` can actually run on a plain
+    ubuntu runner. The quality gates are the pom-backed Maven goals the
+    integration suite cross-checks against the generated pom.
+    """
+
+    @pytest.fixture
+    def java_workflow(self) -> CIWorkflow:
+        """Render the deterministic Java reference workflow."""
+        return CIGenerator(language="java").generate_workflow_from_template()
+
+    def test_workflow_is_valid_yaml(self, java_workflow: CIWorkflow) -> None:
+        """Rendered workflow parses with yaml.safe_load and validates."""
+        parsed = yaml.safe_load(java_workflow.content)
+        assert java_workflow.is_valid
+        assert isinstance(parsed, dict)
+        assert parsed["name"] == "Java Quality Checks"
+
+    def test_workflow_has_quality_and_build_jobs(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """Workflow declares exactly the quality and build jobs."""
+        parsed = yaml.safe_load(java_workflow.content)
+        assert set(parsed["jobs"]) == {"quality", "build"}
+
+    def test_all_jobs_run_on_ubuntu(self, java_workflow: CIWorkflow) -> None:
+        """Every job runs on ubuntu: Maven/JVM builds need no macOS."""
+        parsed = yaml.safe_load(java_workflow.content)
+        for name, job in parsed["jobs"].items():
+            assert job["runs-on"] == "ubuntu-latest", f"{name} must run on ubuntu"
+
+    def test_jdk_matrix_covers_the_lts_releases_above_the_pom_target(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """The quality job matrixes over JDK 17 and 21.
+
+        utils/java.JAVA_RELEASE pins the pom's --release to 17, so the
+        matrix runs the LTS JDKs that can build it (11 from
+        LANGUAGE_CONFIGS predates the target and is deliberately
+        absent).
+        """
+        parsed = yaml.safe_load(java_workflow.content)
+        matrix = parsed["jobs"]["quality"]["strategy"]["matrix"]
+        assert matrix["java-version"] == ["17", "21"]
+
+    def test_setup_actions_are_pinned_to_majors(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """checkout and setup-java are pinned majors with Maven caching."""
+        content = java_workflow.content
+        assert "actions/checkout@v4" in content
+        assert "actions/setup-java@v4" in content
+        assert "cache: 'maven'" in content
+
+    def test_quality_job_runs_every_pom_backed_gate(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """CI runs the checkstyle/pmd/spotbugs/jacoco goals the pom backs.
+
+        The generated pom declares each plugin precisely so these goals
+        resolve (test_java_init_integration cross-checks the pom side).
+        """
+        parsed = yaml.safe_load(java_workflow.content)
+        quality_commands = [
+            cmd.strip()
+            for step in parsed["jobs"]["quality"]["steps"]
+            if (cmd := step.get("run"))
+        ]
+        assert "mvn checkstyle:check" in quality_commands
+        assert "mvn pmd:check" in quality_commands
+        assert "mvn clean test jacoco:report" in quality_commands
+        assert "mvn jacoco:check" in quality_commands
+
+    def test_spotbugs_compiles_before_checking(self, java_workflow: CIWorkflow) -> None:
+        """The SpotBugs step compiles first so the scan is not a no-op.
+
+        SpotBugs reads bytecode: a bare `mvn spotbugs:check` silently
+        passes when target/classes is empty (the #367 report's gap, the
+        PR #430 review's carry-over). The compile must precede the check
+        within one invocation, matching the generated pre-commit hook
+        and scripts/security.sh.
+        """
+        parsed = yaml.safe_load(java_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        spotbugs_runs = [cmd for cmd in run_commands if "spotbugs:check" in cmd]
+        assert len(spotbugs_runs) == 1
+        command = spotbugs_runs[0]
+        assert "compile" in command
+        assert command.index("compile") < command.index("spotbugs:check")
+
+    def test_codecov_upload_cannot_fail_ci(self, java_workflow: CIWorkflow) -> None:
+        """The tokenless Codecov upload is best-effort, never a gate.
+
+        A fresh project has no CODECOV_TOKEN secret and tokenless
+        uploads are rate-limited, so `fail_ci_if_error: true` would make
+        generated projects start red (the #366 report's gap). The
+        enforced coverage gate is the pom-backed `mvn jacoco:check`
+        step instead.
+        """
+        parsed = yaml.safe_load(java_workflow.content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert len(codecov_steps) == 1
+        assert codecov_steps[0]["with"]["fail_ci_if_error"] is False
+
+    def test_build_job_packages_without_rerunning_tests(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """The build job packages the JAR; the suite ran once in quality.
+
+        -DskipTests keeps the single coverage-gated test execution in
+        the quality job (the Swift PR #414 no-double-test-run lesson).
+        """
+        parsed = yaml.safe_load(java_workflow.content)
+        build_commands = [
+            step.get("run", "") for step in parsed["jobs"]["build"]["steps"]
+        ]
+        assert any("mvn clean package -DskipTests" in cmd for cmd in build_commands)
+        assert any("mvn verify -DskipTests" in cmd for cmd in build_commands)
+
+    def test_android_packaging_documented_not_stubbed(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """No step pretends to build the APK Maven cannot produce."""
+        parsed = yaml.safe_load(java_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("gradle" in cmd for cmd in run_commands)
+        assert not any("apk" in cmd.lower() for cmd in run_commands)
+
+    def test_workflow_writes_nothing_to_github_env(
+        self, java_workflow: CIWorkflow
+    ) -> None:
+        """Nothing discovered at runtime is exported to GITHUB_ENV.
+
+        The Swift PR #414 review flagged unvalidated GITHUB_ENV writes
+        as the documented Actions env-injection vector; like the Kotlin
+        and cpp workflows, every value here is a static literal, so
+        there is no dynamic discovery and no GITHUB_ENV/GITHUB_PATH
+        write to guard.
+        """
+        parsed = yaml.safe_load(java_workflow.content)
         run_commands = _all_run_commands(parsed)
         assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
         assert not any("GITHUB_PATH" in cmd for cmd in run_commands)

--- a/tests/unit/reference/test_reference_assets.py
+++ b/tests/unit/reference/test_reference_assets.py
@@ -96,6 +96,27 @@ class TestScriptsReferences:
             assert script_path.is_file()
             assert script_path.stat().st_size > 0, f"Empty Python script: {script}"
 
+    def test_java_lint_script_compiles_before_spotbugs(
+        self, scripts_dir: Path
+    ) -> None:
+        """The java reference lint script's SpotBugs run is no no-op (#368).
+
+        SpotBugs reads bytecode: a bare ``mvn spotbugs:check`` silently
+        passes when target/classes is empty, so the reference script must
+        compile within the same invocation — parity with the generated
+        scripts/security.sh and reference/ci/java.yml.
+        """
+        content = (scripts_dir / "java" / "lint.sh").read_text()
+        commands = [
+            line
+            for line in content.splitlines()
+            if "spotbugs:check" in line and not line.lstrip().startswith("#")
+        ]
+        assert commands, "lint.sh must run the SpotBugs gate"
+        for command in commands:
+            assert "compile" in command
+            assert command.index("compile") < command.index("spotbugs:check")
+
 
 class TestSkillsReferences:
     """Test skills references exist and have proper structure."""


### PR DESCRIPTION
## Summary

Survey-first execution (the Swift #354 / Kotlin #359 / C++ #364 pattern): #366/#367 already delivered the 35-test integration suite, multi-language parametrization, conftest mapping, and setup-instruction matrices. This fills the genuinely missing pieces, including the items the #430 review explicitly deferred here:

- **e2e self-consistency** — the java `EXPECTED_KEY_FILES` entry now includes `.pre-commit-config.yaml` and `scripts/check-all.sh`, matching the kotlin/cpp entries (the #430 round-3 note).
- **Matrices** — java added to the precommit multi-language workflow list; parity assertions added to the java init integration suite.
- **Reference-CI hardening (test-pinned)** — `mvn compile spotbugs:check` in both `reference/ci/java.yml` and the reference `lint.sh` (bare `spotbugs:check` silently passes on empty `target/classes` — the #367 finding, now fixed at its source), and the codecov upload is best-effort (`fail_ci_if_error: false` with rationale: fresh projects have no `CODECOV_TOKEN`; the enforced ≥90% gate is the pom-backed `mvn jacoco:check` step).

## Mutation testing (honest status)

Re-verified: mutmut 3.6.0 still crashes on the repo's 2.x-style `[tool.mutmut]` config. Separately-tracked gap; no score claimed.

## Test plan

- `./scripts/check-all.sh`: all 7 checks pass (coverage ≥90% gate green).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.
- Touched suites green: ci/reference-assets/java-integration/precommit-integration (141 tests) plus the full e2e suite (24).

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
