### PR TITLE
feat(csharp): wire quality tooling across precommit/scripts/metrics/architecture (#370)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1750
+        "line_number": 1767
       }
     ]
   },
-  "generated_at": "2026-06-10T21:13:50Z"
+  "generated_at": "2026-06-11T00:25:17Z"
 }

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Start Green Stay Green is a meta-tool that scaffolds new software projects with 
 
 - **Enterprise-Grade Quality**: 90%+ code coverage, mutation testing, comprehensive linting
 - **AI Integration**: Pre-configured AI subagent profiles and code review workflows
-- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), C/C++ (Tizen), and Java (Wear OS legacy)
-- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), an include-boundary checker (C/C++), and ArchUnit (Java)
+- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), C/C++ (Tizen), Java (Wear OS legacy), and C# (.NET)
+- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), an include-boundary checker (C/C++), ArchUnit (Java), and NetArchTest (C#)
 - **Complete CI/CD**: GitHub Actions workflows with quality gates
 - **Additive Init**: Safe to re-run in existing directories — preserves your files
 - **Developer Experience**: Rich console output, interactive prompts, dry-run mode
@@ -433,6 +433,7 @@ Project names must follow these rules:
 - **Kotlin**: ./gradlew test (≥90% coverage via Kover), detekt, ktlint, OWASP dependency-check
 - **C/C++**: ctest (≥90% coverage via gcov/lcov), clang-format, clang-tidy + cppcheck, lizard, flawfinder
 - **Java**: mvn test (≥90% coverage via JaCoCo), google-java-format, Checkstyle + PMD, SpotBugs, OWASP dependency-check
+- **C#**: dotnet test (≥90% coverage via Coverlet), dotnet format, Roslyn analyzers (CA1502 complexity ≤10), SecurityCodeScan + vulnerable-package scan
 
 See the [CLI Reference](docs/CLI_REFERENCE.md#--language---l-text-optional) for the
 full per-language toolchain table and prerequisites.
@@ -794,6 +795,7 @@ All contributions must:
 - ✅ Kotlin (Wear OS) language support — scaffold, quality tooling, CI, tests (#356, #357, #358, #359)
 - ✅ C/C++ (Tizen native) language support — scaffold, quality tooling, CI, tests (#361, #362, #363, #364)
 - ✅ Java (Wear OS legacy) language support — scaffold, quality tooling, CI, tests, docs (#366, #367, #368, #369)
+- ✅ C# (.NET) quality tooling on top of the foundation scaffold + CI (#370)
 
 ### Planned
 

--- a/docs/GENERATOR_GUIDE.md
+++ b/docs/GENERATOR_GUIDE.md
@@ -83,7 +83,7 @@ output_path.write_text(yaml_content)
 
 **Configuration Options**:
 - `project_name`: Name of the project
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, or java
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, or csharp
 - `language_config`: Language-specific settings (dict)
 
 **Output**: `.pre-commit-config.yaml` with hooks for:
@@ -138,7 +138,7 @@ scripts = generator.generate()
 - `complexity.sh` - Code complexity analysis
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, java
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp
 - `package_name`: Python package name (snake_case)
 
 ### CIGenerator (AI-powered)
@@ -178,7 +178,7 @@ workflows_dir.mkdir(parents=True, exist_ok=True)
 - Documentation validation
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, java
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp
 
 ### SkillsGenerator
 
@@ -376,6 +376,7 @@ generator.generate(language="python", project_name="my-app")
 - Kotlin: Konsist architecture test
 - C/C++: include-boundary checker (stdlib Python script)
 - Java: ArchUnit architecture test
+- C#: NetArchTest architecture test
 
 ### GitHubActionsReviewGenerator (AI-powered)
 

--- a/reference/ci/csharp.yml
+++ b/reference/ci/csharp.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ["7.0", "8.0"]
+        # The generated csproj targets net8.0, which older SDKs cannot
+        # build, so the matrix pins the 8.0 line (extend it together
+        # with the TargetFramework).
+        dotnet-version: ["8.0"]
 
     steps:
       - name: Checkout code
@@ -30,23 +33,31 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Build
+      # The csproj treats analyzer warnings as errors (Roslyn CA rules,
+      # the CA1502 complexity ceiling, SecurityCodeScan), so this plain
+      # build doubles as the lint gate.
+      - name: Build (Roslyn analyzers as errors)
         run: dotnet build --no-restore
 
-      - name: Run StyleCop
+      - name: Check formatting (dotnet format)
         run: dotnet format --verify-no-changes
 
-      - name: Run tests with coverage
+      # /p:CollectCoverage=true activates the Coverlet gate; the >=90%
+      # line bound lives in the csproj (Threshold/ThresholdType/
+      # ThresholdStat) — its single home — so this invocation enforces
+      # it without restating the number. opencover output feeds the
+      # Codecov upload below.
+      - name: Run tests with coverage (>=90% gate in the csproj)
         run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
 
+      # Best-effort: a fresh `green init` project ships no
+      # CODECOV_TOKEN secret, so a failing upload must not start the
+      # project red; the real coverage gate is the Coverlet run above.
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.opencover.xml
-          fail_ci_if_error: true
-
-      - name: Check coverage threshold
-        run: dotnet test /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line
+          fail_ci_if_error: false
 
   build:
     name: Build and Package

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -944,10 +944,10 @@ def _scripts_dir_has_other_language(scripts_dir: Path, language: str) -> bool:
 
 # Languages with native quality-script templates in ScriptsGenerator.
 # The generator falls back to *Python* scripts for anything else, which
-# would be wrong for e.g. a C# project, so the init pipeline skips
+# would be wrong for e.g. a Ruby project, so the init pipeline skips
 # the step instead.
 _SCRIPTS_STEP_LANGUAGES: frozenset[str] = frozenset(
-    {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java"}
+    {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java", "csharp"}
 )
 
 
@@ -962,7 +962,7 @@ def _generate_scripts_step(
 
     If scripts/ already contains scripts from a different language,
     automatically uses scripts/{language}/ subdirectory to avoid conflicts.
-    Languages without native script templates (csharp, ruby)
+    Languages without native script templates (ruby)
     are skipped with an informational message instead of receiving the
     generator's Python fallback.
 
@@ -1010,7 +1010,7 @@ def _generate_precommit_step(
 ) -> None:
     """Generate pre-commit configuration, merging with existing if present.
 
-    Languages PreCommitGenerator does not support yet (csharp, ruby)
+    Languages PreCommitGenerator does not support yet (ruby)
     are skipped with an informational message instead of aborting the
     whole init run.
     """
@@ -1257,10 +1257,11 @@ def _generate_architecture_step(
     Python, dependency-cruiser for TypeScript, go-arch-lint for Go,
     cargo-deny for Rust, SwiftLint custom rules for Swift, a Konsist test
     for Kotlin, an include-boundary checker for C/C++, an ArchUnit test
-    for Java). Runs regardless of API key availability; only Python,
-    TypeScript, Go, Rust, Swift, Kotlin, C/C++, and Java projects produce
-    output. The previous ``orchestrator`` argument was unused and has
-    been removed from this private helper.
+    for Java, a NetArchTest test for C#). Runs regardless of API key
+    availability; only Python, TypeScript, Go, Rust, Swift, Kotlin,
+    C/C++, Java, and C# projects produce output. The previous
+    ``orchestrator`` argument was unused and has been removed from this
+    private helper.
     """
     supported = {
         "python",
@@ -1271,11 +1272,12 @@ def _generate_architecture_step(
         "kotlin",
         "cpp",
         "java",
+        "csharp",
     }
     if language not in supported:
         # The generator only supports these languages; surface a dim info
         # line so users understand why no architecture rules were generated
-        # for, e.g., a C# project rather than seeing silence.
+        # for, e.g., a Ruby project rather than seeing silence.
         console.print(
             f"[dim]Architecture rules unavailable for {language} "
             f"(supported: {', '.join(sorted(supported))})[/dim]"
@@ -1434,7 +1436,7 @@ def _generate_metrics_dashboard_step(
 ) -> None:
     """Generate live metrics dashboard and workflow.
 
-    Languages MetricsGenerator does not support yet (csharp, ruby)
+    Languages MetricsGenerator does not support yet (ruby)
     are skipped with an informational message instead of aborting init
     when ``--enable-live-dashboard`` is passed.
     """

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -3,7 +3,7 @@
 Generates architecture validation configuration for import-linter (Python),
 dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust),
 SwiftLint custom rules (Swift), Konsist (Kotlin), a stdlib-Python
-include-boundary checker (C/C++), and ArchUnit (Java).
+include-boundary checker (C/C++), ArchUnit (Java), and NetArchTest (C#).
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 import warnings
 
+from start_green_stay_green.utils.csharp import csharp_namespace
 from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.java import android_package_path
 
@@ -31,7 +32,7 @@ class ArchitectureResult:
         output_dir: Directory containing generated files.
         files_created: List of files created.
         language: Target language (python, typescript, go, rust, swift,
-            kotlin, cpp, java).
+            kotlin, cpp, java, csharp).
     """
 
     output_dir: Path
@@ -175,6 +176,23 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         docs_url="https://www.archunit.org/",
         display_name="Java",
     ),
+    "csharp": _LanguageTooling(
+        # NetArchTest is the issue's first choice (ArchUnitNET is the
+        # alternative; it adds slices/cycle rules but a heavier API —
+        # the gap is documented in the generated test). Its 'config' is
+        # an xUnit test compiled into the project — the Konsist/ArchUnit
+        # precedent — so run_cmd carries no {config_file} placeholder
+        # and the one-time wiring lives in install_cmd. Unlike javac,
+        # C# namespaces carry no directory-matching requirement, so the
+        # flat copy into tests/ is correct and no {package_path}
+        # resolution is needed (the inverse of the Java entry).
+        tool="NetArchTest",
+        config_file="ArchitectureTest.cs",
+        install_cmd="cp plans/architecture/ArchitectureTest.cs tests/",
+        run_cmd="dotnet test --filter FullyQualifiedName~ArchitectureTest",
+        docs_url="https://github.com/BenMorris/NetArchTest",
+        display_name="C#",
+    ),
 }
 
 
@@ -185,8 +203,8 @@ class ArchitectureEnforcementGenerator:
     config for TypeScript, go-arch-lint config for Go, cargo-deny
     config for Rust, SwiftLint custom rules for Swift, a Konsist
     test for Kotlin, a runnable include-boundary checker for C/C++,
-    and an ArchUnit test for Java to enforce layer separation and
-    prevent circular dependencies.
+    an ArchUnit test for Java, and a NetArchTest test for C# to
+    enforce layer separation and prevent circular dependencies.
 
     Attributes:
         orchestrator: AI orchestrator for content generation.
@@ -234,7 +252,7 @@ class ArchitectureEnforcementGenerator:
 
         Args:
             language: Target language (python, typescript, go, rust,
-                swift, kotlin, cpp, java).
+                swift, kotlin, cpp, java, csharp).
             project_name: Name of the project.
 
         Returns:
@@ -262,6 +280,7 @@ class ArchitectureEnforcementGenerator:
             "kotlin": partial(self._generate_kotlin_config, project_name),
             "cpp": self._generate_cpp_config,
             "java": partial(self._generate_java_config, project_name),
+            "csharp": partial(self._generate_csharp_config, project_name),
         }
         files_created = config_builders[language]()
 
@@ -1058,6 +1077,153 @@ public class ArchitectureTest {{
         config_path.write_text(config_content)
         return [config_path]
 
+    def _generate_csharp_config(self, project_name: str) -> list[Path]:
+        """Generate the NetArchTest architecture test for C#.
+
+        NetArchTest (the issue's first choice; ArchUnitNET is the
+        documented alternative) expresses layer rules as an xUnit test
+        over the compiled assembly — the C# analogue of the Kotlin
+        Konsist and Java ArchUnit tests. The emitted file is a template
+        parked in ``plans/architecture``: it only enforces once copied
+        into ``tests/`` (the NetArchTest.Rules dependency is already
+        declared in the generated ``.csproj``). Unlike javac, C#
+        namespaces carry no directory-matching requirement, so the flat
+        copy is correct — the inverse of the Java package-path lesson.
+        The test documents its enforcement limits explicitly: compiled-
+        assembly analysis (reflection/DI invisible), namespace-
+        convention layers, the vacuous pass on still-empty layer
+        namespaces (the ``withOptionalLayers(true)`` analogue, with a
+        tighten-me note), and the missing slices/cycle rule (cycle
+        freedom among the four layers follows from the acyclic matrix;
+        ArchUnitNET is named for anything stronger). The dependency
+        matrix mirrors the Go/Java configs: presentation -> application
+        -> domain, with infrastructure allowed to depend on domain only.
+
+        Args:
+            project_name: Name of the project; layer namespaces derive
+                from its shared PascalCase namespace so the test stays
+                in sync with the scaffolded sources.
+
+        Returns:
+            List of files created.
+        """
+        config_path = self.output_dir / "ArchitectureTest.cs"
+
+        namespace = csharp_namespace(project_name)
+        config_content = f"""\
+// NetArchTest architecture test enforcing layered architecture.
+//
+// NetArchTest (https://github.com/BenMorris/NetArchTest) expresses
+// layer rules as an xUnit test over the compiled assembly — the C#
+// analogue of the Kotlin Konsist and Java ArchUnit tests.
+//
+// Wiring (one-time): this file is a template parked in
+// plans/architecture; it only enforces once it lives in the test
+// tree. C# namespaces carry no directory-matching requirement
+// (unlike Java packages), so a flat copy is correct:
+//   cp plans/architecture/ArchitectureTest.cs tests/
+//   dotnet test --filter FullyQualifiedName~ArchitectureTest
+// The NetArchTest.Rules dependency is already declared in the
+// generated .csproj.
+//
+// Enforcement limits (documented, not hidden):
+//   - NetArchTest analyzes the compiled assembly (via Mono.Cecil), so
+//     the project must build first (dotnet test does); dependencies
+//     created via reflection or dependency-injection wiring are
+//     invisible.
+//   - Layers are defined by the namespace convention below
+//     ({namespace}.<Layer>); code outside those namespaces is
+//     unchecked.
+//   - A rule whose namespace selects no types yet passes vacuously —
+//     the pragmatic warn-first default (the ArchUnit
+//     withOptionalLayers(true) analogue). Tighten by asserting
+//     result.SelectedTypesForTesting is non-empty once every layer
+//     namespace has code.
+//   - NetArchTest has no slices/cycle rule. Cycle freedom among the
+//     four layers follows from the acyclic dependency matrix below,
+//     but arbitrary namespace cycles outside it go unchecked — and
+//     the C# compiler does NOT reject namespace cycles, so that gap
+//     cannot be attributed to the build system. ArchUnitNET
+//     (https://archunitnet.readthedocs.io/) adds true cycle slices if
+//     this project ever needs them.
+//
+// Dependency matrix (mirrors the Go/Java configs):
+//   Presentation   -> Application, Domain
+//   Application    -> Domain
+//   Infrastructure -> Domain
+//   Domain         -> (nothing)
+using NetArchTest.Rules;
+using Xunit;
+
+namespace {namespace}.Architecture
+{{
+    public class ArchitectureTest
+    {{
+        private const string BaseNamespace = "{namespace}";
+
+        private static Types ProjectTypes() =>
+            Types.InAssembly(typeof(ArchitectureTest).Assembly);
+
+        private static string Offenders(TestResult result) =>
+            result.FailingTypeNames == null
+                ? "(none reported)"
+                : string.Join(", ", result.FailingTypeNames);
+
+        [Fact]
+        public void DomainDoesNotDependOnOuterLayers()
+        {{
+            var result = ProjectTypes()
+                .That().ResideInNamespaceStartingWith(BaseNamespace + ".Domain")
+                .ShouldNot().HaveDependencyOnAny(
+                    BaseNamespace + ".Application",
+                    BaseNamespace + ".Presentation",
+                    BaseNamespace + ".Infrastructure")
+                .GetResult();
+
+            Assert.True(
+                result.IsSuccessful,
+                "Domain must stay pure; offenders: " + Offenders(result));
+        }}
+
+        [Fact]
+        public void ApplicationDependsOnlyInward()
+        {{
+            var result = ProjectTypes()
+                .That().ResideInNamespaceStartingWith(BaseNamespace + ".Application")
+                .ShouldNot().HaveDependencyOnAny(
+                    BaseNamespace + ".Presentation",
+                    BaseNamespace + ".Infrastructure")
+                .GetResult();
+
+            Assert.True(
+                result.IsSuccessful,
+                "Application may depend on Domain only; offenders: "
+                    + Offenders(result));
+        }}
+
+        [Fact]
+        public void InfrastructureDependsOnlyOnDomain()
+        {{
+            var result = ProjectTypes()
+                .That()
+                .ResideInNamespaceStartingWith(BaseNamespace + ".Infrastructure")
+                .ShouldNot().HaveDependencyOnAny(
+                    BaseNamespace + ".Presentation",
+                    BaseNamespace + ".Application")
+                .GetResult();
+
+            Assert.True(
+                result.IsSuccessful,
+                "Infrastructure may depend on Domain only; offenders: "
+                    + Offenders(result));
+        }}
+    }}
+}}
+"""
+
+        config_path.write_text(config_content)
+        return [config_path]
+
     def _generate_readme(self, language: str, project_name: str) -> Path:
         """Generate README with usage instructions.
 
@@ -1146,6 +1312,7 @@ Edit the configuration file:
 - Kotlin: `ArchitectureTest.kt`
 - C/C++: `check_architecture.py` (the ALLOWED_DEPENDENCIES matrix at the top)
 - Java: `ArchitectureTest.java` (the layered-architecture rules in the test)
+- C#: `ArchitectureTest.cs` (the NetArchTest rules in the test)
 
 See documentation:
 - Python: https://import-linter.readthedocs.io/
@@ -1156,6 +1323,7 @@ See documentation:
 - Kotlin: https://docs.konsist.lemonappdev.com/
 - C/C++: the header comment in check_architecture.py (self-documented)
 - Java: https://www.archunit.org/
+- C#: https://github.com/BenMorris/NetArchTest
 
 ## Integration
 

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -18,6 +18,12 @@ from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
 from start_green_stay_green.utils.cpp import cpp_identifier
+from start_green_stay_green.utils.csharp import COVERLET_MSBUILD_VERSION
+from start_green_stay_green.utils.csharp import NETARCHTEST_RULES_VERSION
+from start_green_stay_green.utils.csharp import SECURITY_CODE_SCAN_VERSION
+from start_green_stay_green.utils.csharp import TEST_SDK_VERSION
+from start_green_stay_green.utils.csharp import XUNIT_RUNNER_VERSION
+from start_green_stay_green.utils.csharp import XUNIT_VERSION
 from start_green_stay_green.utils.java import ARCHUNIT_VERSION
 from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
 from start_green_stay_green.utils.java import DEPENDENCY_CHECK_PLUGIN_VERSION
@@ -85,9 +91,10 @@ class DependenciesGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for csharp and ruby —
+    architecture, and metrics steps for ruby —
     the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
+    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
+    pipeline.
 
     Attributes:
         output_dir: Directory where dependency files will be written
@@ -765,6 +772,15 @@ Wear OS app</description>
     def _generate_csharp_dependencies(self) -> dict[str, Path]:
         """Generate C# dependency files.
 
+        Emits the single SDK-style ``.csproj`` that owns the generated
+        project's quality policy (#370): the xUnit test stack, the
+        Coverlet coverage gate (the >=90% bound lives here — the
+        Kover/JaCoCo manifest-owned precedent), the Roslyn analyzer
+        configuration (warnings-as-errors), the ``CodeMetricsConfig.txt``
+        wiring behind the CA1502 complexity ceiling, the NetArchTest
+        dependency backing the architecture template, and the
+        SecurityCodeScan analyzer.
+
         Returns:
             Dictionary mapping file names to file paths
         """
@@ -783,23 +799,87 @@ Wear OS app</description>
         """Generate C# .csproj content.
 
         Returns:
-            Content for .csproj with project settings and dependencies
+            Content for .csproj with project settings, the quality
+            gates the manifest owns, and pinned NuGet dependencies
         """
-        return """<Project Sdk="Microsoft.NET.Sdk">
+        return f"""<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Single-project layout: src/ (the application) and tests/ (the
+    xUnit suite) compile into ONE assembly via the SDK's default
+    globbing, so the test packages below sit next to the app code and
+    `dotnet test` runs the whole project. The parked NetArchTest
+    template (plans/architecture/ArchitectureTest.cs) also compiles
+    into this assembly once copied into tests/.
+  -->
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- Roslyn analyzer gate (#370): the SDK analyzers run in every
+         build and TreatWarningsAsErrors makes each `dotnet build`
+         (pre-commit hook, scripts/lint.sh, CI) a failing lint gate.
+         This PropertyGroup is the single home of that policy; nothing
+         restates the flag on a command line. -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Coverlet coverage gate (#370): the >=90% line bound lives
+         HERE and only here. scripts/test.sh (coverage mode) and CI
+         pass /p:CollectCoverage=true to activate it and never restate
+         the number. coverlet.msbuild hooks the test task itself, so a
+         failing bound fails `dotnet test` directly. -->
+    <Threshold>90</Threshold>
+    <ThresholdType>line</ThresholdType>
+    <ThresholdStat>total</ThresholdStat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <!-- Threshold home for the CA1502 cyclomatic-complexity ceiling
+         (<=10). The .NET SDK metrics analyzers only read the bound
+         from an AdditionalFiles entry named exactly
+         CodeMetricsConfig.txt; the file itself is written at the
+         project root by the scripts generator (the pmd-ruleset.xml
+         companion split), and .editorconfig switches CA1502 on. -->
+    <AdditionalFiles Include="CodeMetricsConfig.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="{XUNIT_VERSION}" />
+    <PackageReference Include="xunit.runner.visualstudio" \
+Version="{XUNIT_RUNNER_VERSION}">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="{TEST_SDK_VERSION}" />
+
+    <!-- Coverage engine behind the manifest-owned threshold above
+         (build-time assets only, never a runtime dependency). -->
+    <PackageReference Include="coverlet.msbuild" \
+Version="{COVERLET_MSBUILD_VERSION}">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; \
+buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
+    <!-- Backs plans/architecture/ArchitectureTest.cs (the ArchUnit/
+         Konsist manifest-touch precedent): declared here so the
+         parked template compiles as soon as it is copied into
+         tests/. -->
+    <PackageReference Include="NetArchTest.Rules" \
+Version="{NETARCHTEST_RULES_VERSION}" />
+
+    <!-- Source-level security analysis as a Roslyn analyzer: SQL
+         injection, XSS, weak crypto, and friends fail the build via
+         TreatWarningsAsErrors. Dependency CVE scanning is separate
+         (scripts/security.sh runs the vulnerable-package listing). -->
+    <PackageReference Include="SecurityCodeScan.VS2019" \
+Version="{SECURITY_CODE_SCAN_VERSION}">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -511,6 +511,24 @@ LANGUAGE_TOOLS: dict[str, dict[str, str]] = {
         "security": "SpotBugs (mvn spotbugs:check)",
         "dependency_check": "OWASP dependency-check (mvn dependency-check:check)",
     },
+    # C# (#370): coverage is Coverlet, activated by
+    # /p:CollectCoverage=true with the >=90% bound living in the
+    # generated csproj (the JaCoCo/Kover manifest-owned precedent).
+    # The Roslyn CA1502 rule owns the <=10 complexity gate (threshold
+    # in CodeMetricsConfig.txt, enabled via .editorconfig). Stryker.NET
+    # is a periodic mutation gate like pitest/mull/muter, not a
+    # per-commit hook. Each tool appears in exactly one category:
+    # SecurityCodeScan owns source-level security (it runs as a Roslyn
+    # analyzer inside every build) and the dotnet CLI's vulnerable-
+    # package listing owns dependency CVE scanning.
+    "csharp": {
+        "coverage": "Coverlet (dotnet test /p:CollectCoverage=true)",
+        "mutation": "Stryker.NET (dotnet stryker)",
+        "complexity": "Roslyn CA1502 (CodeMetricsConfig.txt)",
+        "documentation": "DocFX",
+        "security": "SecurityCodeScan (Roslyn analyzer)",
+        "dependency_check": "dotnet list package --vulnerable",
+    },
 }
 
 

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -26,7 +26,7 @@ class GenerationConfig:
     Attributes:
         project_name: Name of the project.
         language: Programming language (python, typescript, go, rust,
-            swift, kotlin, cpp, java).
+            swift, kotlin, cpp, java, csharp).
         language_config: Additional language-specific configuration.
     """
 
@@ -628,6 +628,104 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         ],
         "default_language_version": {},
     },
+    "csharp": {
+        "hooks": [
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v4.5.0",
+                "hooks": [
+                    {"id": "trailing-whitespace"},
+                    {"id": "end-of-file-fixer"},
+                    {"id": "check-yaml"},
+                    {"id": "check-json"},
+                    # identify tags .csproj files as xml, so the stock
+                    # check-xml hook gates the manifest's
+                    # well-formedness (the AndroidManifest.xml /
+                    # tizen-manifest.xml precedent).
+                    {"id": "check-xml"},
+                    {"id": "check-added-large-files", "args": ["--maxkb=500"]},
+                    {"id": "check-case-conflict"},
+                    {"id": "check-merge-conflict"},
+                    {"id": "check-symlinks"},
+                    {"id": "detect-private-key"},
+                    {"id": "fix-byte-order-marker"},
+                    {"id": "mixed-line-ending", "args": ["--fix=lf"]},
+                    {"id": "no-commit-to-branch", "args": ["--branch", "main"]},
+                ],
+            },
+            # Both C# hooks run the dotnet CLI as `repo: local` system
+            # hooks (the Swift/Kotlin/Java precedent: no official
+            # pre-commit mirror exists for the .NET toolchain). Install
+            # the .NET 8 SDK with: `brew install dotnet-sdk` (macOS) or
+            # `apt-get install dotnet-sdk-8.0` (Debian/Ubuntu) — both
+            # `dotnet format` and the Roslyn analyzers ship inside it,
+            # so there is nothing else to install.
+            #
+            # dotnet operates on the project (not a file list), so both
+            # hooks set pass_filenames: false and use the c# type
+            # filter only to decide WHETHER to run.
+            {
+                "repo": "local",
+                "hooks": [
+                    {
+                        "id": "dotnet-format",
+                        "name": "dotnet format (check mode)",
+                        # Check-mode: a bare `dotnet format` rewrites
+                        # files and exits 0 either way, so it could
+                        # never fail a commit. --verify-no-changes
+                        # exits non-zero on unformatted code;
+                        # scripts/format.sh keeps the fixing path.
+                        "entry": "dotnet format --verify-no-changes",
+                        "language": "system",
+                        "types": ["c#"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                    {
+                        "id": "roslyn-analyzers",
+                        "name": "Roslyn analyzers (dotnet build)",
+                        # The csproj is the single home of the lint
+                        # policy. It enables the SDK analyzers (with
+                        # the CA1502 <=10 complexity ceiling switched
+                        # on via .editorconfig and bounded by
+                        # CodeMetricsConfig.txt, plus the
+                        # SecurityCodeScan analyzer) and treats
+                        # warnings as errors, so this plain build
+                        # fails on findings — no -warnaserror restated
+                        # here.
+                        "entry": "dotnet build --nologo",
+                        "language": "system",
+                        "types": ["c#"],
+                        "pass_filenames": False,  # nosec B105  # Boolean config, not password
+                    },
+                ],
+            },
+            {
+                "repo": "https://github.com/gitleaks/gitleaks",
+                "rev": "v8.18.4",
+                "hooks": [
+                    {"id": "gitleaks"},
+                ],
+            },
+            {
+                "repo": "https://github.com/shellcheck-py/shellcheck-py",
+                "rev": "v0.9.0.6",
+                "hooks": [
+                    {"id": "shellcheck"},
+                ],
+            },
+            {
+                "repo": "https://github.com/Yelp/detect-secrets",
+                "rev": "v1.4.0",
+                "hooks": [
+                    {
+                        "id": "detect-secrets",
+                        "args": ["--baseline", ".secrets.baseline"],
+                    },
+                ],
+            },
+        ],
+        "default_language_version": {},
+    },
     "cpp": {
         "hooks": [
             {
@@ -753,7 +851,7 @@ class PreCommitGenerator(BaseGenerator):
     Includes formatting, linting, security, and general file quality checks.
 
     Supports: Python, TypeScript, Go, Rust, Swift, Kotlin, C/C++ (cpp),
-    Java, and other languages.
+    Java, C# (csharp), and other languages.
 
     Attributes:
         orchestrator: Optional AI orchestrator for enhanced generation.

--- a/start_green_stay_green/generators/readme.py
+++ b/start_green_stay_green/generators/readme.py
@@ -70,9 +70,10 @@ class ReadmeGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for csharp and ruby —
+    architecture, and metrics steps for ruby —
     the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
+    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
+    pipeline.
 
     Attributes:
         output_dir: Directory where README.md will be created
@@ -1021,13 +1022,22 @@ Generated with [Start Green Stay Green](https://github.com/Geoffe-Ga/start_green
     def _csharp_readme_content(self) -> str:
         """Generate C# README.md content.
 
+        Truthfully advertises the #370 quality toolchain: every
+        artifact the README names (pre-commit hooks, quality scripts,
+        the analyzer companions, the NetArchTest template, the CI
+        workflow) is generated next to it, and the numeric gates are
+        described by pointing at their single homes (the csproj for
+        coverage, CodeMetricsConfig.txt for complexity) rather than
+        inventing another copy.
+
         Returns:
             Content for README.md
         """
         # Convert project name to title case for display
         display_name = self.config.project_name.replace("-", " ").title()
+        project = self.config.project_name
 
-        return f"""# {self.config.project_name}
+        return f"""# {project}
 
 {display_name} - A quality-controlled C# project generated with
 Start Green Stay Green.
@@ -1036,12 +1046,17 @@ Start Green Stay Green.
 
 This project was generated with maximum quality standards from day one, including:
 
-- ✅ Comprehensive testing infrastructure (xUnit with 90%+ coverage requirement)
-- ✅ Code quality tools (Roslyn analyzers, dotnet format)
-- ✅ Security scanning (dotnet list package --vulnerable)
-- ✅ Type safety (C#'s strong typing system)
-- ✅ Pre-commit hooks (quality checks)
-- ✅ CI/CD pipeline (GitHub Actions)
+- ✅ Comprehensive testing infrastructure (xUnit; ≥90% line coverage
+  enforced by Coverlet — the bound lives in `{project}.csproj`)
+- ✅ Code quality tools (Roslyn analyzers as errors, dotnet format,
+  cyclomatic complexity ≤10 via the CA1502 rule)
+- ✅ Security scanning (SecurityCodeScan analyzer in every build +
+  `dotnet list package --vulnerable` in `scripts/security.sh`)
+- ✅ Pre-commit hooks (`.pre-commit-config.yaml`)
+- ✅ Quality scripts (`./scripts/check-all.sh` and friends)
+- ✅ Architecture enforcement (NetArchTest template in
+  `plans/architecture/`)
+- ✅ CI/CD pipeline (`.github/workflows/ci.yml`)
 - ✅ AI-assisted development (Claude Code skills and subagents)
 
 ## Installation
@@ -1049,7 +1064,7 @@ This project was generated with maximum quality standards from day one, includin
 ```bash
 # Clone the repository
 git clone <repository-url>
-cd {self.config.project_name}
+cd {project}
 
 # Restore dependencies
 dotnet restore
@@ -1068,7 +1083,7 @@ dotnet run
 
 Expected output:
 ```
-Hello from {self.config.project_name}!
+Hello from {project}!
 ```
 
 ## Development
@@ -1076,48 +1091,79 @@ Hello from {self.config.project_name}!
 ### Running Quality Checks
 
 ```bash
+# Everything at once (format, lint, tests + coverage, security)
+./scripts/check-all.sh
+
 # Run all tests
 dotnet test
 
-# Run tests with coverage
-dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+# Run tests with the ≥90% coverage gate (the bound lives in
+# {project}.csproj — Threshold/ThresholdType/ThresholdStat — its
+# single home; nothing on the command line restates it)
+dotnet test /p:CollectCoverage=true
 
-# Format code
+# Format code (fix in place)
 dotnet format
 
-# Check formatting
+# Check formatting (exits non-zero on unformatted code; this is what
+# the pre-commit hook runs)
 dotnet format --verify-no-changes
 
-# Build project
+# Lint: the Roslyn analyzers run inside the compiler, and the csproj
+# treats warnings as errors, so a plain build IS the lint gate
 dotnet build
-
-# Build for release
-dotnet build -c Release
 ```
 
 ### Quality Tools
 
 This project includes:
 
-- **xUnit**: Testing framework with 90%+ coverage requirement
-- **Coverlet**: Code coverage tool
-- **Roslyn Analyzers**: Static code analysis
-- **dotnet format**: Code formatter
-- **NuGet**: Package management with vulnerability scanning
+- **xUnit**: Testing framework
+- **Coverlet** (`coverlet.msbuild`): Coverage with the ≥90% line bound
+  pinned in `{project}.csproj`
+- **Roslyn analyzers**: Static analysis in every `dotnet build`, with
+  warnings promoted to errors by the csproj
+- **CA1502 complexity gate**: Cyclomatic complexity ≤10; the rule is
+  enabled in `.editorconfig` and its threshold lives in
+  `CodeMetricsConfig.txt` (the single home of the number)
+- **SecurityCodeScan**: Source-level security analysis as a Roslyn
+  analyzer
+- **dotnet format**: Code formatter (reads `.editorconfig`)
+- **NetArchTest**: Architecture rules as an xUnit test (see below)
+- **NuGet**: Package management; `scripts/security.sh` scans for
+  vulnerable packages (needs network access — it warns and skips
+  offline)
+
+### Architecture Enforcement
+
+`plans/architecture/ArchitectureTest.cs` is a NetArchTest xUnit test
+template enforcing the layered architecture. Wire it once:
+
+```bash
+# C# namespaces carry no directory-matching requirement, so a flat
+# copy is correct:
+cp plans/architecture/ArchitectureTest.cs tests/
+dotnet test --filter FullyQualifiedName~ArchitectureTest
+```
+
+See `plans/architecture/README.md` for the layer matrix and the
+documented enforcement limits.
 
 ### Project Structure
 
 ```
-{self.config.project_name}/
+{project}/
 ├── src/                  # Application source code
 │   └── Program.cs
-├── tests/                # Test suite
-│   └── UnitTests.cs
+├── tests/                # Test suite (xUnit)
+│   └── MainTests.cs
 ├── scripts/              # Quality control scripts
+├── plans/architecture/   # NetArchTest template + runner
 ├── .github/workflows/    # CI/CD pipelines
 ├── .claude/              # AI subagents and skills
-├── {self.config.project_name}.sln  # Solution file
-└── {self.config.project_name}.csproj  # Project file
+├── .editorconfig         # Roslyn analyzer severities (enables CA1502)
+├── CodeMetricsConfig.txt # CA1502 complexity threshold (≤10)
+└── {project}.csproj  # Project file (coverage gate + analyzer policy)
 ```
 
 ### Testing
@@ -1126,7 +1172,7 @@ This project includes:
 # Run all tests
 dotnet test
 
-# Run tests with coverage
+# Run tests with coverage (gate enforced by the csproj)
 dotnet test /p:CollectCoverage=true
 
 # Run tests with verbose output
@@ -1140,9 +1186,12 @@ dotnet test --filter "FullyQualifiedName~TestName"
 
 This project maintains MAXIMUM QUALITY standards:
 
-- **Test Coverage**: ≥90% required
-- **Type Safety**: 100% compile-time type checking
-- **All Analyzers**: Must pass with zero violations
+- **Test Coverage**: ≥90% required (Coverlet, bound in the csproj)
+- **Complexity**: ≤10 per method (CA1502, bound in
+  CodeMetricsConfig.txt)
+- **Type Safety**: 100% compile-time type checking (nullable enabled)
+- **All Analyzers**: Must pass with zero violations (warnings are
+  errors)
 - **Code Style**: Enforced by dotnet format
 
 ## License

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -206,6 +206,7 @@ class ScriptsGenerator:
             "kotlin": self._generate_kotlin_scripts,
             "cpp": self._generate_cpp_scripts,
             "java": self._generate_java_scripts,
+            "csharp": self._generate_csharp_scripts,
         }
         # Fallback to Python scripts for unknown languages.
         builder = builders.get(self.config.language, self._generate_python_scripts)
@@ -525,6 +526,55 @@ class ScriptsGenerator:
         # Companion PMD ruleset — written at the project root, not
         # added to the scripts dict (it isn't an executable).
         self._write_companion_config("pmd-ruleset.xml", self._PMD_RULESET_TEMPLATE)
+
+        return scripts
+
+    def _generate_csharp_scripts(self) -> dict[str, Path]:
+        """Generate C#-specific quality control scripts (#370).
+
+        Emits check/format/lint/test/security scripts plus two
+        companions at the project root: ``.editorconfig`` (the switch
+        that enables the otherwise-off CA1502 complexity rule) and
+        ``CodeMetricsConfig.txt`` (the single home of its <=10 bound,
+        wired into the build via the csproj's AdditionalFiles entry —
+        the pmd-ruleset.xml companion split). Like the Java scripts,
+        these mostly invoke gates the manifest owns: the csproj
+        configures the Roslyn analyzers (warnings-as-errors) and the
+        Coverlet >=90% coverage threshold, so every script is a thin
+        ``dotnet`` CLI invocation that cannot version-drift from the
+        build.
+
+        Returns:
+            Dictionary mapping script names to file paths
+        """
+        scripts: dict[str, Path] = {}
+
+        scripts["check-all.sh"] = self._write_script(
+            "check-all.sh",
+            self._csharp_check_all_script(),
+        )
+        scripts["format.sh"] = self._write_script(
+            "format.sh",
+            self._csharp_format_script(),
+        )
+        scripts["lint.sh"] = self._write_script(
+            "lint.sh",
+            self._csharp_lint_script(),
+        )
+        scripts["test.sh"] = self._write_script(
+            "test.sh",
+            self._csharp_test_script(),
+        )
+        scripts["security.sh"] = self._write_script(
+            "security.sh",
+            self._csharp_security_script(),
+        )
+        # Companion analyzer configs — written at the project root, not
+        # added to the scripts dict (they aren't executables).
+        self._write_companion_config(".editorconfig", self._EDITORCONFIG_TEMPLATE)
+        self._write_companion_config(
+            "CodeMetricsConfig.txt", self._CODE_METRICS_CONFIG_TEMPLATE
+        )
 
         return scripts
 
@@ -4855,6 +4905,491 @@ exit 0
         </properties>
     </rule>
 </ruleset>
+"""
+
+    # C# script generators (#370)
+
+    def _csharp_check_all_script(self) -> str:
+        """Generate C# check-all.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Format check (dotnet format --verify-no-changes)
+  2. Roslyn analyzers + complexity <=10 (dotnet build; the csproj
+     treats warnings as errors and CodeMetricsConfig.txt holds the
+     CA1502 bound)
+  3. Tests + coverage >=90% (dotnet test + Coverlet; the bound lives
+     in the csproj)
+  4. Security (vulnerable NuGet package scan)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+
+    echo "Running: $check_name"
+    # "${@}" is safe under set -u even when no extra args remain
+    # (unlike a named local array, which needs the
+    # ${args[@]+"${args[@]}"} guard the python template uses).
+    if "$SCRIPT_DIR/$script" "${@}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+run_check "Format" "format.sh"
+run_check "Linting" "lint.sh"
+run_check "Tests" "test.sh" --coverage
+run_check "Security" "security.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    exit 1
+else
+    echo "✓ All quality checks passed!"
+    exit 0
+fi
+"""
+
+    def _csharp_format_script(self) -> str:
+        """Generate C# format.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/format.sh - Format C# code
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+# Default (no flags) writes formatting in place, same as --fix; use
+# --check for a non-mutating verification pass.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format C# code using dotnet format — the same tool the pre-commit
+hook invokes, so the two can never disagree. It ships inside the
+.NET SDK and reads .editorconfig, so the style standard has one home.
+
+OPTIONS:
+    --fix       Apply formatting (default, writes in place)
+    --check     Check only, fail if formatting needed
+                (--verify-no-changes exits non-zero on unformatted
+                code; a bare 'dotnet format' exits 0 either way)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v dotnet &> /dev/null; then
+    echo "✗ dotnet not found" >&2
+    echo "  Install with: brew install dotnet-sdk (macOS)" >&2
+    echo "             or: apt-get install dotnet-sdk-8.0 (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Formatting (dotnet format) ==="
+
+# Fixing is the default; an explicit --fix overrides --check.
+if $CHECK && ! $FIX; then
+    dotnet format --verify-no-changes || \\
+        { echo "✗ Format check failed" >&2; exit 1; }
+    echo "✓ Code formatting check passed"
+else
+    dotnet format || \\
+        { echo "✗ Formatting failed" >&2; exit 1; }
+    echo "✓ Code formatted successfully"
+fi
+exit 0
+"""
+
+    def _csharp_lint_script(self) -> str:
+        """Generate C# lint.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/lint.sh - Static analysis: Roslyn analyzers (dotnet build)
+# Usage: ./scripts/lint.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run static analysis. All Roslyn analysis runs inside the compiler, so
+a plain 'dotnet build' IS the lint gate — the csproj is the single
+source of the policy (EnableNETAnalyzers, AnalysisLevel latest,
+TreatWarningsAsErrors) and this script restates none of it:
+  - .NET SDK code-quality (CA) rules
+  - Complexity <=10: the CA1502 rule, enabled in .editorconfig with
+    its bound in CodeMetricsConfig.txt (the single home; nothing else
+    restates the number)
+  - SecurityCodeScan (source-level security analysis; declared in the
+    csproj, runs in this same compiler pass — scripts/security.sh
+    covers dependency CVEs instead, so the two never double-report)
+
+Install: brew install dotnet-sdk (macOS) /
+         apt-get install dotnet-sdk-8.0 (Debian/Ubuntu)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           Analyzer or complexity findings (build failed)
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v dotnet &> /dev/null; then
+    echo "✗ dotnet not found - the analyzers run inside dotnet build" >&2
+    echo "  Install with: brew install dotnet-sdk (macOS)" >&2
+    echo "             or: apt-get install dotnet-sdk-8.0 (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Static Analysis (Roslyn analyzers via dotnet build) ==="
+
+dotnet build --nologo || \\
+    { echo "✗ Roslyn analyzers found issues" >&2; exit 1; }
+
+echo "✓ Linting checks passed"
+exit 0
+"""
+
+    def _csharp_test_script(self) -> str:
+        """Generate C# test.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/test.sh - Run C# tests via the dotnet CLI
+# Usage: ./scripts/test.sh [--coverage] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+COVERAGE=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run the xUnit test suite (dotnet test). src/ and tests/ compile into
+one assembly (the single-project layout in the .csproj), so the whole
+project is the coverage denominator.
+
+OPTIONS:
+    --coverage  Enforce >=90% line coverage via Coverlet
+                (/p:CollectCoverage=true activates the gate; the bound
+                lives in the .csproj's Threshold properties — its
+                single home; this script never restates the number.
+                coverlet.msbuild hooks the test task itself, so a
+                missed bound fails this invocation directly.)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All tests passed (and coverage met, with --coverage)
+    1           Test failures or coverage below threshold
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v dotnet &> /dev/null; then
+    echo "✗ dotnet not found - the test suite runs via the dotnet CLI" >&2
+    echo "  Install with: brew install dotnet-sdk (macOS)" >&2
+    echo "             or: apt-get install dotnet-sdk-8.0 (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Running Tests (dotnet test) ==="
+
+if $COVERAGE; then
+    dotnet test /p:CollectCoverage=true || \\
+        { echo "✗ Tests or coverage gate failed" >&2; exit 1; }
+else
+    dotnet test || { echo "✗ Tests failed" >&2; exit 1; }
+fi
+
+echo "✓ Tests passed"
+exit 0
+"""
+
+    def _csharp_security_script(self) -> str:
+        """Generate C# security.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/security.sh - Security checks for C#
+# Usage: ./scripts/security.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run security checks.
+
+Division of labor:
+  - Secret scanning (gitleaks + detect-secrets) runs in pre-commit.
+  - Source-level security analysis (SecurityCodeScan) is a Roslyn
+    analyzer declared in the csproj: it runs inside every
+    'dotnet build' (scripts/lint.sh, the pre-commit hook, CI), so this
+    script does not rebuild just to re-run it.
+  - This script owns dependency CVE scanning via
+    'dotnet list package --vulnerable'.
+
+The vulnerable-package listing needs a package restore and queries the
+NuGet vulnerability database over the network; when it cannot run
+(offline, no restore) the scan is skipped with a warning rather than
+failing a fresh clone.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           No issues found (or the CVE scan skipped; see above)
+    1           Vulnerable NuGet packages reported
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v dotnet &> /dev/null; then
+    echo "✗ dotnet not found - the security checks run via the dotnet CLI" >&2
+    echo "  Install with: brew install dotnet-sdk (macOS)" >&2
+    echo "             or: apt-get install dotnet-sdk-8.0 (Debian/Ubuntu)" >&2
+    exit 1
+fi
+
+echo "=== Security (vulnerable NuGet packages) ==="
+
+# The exit code of 'dotnet list package --vulnerable' stayed 0 even
+# with findings across several SDK lines (dotnet/sdk#25091), so the
+# gate greps the report line instead of trusting the exit code — the
+# grep is SDK-version-proof.
+#
+# Pragmatic default: when the listing itself cannot run (offline, no
+# restore yet), warn and skip so a fresh clone passes check-all.sh out
+# of the box. Tighten by replacing the warning block with 'exit 1'
+# once network access is guaranteed everywhere (including CI).
+if VULN_REPORT=$(dotnet list package --vulnerable 2>&1); then
+    if echo "$VULN_REPORT" | grep -q "has the following vulnerable packages"; then
+        echo "$VULN_REPORT"
+        echo "✗ Vulnerable NuGet packages found" >&2
+        exit 1
+    fi
+    echo "✓ No vulnerable NuGet packages reported"
+else
+    echo "⚠ Could not run the vulnerable-package scan" >&2
+    echo "⚠ (it needs 'dotnet restore' and network access to the" >&2
+    echo "⚠ NuGet vulnerability database) - skipping" >&2
+fi
+
+echo "✓ Security checks passed"
+exit 0
+"""
+
+    # .editorconfig companion. Shared by every Roslyn-analyzer
+    # invocation (the pre-commit dotnet-format/roslyn-analyzers hooks,
+    # scripts/lint.sh, CI): the .NET SDK ships the CA1502 cyclomatic-
+    # complexity rule DISABLED by default, and this severity switch is
+    # the one place that turns it on. The numeric bound itself lives in
+    # CodeMetricsConfig.txt (the only home the metrics analyzers read).
+    _EDITORCONFIG_TEMPLATE = """\
+# .editorconfig generated by Start Green Stay Green.
+#
+# dotnet format and the Roslyn analyzers both read this file, so the
+# style/severity policy has one home for the pre-commit hooks,
+# scripts/lint.sh, and CI alike.
+root = true
+
+[*.cs]
+# CA1502 (avoid excessive cyclomatic complexity) ships with the .NET
+# SDK analyzers but is disabled by default; this is the single switch
+# that enables it. Its <=10 threshold lives in CodeMetricsConfig.txt,
+# declared as an AdditionalFiles item in the .csproj.
+dotnet_diagnostic.CA1502.severity = error
+"""
+
+    # CodeMetricsConfig.txt companion — the SINGLE home of the C#
+    # cyclomatic-complexity bound (mirroring the <=10 gate radon/eslint/
+    # gocyclo/clippy/SwiftLint/detekt/lizard/PMD apply for the other
+    # languages); neither the scripts nor the csproj restate the number.
+    # The .NET SDK metrics analyzers only read thresholds from an
+    # AdditionalFiles entry named exactly CodeMetricsConfig.txt.
+    _CODE_METRICS_CONFIG_TEMPLATE = """\
+# Code-metrics thresholds for the .NET SDK analyzers, generated by
+# Start Green Stay Green. Format: 'RuleId: Threshold'.
+#
+# CA1502 fires when a method's cyclomatic complexity EXCEEDS the
+# threshold, so 10 reports 11+ and enforces the <= 10 ceiling the
+# other supported languages gate on. This file is the single home of
+# that bound (.editorconfig only flips the rule's severity, and the
+# .csproj only wires this file in via AdditionalFiles).
+CA1502: 10
 """
 
     # Language-agnostic script generators

--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -17,6 +17,7 @@ from start_green_stay_green.generators.base import validate_language
 from start_green_stay_green.utils.cpp import TIZEN_API_VERSION
 from start_green_stay_green.utils.cpp import cpp_identifier
 from start_green_stay_green.utils.cpp import tizen_app_id
+from start_green_stay_green.utils.csharp import csharp_namespace
 from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
@@ -66,9 +67,10 @@ class StructureGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for csharp and ruby —
+    architecture, and metrics steps for ruby —
     the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
+    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
+    pipeline.
 
     Attributes:
         output_dir: Directory where structure will be created
@@ -791,16 +793,25 @@ public class MainActivity extends Activity {{
     def _csharp_program_cs(self) -> str:
         """Generate C# Program.cs content.
 
+        The namespace comes from the shared
+        :func:`~start_green_stay_green.utils.csharp.csharp_namespace`
+        helper so the structure, tests, and architecture generators can
+        never disagree on it, and ``Main`` is public because the
+        scaffolded xUnit test (``tests/MainTests.cs``) invokes it
+        directly — an implicitly private ``Main`` would be a guaranteed
+        compile error in the generated project (#370).
+
         Returns:
             Content for Program.cs with Hello World
         """
+        namespace = csharp_namespace(self.config.package_name)
         return f"""using System;
 
-namespace {self.config.package_name}
+namespace {namespace}
 {{
     class Program
     {{
-        static void Main(string[] args)
+        public static void Main(string[] args)
         {{
             Console.WriteLine("Hello from {self.config.project_name}!");
         }}

--- a/start_green_stay_green/generators/tests_gen.py
+++ b/start_green_stay_green/generators/tests_gen.py
@@ -15,6 +15,7 @@ from start_green_stay_green.generators.base import BaseGenerator
 from start_green_stay_green.generators.base import GenerationError
 from start_green_stay_green.generators.base import validate_language
 from start_green_stay_green.utils.cpp import cpp_identifier
+from start_green_stay_green.utils.csharp import csharp_namespace
 from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
@@ -63,9 +64,10 @@ class TestsGenerator(BaseGenerator):
     All 10 supported languages (python, typescript, go, rust, java, csharp,
     ruby, swift, kotlin, cpp) are available at the generator level. Note that
     the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for csharp and ruby —
+    architecture, and metrics steps for ruby —
     the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), and Java (#366/#367) run the full pipeline.
+    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
+    pipeline.
 
     Attributes:
         output_dir: Directory where tests structure will be created
@@ -454,13 +456,17 @@ public class GreetingTest {{
     def _csharp_test_main_cs(self) -> str:
         """Generate C# MainTests.cs content.
 
+        The namespace derives from the shared
+        :func:`~start_green_stay_green.utils.csharp.csharp_namespace`
+        helper — the same source the structure generator uses for
+        ``Program.cs`` — so ``MainTests`` (in ``<Namespace>.Tests``)
+        resolves ``Program`` (in ``<Namespace>``) through C#'s
+        enclosing-namespace lookup without a using directive (#370).
+
         Returns:
             Content for MainTests.cs with xUnit [Fact] attribute
         """
-        # Convert package_name to PascalCase for C# namespace
-        namespace = "".join(
-            word.capitalize() for word in self.config.package_name.split("_")
-        )
+        namespace = csharp_namespace(self.config.package_name)
 
         return f"""using Xunit;
 

--- a/start_green_stay_green/utils/csharp.py
+++ b/start_green_stay_green/utils/csharp.py
@@ -1,0 +1,70 @@
+"""C# naming helpers and NuGet toolchain versions (#370).
+
+Provides a single source of truth for the PascalCase root namespace
+derived from a project's package name, shared by the C# scaffold's
+structure, tests, dependencies, and architecture generators: source
+``namespace`` declarations, the xUnit test namespace, and the
+NetArchTest layer matrix all derive from :func:`csharp_namespace`, so
+they can never drift apart. Unlike Java packages, C# namespaces carry
+no directory-matching requirement, so the helper has no path
+counterpart (the inverse of ``utils.java.android_package_path``).
+
+The pinned NuGet package versions for the generated ``.csproj`` live
+here for the same reason (the ``utils.java`` Maven-pin precedent). All
+pins were verified against the live nuget.org flat-container index
+before being recorded.
+"""
+
+from __future__ import annotations
+
+import re
+
+from start_green_stay_green.utils.naming import pascal_case
+
+# Pinned NuGet package versions for the generated .csproj manifest.
+# xUnit test stack (foundation scaffold).
+XUNIT_VERSION = "2.6.0"
+XUNIT_RUNNER_VERSION = "2.5.3"
+TEST_SDK_VERSION = "17.8.0"
+# coverlet.msbuild backs the >=90% coverage gate (#370). The 8.x line
+# matches the scaffold's net8.0 TargetFramework; the 10.x line tracks
+# the .NET 10 SDK the scaffold does not target yet. Live-verified.
+COVERLET_MSBUILD_VERSION = "8.0.1"
+# NetArchTest.Rules backs the generated architecture test (#370); a
+# plain PackageReference in the single-project csproj (the ArchUnit/
+# Konsist manifest-touch precedent). Live-verified latest stable.
+NETARCHTEST_RULES_VERSION = "1.3.2"
+# SecurityCodeScan runs as a Roslyn analyzer during every build (#370).
+# Live-verified latest stable; the VS2019 suffix is the package's
+# naming convention, not a Visual Studio requirement — it is a
+# netstandard2.0 analyzer that the .NET 8 SDK loads fine.
+SECURITY_CODE_SCAN_VERSION = "5.6.7"
+
+# Characters that split a package name into namespace words.
+_SEPARATORS = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def csharp_namespace(package_name: str) -> str:
+    """Derive a valid PascalCase C# root namespace from a package name.
+
+    Separator characters (hyphens, dots, anything not alphanumeric) are
+    normalized to underscores and the result runs through the shared
+    :func:`~start_green_stay_green.utils.naming.pascal_case` helper
+    (``wrist_ledger`` -> ``WristLedger``). On top of that, C#'s
+    identifier rules apply: a namespace that would start with a digit
+    gains an ``App`` prefix, and a name with no usable characters falls
+    back to ``App``.
+
+    Args:
+        package_name: The project's package identifier (e.g.
+            ``wrist_ledger`` or ``wrist-ledger``).
+
+    Returns:
+        A PascalCase namespace such as ``WristLedger``.
+    """
+    namespace = pascal_case(_SEPARATORS.sub("_", package_name))
+    if not namespace:
+        return "App"
+    if namespace[0].isdigit():
+        return f"App{namespace}"
+    return namespace

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -3,12 +3,13 @@
 Tests the complete sgsg init flow for supported languages, verifying
 that the CLI produces valid project structures end-to-end.
 
-Note: csharp and ruby are supported at the generator level, but the
-quality-tooling pipeline steps (PreCommitGenerator, scripts, metrics,
-architecture) skip them. Kotlin completed the pipeline with #357/#358,
-C/C++ followed with #362 (quality tooling) and #363 (CI workflow), and
-Java with #366 (Wear OS foundation + CI) and #367 (quality tooling), so
-all three join CLI_SUPPORTED_LANGUAGES below
+Note: ruby is supported at the generator level, but the quality-tooling
+pipeline steps (PreCommitGenerator, scripts, metrics, architecture)
+skip it. Kotlin completed the pipeline with #357/#358, C/C++ followed
+with #362 (quality tooling) and #363 (CI workflow), Java with #366
+(Wear OS foundation + CI) and #367 (quality tooling), and C# with #370
+(quality tooling on top of the foundation scaffold + CI), so all four
+join CLI_SUPPORTED_LANGUAGES below
 (test_language_generators.py covers the generator-only languages).
 
 All tests use an environment with API keys stripped and a null keyring
@@ -35,6 +36,7 @@ CLI_SUPPORTED_LANGUAGES = (
     "kotlin",
     "cpp",
     "java",
+    "csharp",
 )
 
 # Expected key files per language that sgsg init should create
@@ -110,6 +112,18 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         "app/src/main/java/com/example/test_project/MainActivity.java",
         ".pre-commit-config.yaml",
         "scripts/check-all.sh",
+        ".github/workflows/ci.yml",
+        "README.md",
+    ],
+    "csharp": [
+        "test-project.csproj",
+        "src/Program.cs",
+        "tests/MainTests.cs",
+        ".editorconfig",
+        "CodeMetricsConfig.txt",
+        ".pre-commit-config.yaml",
+        "scripts/check-all.sh",
+        "plans/architecture/ArchitectureTest.cs",
         ".github/workflows/ci.yml",
         "README.md",
     ],

--- a/tests/integration/generators/test_csharp_init_integration.py
+++ b/tests/integration/generators/test_csharp_init_integration.py
@@ -1,0 +1,338 @@
+"""Integration tests for ``sgsg init --language csharp`` (#370).
+
+Runs the full init flow once via the Typer CliRunner and asserts the
+generated C# project tree, the SDK-style csproj manifest, and the
+quality-tooling artifacts. The AI orchestrator is patched to ``None``
+so no real Anthropic API calls are made (Issue #196); the null keyring
+backend is enforced globally by ``tests/conftest.py``.
+
+These tests are structural only — they never invoke the dotnet CLI —
+so they pass on CI runners without a .NET SDK, mirroring
+``test_java_init_integration.py`` (#367).
+
+With #370 the quality toolchain (pre-commit config, quality scripts,
+the .editorconfig/CodeMetricsConfig.txt analyzer companions,
+architecture rules) is generated for csharp alongside the foundation
+scaffold and its CI workflow, so this suite locks in the presence of
+every pipeline artifact.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from defusedxml import ElementTree as DefusedElementTree
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green.cli import app
+from start_green_stay_green.utils.csharp import csharp_namespace
+
+# Project name chosen to exercise the hyphen sanitization path:
+# wrist-ledger -> package wrist_ledger -> namespace WristLedger.
+_PROJECT_NAME = "wrist-ledger"
+_NAMESPACE = csharp_namespace("wrist_ledger")
+
+
+@pytest.fixture(scope="module")
+def csharp_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Run ``sgsg init --language csharp`` once and return the project root.
+
+    Args:
+        tmp_path_factory: Pytest factory for a module-scoped temp directory.
+
+    Returns:
+        Path to the generated project directory.
+    """
+    output_dir = tmp_path_factory.mktemp("csharp-init")
+    runner = CliRunner()
+    with patch(
+        "start_green_stay_green.cli._initialize_orchestrator", return_value=None
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                _PROJECT_NAME,
+                "--language",
+                "csharp",
+                "--output-dir",
+                str(output_dir),
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0, f"sgsg init failed for csharp: {result.output}"
+    return output_dir / _PROJECT_NAME
+
+
+class TestCsharpInitTree:
+    """Assert the generated C# project tree."""
+
+    def test_project_directory_created(self, csharp_project: Path) -> None:
+        """Init creates the project directory."""
+        assert csharp_project.is_dir()
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            f"{_PROJECT_NAME}.csproj",
+            "src/Program.cs",
+            "tests/MainTests.cs",
+            "README.md",
+            # The CI workflow is real: ci.py has a csharp config and
+            # reference/ci/csharp.yml backs it.
+            ".github/workflows/ci.yml",
+        ],
+    )
+    def test_expected_file_generated(
+        self, csharp_project: Path, relative_path: str
+    ) -> None:
+        """Every expected csharp project file exists and is non-empty."""
+        file_path = csharp_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # Quality tooling (#370) is now generated alongside the
+            # foundation scaffold.
+            ".pre-commit-config.yaml",
+            ".editorconfig",
+            "CodeMetricsConfig.txt",
+            "scripts/check-all.sh",
+            "scripts/format.sh",
+            "scripts/lint.sh",
+            "scripts/test.sh",
+            "scripts/security.sh",
+            "plans/architecture/ArchitectureTest.cs",
+            "plans/architecture/run-check.sh",
+        ],
+    )
+    def test_quality_tooling_artifact_generated(
+        self, csharp_project: Path, relative_path: str
+    ) -> None:
+        """#370 quality-tooling artifacts exist and are non-empty."""
+        file_path = csharp_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # The metrics dashboard is opt-in (--enable-live-dashboard).
+            "docs/metrics.json",
+            # No solution file is generated (single-project layout).
+            f"{_PROJECT_NAME}.sln",
+        ],
+    )
+    def test_out_of_scope_artifact_not_generated(
+        self, csharp_project: Path, relative_path: str
+    ) -> None:
+        """The scaffold must not emit opt-in or unadvertised artifacts."""
+        assert not (csharp_project / relative_path).exists()
+
+
+class TestCsharpInitQualityTooling:
+    """Assert the generated quality-tooling configs are valid (#370)."""
+
+    def test_precommit_config_parses_and_includes_csharp_hooks(
+        self, csharp_project: Path
+    ) -> None:
+        """.pre-commit-config.yaml parses and wires the C# toolchain."""
+        content = (csharp_project / ".pre-commit-config.yaml").read_text()
+        parsed = yaml.safe_load(
+            "\n".join(line for line in content.split("\n") if not line.startswith("#"))
+        )
+        local_repo = next(
+            repo for repo in parsed["repos"] if repo.get("repo") == "local"
+        )
+        hook_ids = {hook["id"] for hook in local_repo["hooks"]}
+        assert {"dotnet-format", "roslyn-analyzers"} <= hook_ids
+
+    def test_precommit_formatter_hook_is_check_mode(self, csharp_project: Path) -> None:
+        """The dotnet-format hook can actually fail on unformatted code."""
+        content = (csharp_project / ".pre-commit-config.yaml").read_text()
+        assert "dotnet format --verify-no-changes" in content
+
+    def test_code_metrics_config_carries_the_complexity_bound(
+        self, csharp_project: Path
+    ) -> None:
+        """CodeMetricsConfig.txt is the single home of the <=10 bound."""
+        content = (csharp_project / "CodeMetricsConfig.txt").read_text()
+        assert "CA1502: 10" in content
+
+    def test_editorconfig_enables_the_complexity_rule(
+        self, csharp_project: Path
+    ) -> None:
+        """.editorconfig switches the otherwise-off CA1502 rule on."""
+        content = (csharp_project / ".editorconfig").read_text()
+        assert "dotnet_diagnostic.CA1502.severity = error" in content
+
+    def test_check_all_script_runs_the_csharp_toolchain(
+        self, csharp_project: Path
+    ) -> None:
+        """check-all.sh chains format, lint, coverage-gated tests, security."""
+        content = (csharp_project / "scripts" / "check-all.sh").read_text()
+        assert 'run_check "Tests" "test.sh" --coverage' in content
+
+    def test_architecture_test_defines_the_layer_matrix(
+        self, csharp_project: Path
+    ) -> None:
+        """The NetArchTest template derives its layers from the project name."""
+        source = (
+            csharp_project / "plans" / "architecture" / "ArchitectureTest.cs"
+        ).read_text()
+        assert f"namespace {_NAMESPACE}.Architecture" in source
+        assert f'BaseNamespace = "{_NAMESPACE}"' in source
+        assert ".HaveDependencyOnAny(" in source
+
+
+class TestCsharpInitManifest:
+    """Assert the csproj manifest and the CI workflow."""
+
+    def test_csproj_is_well_formed_sdk_project(self, csharp_project: Path) -> None:
+        """The csproj parses as XML rooted at an SDK-style Project."""
+        content = (csharp_project / f"{_PROJECT_NAME}.csproj").read_text()
+        root = DefusedElementTree.fromstring(content)
+        assert root.tag == "Project"
+        assert root.get("Sdk") == "Microsoft.NET.Sdk"
+
+    def test_csproj_owns_the_quality_gates(self, csharp_project: Path) -> None:
+        """The csproj pins the coverage bound and the analyzer policy."""
+        content = (csharp_project / f"{_PROJECT_NAME}.csproj").read_text()
+        assert "<Threshold>90</Threshold>" in content
+        assert "<TreatWarningsAsErrors>true</TreatWarningsAsErrors>" in content
+        assert '<AdditionalFiles Include="CodeMetricsConfig.txt" />' in content
+        assert 'Include="coverlet.msbuild"' in content
+        assert 'Include="NetArchTest.Rules"' in content
+        assert 'Include="SecurityCodeScan.VS2019"' in content
+
+    def test_ci_workflow_parses_and_gates_via_the_manifest(
+        self, csharp_project: Path
+    ) -> None:
+        """ci.yml parses as YAML and never restates the coverage bound.
+
+        The >=90% number lives in the csproj (single home), so the CI
+        coverage step passes only /p:CollectCoverage=true.
+        """
+        content = (csharp_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "C# Quality Checks"
+        assert "/p:CollectCoverage=true" in content
+        assert "/p:Threshold=" not in content
+
+    def test_ci_matrix_can_build_the_target_framework(
+        self, csharp_project: Path
+    ) -> None:
+        """The SDK matrix has no entry older than the net8.0 target.
+
+        An SDK 7 runner cannot build a net8.0 project, so its matrix
+        leg would be red on every push.
+        """
+        content = (csharp_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        matrix = parsed["jobs"]["quality"]["strategy"]["matrix"]["dotnet-version"]
+        assert "7.0" not in matrix
+        assert any(str(version).startswith("8") for version in matrix)
+
+    def test_ci_codecov_upload_cannot_fail_a_fresh_project(
+        self, csharp_project: Path
+    ) -> None:
+        """The Codecov upload is best-effort in generated projects.
+
+        A fresh `green init` project ships no CODECOV_TOKEN secret, so
+        `fail_ci_if_error: true` would start the project red; the real
+        coverage gate is the csproj-backed Coverlet run (#368 lesson).
+        """
+        content = (csharp_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert codecov_steps, "CI must still upload coverage to Codecov"
+        for step in codecov_steps:
+            assert step["with"]["fail_ci_if_error"] is False
+
+
+class TestCsharpInitSources:
+    """Assert the generated C# source and test files."""
+
+    def test_program_namespace_and_visibility(self, csharp_project: Path) -> None:
+        """Program.cs uses the shared namespace and a public Main."""
+        source = (csharp_project / "src" / "Program.cs").read_text()
+        assert f"namespace {_NAMESPACE}" in source
+        assert "public static void Main" in source
+        assert f'"Hello from {_PROJECT_NAME}!"' in source
+
+    def test_generated_test_resolves_program(self, csharp_project: Path) -> None:
+        """MainTests.cs nests under the Program namespace and calls Main."""
+        source = (csharp_project / "tests" / "MainTests.cs").read_text()
+        assert f"namespace {_NAMESPACE}.Tests" in source
+        assert "Program.Main(" in source
+        assert "[Fact]" in source
+
+
+class TestCsharpInitReadme:
+    """Assert the generated README stays truthful (#370)."""
+
+    def test_readme_advertises_370_tooling_as_real(self, csharp_project: Path) -> None:
+        """README advertises the now-generated #370 quality tooling.
+
+        Every artifact the README checkmarks must exist next to it —
+        the truthfulness contract.
+        """
+        readme = (csharp_project / "README.md").read_text()
+        assert "./scripts/check-all.sh" in readme
+        assert (csharp_project / "scripts" / "check-all.sh").is_file()
+        assert "plans/architecture" in readme
+        assert (
+            csharp_project / "plans" / "architecture" / "ArchitectureTest.cs"
+        ).is_file()
+        assert ".github/workflows/ci.yml" in readme
+        assert (csharp_project / ".github" / "workflows" / "ci.yml").is_file()
+
+    def test_readme_structure_block_is_truthful(self, csharp_project: Path) -> None:
+        """README never names a solution file the scaffold does not emit."""
+        readme = (csharp_project / "README.md").read_text()
+        assert ".sln" not in readme
+
+
+class TestCsharpInitConsoleOutput:
+    """Assert init's console output reflects the #370 wiring."""
+
+    def test_init_skips_no_pipeline_steps(self, tmp_path: Path) -> None:
+        """Init prints no skip notice for any csharp pipeline step.
+
+        The pre-commit, scripts, and architecture steps gained csharp
+        support with #370 (CI has been real since the foundation), so
+        every "unavailable" notice must be gone.
+        """
+        runner = CliRunner()
+        with patch(
+            "start_green_stay_green.cli._initialize_orchestrator",
+            return_value=None,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "init",
+                    "--project-name",
+                    "skip-check",
+                    "--language",
+                    "csharp",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--no-interactive",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Pre-commit config unavailable for csharp" not in result.output
+        assert "Quality scripts unavailable for csharp" not in result.output
+        assert "Architecture rules unavailable for csharp" not in result.output
+        assert "CI pipeline unavailable for csharp" not in result.output
+        assert "Generated CI pipeline" in result.output

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -1375,6 +1375,234 @@ class TestArchitectureEnforcementGeneratorJava:
         assert result.language == "java"
 
 
+class TestArchitectureEnforcementGeneratorCsharp:
+    """Test C#-specific architecture rules (#370)."""
+
+    @staticmethod
+    def _generate(tmp_path: Path, project_name: str = "my-app") -> Path:
+        """Generate the C# architecture config and return its directory."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+        generator.generate(language="csharp", project_name=project_name)
+        return output_dir
+
+    def test_generate_csharp_creates_netarchtest_test(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test generating the NetArchTest architecture test for C#."""
+        output_dir = self._generate(tmp_path)
+
+        config_file = output_dir / "ArchitectureTest.cs"
+        assert config_file.exists()
+
+        # Should create README and run script
+        assert (output_dir / "README.md").exists()
+        assert (output_dir / "run-check.sh").exists()
+
+    def test_csharp_config_is_structurally_valid_csharp(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """ArchitectureTest.cs must be structurally valid C# source.
+
+        There is no C# parser in the test environment, so validity is
+        checked structurally (the Kotlin/Java precedent): balanced
+        braces/parentheses, usings before the namespace declaration,
+        and no unrendered template placeholders.
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        code_lines = [
+            line
+            for line in source.splitlines()
+            if line.strip() and not line.lstrip().startswith(("//", "*", "/*"))
+        ]
+        code = "\n".join(code_lines)
+
+        assert code.count("{") == code.count("}")
+        assert code.count("(") == code.count(")")
+        # Usings come first, then the namespace, then the class.
+        assert code_lines[0].startswith("using ")
+        using_lines = [line for line in code_lines if line.startswith("using ")]
+        assert using_lines
+        assert all(line.rstrip().endswith(";") for line in using_lines)
+        assert code.index("using ") < code.index("namespace ")
+        assert code.index("namespace ") < code.index("public class ArchitectureTest")
+        assert "[Fact]" in code
+        # No unrendered Python format placeholders may survive.
+        assert "{namespace}" not in source
+
+    def test_csharp_config_uses_netarchtest_api(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test drives NetArchTest's fluent rules API."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert "using NetArchTest.Rules;" in source
+        assert "using Xunit;" in source
+        assert "Types.InAssembly(" in source
+        assert ".GetResult()" in source
+        assert ".IsSuccessful" in source
+
+    def test_csharp_config_enforces_layer_separation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test C# config encodes the four-layer inward-only matrix."""
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        for layer in ("Domain", "Application", "Presentation", "Infrastructure"):
+            assert f'"{layer}"' in source or f".{layer}" in source
+        # Domain must not reach any outer layer; application must not
+        # reach presentation/infrastructure; infrastructure must not
+        # reach presentation/application.
+        assert ".ShouldNot()" in source
+        assert ".HaveDependencyOnAny(" in source
+
+    def test_csharp_config_documents_cycle_rule_gap(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test discloses how cycle freedom is (and is not) covered.
+
+        NetArchTest has no slices/cycle rule (ArchUnitNET does — the
+        documented alternative): cycle freedom among the four layers
+        follows from the acyclic dependency matrix, but arbitrary
+        namespace cycles outside it go unchecked, and the C# compiler
+        does NOT reject namespace cycles, so the limit must be stated
+        rather than attributed to the build system.
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert "ArchUnitNET" in source
+        assert "does NOT reject" in source
+        assert "acyclic" in source
+
+    def test_csharp_config_derives_layer_namespaces_from_project_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Layer namespaces come from the shared csharp_namespace helper.
+
+        A hyphenated project name must produce the PascalCase namespace
+        (my-app -> MyApp), keeping the architecture test in sync with
+        the scaffolded sources.
+        """
+        output_dir = self._generate(tmp_path, project_name="my-app")
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert '"MyApp"' in source
+        assert "namespace MyApp.Architecture" in source
+
+    def test_csharp_config_documents_compiled_assembly_limits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test documents what NetArchTest cannot enforce.
+
+        NetArchTest analyzes the compiled assembly (via Mono.Cecil), so
+        the generated test must disclose that reflection/DI wiring is
+        invisible and that the project must build first.
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert "reflection" in source
+        assert "compiled" in source
+
+    def test_csharp_config_documents_wiring_requirement(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The test discloses it only enforces once copied into tests/.
+
+        Unlike javac, C# namespaces carry no directory-matching
+        requirement, so the flat copy is correct (and the template says
+        so — the inverse of the Java package-path lesson).
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert "cp plans/architecture/ArchitectureTest.cs tests/" in source
+        assert "directory" in source
+
+    def test_csharp_config_documents_vacuous_pass_default(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The warn-first empty-namespace default carries a tighten note.
+
+        NetArchTest rules pass vacuously when a layer namespace has no
+        types yet (the withOptionalLayers(true) analogue), so the test
+        must disclose it and point at the tighten-me path.
+        """
+        output_dir = self._generate(tmp_path)
+
+        source = (output_dir / "ArchitectureTest.cs").read_text()
+        assert "vacuous" in source
+        assert "Tighten" in source
+
+    def test_csharp_readme_mentions_netarchtest(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the C# README references the NetArchTest tooling."""
+        output_dir = self._generate(tmp_path)
+
+        readme = (output_dir / "README.md").read_text()
+        assert "NetArchTest" in readme
+        assert "ArchitectureTest.cs" in readme
+
+    def test_csharp_run_script_probes_dotnet(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the C# run-check.sh probes the dotnet binary."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "command -v dotnet" in script
+
+    def test_csharp_run_script_filters_to_architecture_test(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the C# run-check.sh runs only the architecture test."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "--filter" in script
+        assert "ArchitectureTest" in script
+
+    def test_csharp_run_script_uses_display_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the C# run-check.sh announces the 'C#' display name."""
+        output_dir = self._generate(tmp_path)
+
+        script = (output_dir / "run-check.sh").read_text()
+        assert "Checking C# architecture" in script
+
+    def test_csharp_result_reports_csharp_language(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the result object records the csharp language."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        result = generator.generate(language="csharp", project_name="my-app")
+
+        assert result.language == "csharp"
+
+
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
 
@@ -1425,6 +1653,7 @@ class TestLanguageTooling:
             ("kotlin", "Kotlin"),
             ("cpp", "C/C++"),
             ("java", "Java"),
+            ("csharp", "C#"),
         ],
     )
     def test_each_tooling_carries_a_display_name(
@@ -1469,6 +1698,21 @@ class TestLanguageTooling:
         tooling = _LANGUAGE_TOOLING["java"]
         assert "{config_file}" not in tooling.run_cmd
         assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
+
+    def test_csharp_install_cmd_carries_the_config_path(self) -> None:
+        """C# references its config via install_cmd, not run_cmd (#370).
+
+        NetArchTest's 'config' is an xUnit test compiled into the
+        project — the Konsist/ArchUnit precedent — so the dotnet run
+        command takes no config-file flag and the wiring step (the flat
+        copy into tests/) lives in install_cmd. Unlike javac, C#
+        namespaces carry no directory-matching requirement, so the
+        flat copy needs no {package_path} resolution.
+        """
+        tooling = _LANGUAGE_TOOLING["csharp"]
+        assert "{config_file}" not in tooling.run_cmd
+        assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
+        assert "{package_path}" not in tooling.install_cmd
 
     def test_java_install_cmd_resolves_package_matched_path(self) -> None:
         """Java's install command targets the package-matching directory.

--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -13,6 +13,12 @@ from start_green_stay_green.generators.dependencies import DependencyConfig
 from start_green_stay_green.utils.cpp import CATCH2_VERSION
 from start_green_stay_green.utils.cpp import CMAKE_MINIMUM_VERSION
 from start_green_stay_green.utils.cpp import CPP_STANDARD
+from start_green_stay_green.utils.csharp import COVERLET_MSBUILD_VERSION
+from start_green_stay_green.utils.csharp import NETARCHTEST_RULES_VERSION
+from start_green_stay_green.utils.csharp import SECURITY_CODE_SCAN_VERSION
+from start_green_stay_green.utils.csharp import TEST_SDK_VERSION
+from start_green_stay_green.utils.csharp import XUNIT_RUNNER_VERSION
+from start_green_stay_green.utils.csharp import XUNIT_VERSION
 from start_green_stay_green.utils.java import ARCHUNIT_VERSION
 from start_green_stay_green.utils.java import CHECKSTYLE_PLUGIN_VERSION
 from start_green_stay_green.utils.java import DEPENDENCY_CHECK_PLUGIN_VERSION
@@ -728,6 +734,130 @@ class TestJavaDependencies:
             assert "<artifactId>dependency-check-maven</artifactId>" in content
             assert f"<version>{DEPENDENCY_CHECK_PLUGIN_VERSION}</version>" in content
             assert "<failBuildOnCVSS>7</failBuildOnCVSS>" in content
+
+
+class TestCsharpDependencies:
+    """Test the C# .csproj manifest generation (#370)."""
+
+    @staticmethod
+    def _csproj(tmpdir: str) -> str:
+        """Generate the csharp dependency files and return the csproj.
+
+        Args:
+            tmpdir: Directory to generate into.
+
+        Returns:
+            The generated ``.csproj`` content.
+        """
+        config = DependencyConfig(
+            project_name="wrist-ledger",
+            language="csharp",
+            package_name="wrist_ledger",
+        )
+        files = DependenciesGenerator(Path(tmpdir), config).generate()
+        csproj_path: Path = files["wrist-ledger.csproj"]
+        return csproj_path.read_text()
+
+    def test_csproj_is_well_formed_xml_with_sdk_attribute(self) -> None:
+        """The csproj parses as XML rooted at an SDK-style Project."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = DefusedElementTree.fromstring(self._csproj(tmpdir))
+            assert root.tag == "Project"
+            assert root.get("Sdk") == "Microsoft.NET.Sdk"
+
+    def test_csproj_pins_the_xunit_test_stack(self) -> None:
+        """xUnit, its VS runner, and the test SDK are pinned from utils."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert f'Include="xunit" Version="{XUNIT_VERSION}"' in content
+            assert (
+                f'Include="xunit.runner.visualstudio" Version="{XUNIT_RUNNER_VERSION}"'
+                in content
+            )
+            assert (
+                f'Include="Microsoft.NET.Test.Sdk" Version="{TEST_SDK_VERSION}"'
+                in content
+            )
+
+    def test_csproj_carries_the_coverlet_coverage_gate(self) -> None:
+        """coverlet.msbuild is pinned and the >=90% bound lives here.
+
+        The csproj is the single home of the coverage threshold (the
+        Kover/JaCoCo manifest-owned precedent): scripts/test.sh and CI
+        only pass ``/p:CollectCoverage=true`` and never restate the
+        number. coverlet.msbuild hooks the dotnet test task itself, so
+        the gate fails the test invocation directly — there is no
+        standalone-goal/empty-report no-op path to guard against.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert (
+                f'Include="coverlet.msbuild" Version="{COVERLET_MSBUILD_VERSION}"'
+                in content
+            )
+            assert "<Threshold>90</Threshold>" in content
+            assert "<ThresholdType>line</ThresholdType>" in content
+            assert "<ThresholdStat>total</ThresholdStat>" in content
+
+    def test_csproj_enables_roslyn_analyzers_as_errors(self) -> None:
+        """The Roslyn analyzer gate is build-borne and warnings fail it.
+
+        ``EnableNETAnalyzers``/``AnalysisLevel`` turn the SDK analyzers
+        on and ``TreatWarningsAsErrors`` makes every ``dotnet build``
+        (pre-commit hook, lint.sh, CI) a failing lint gate — the csproj
+        is the single home of that policy.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert "<EnableNETAnalyzers>true</EnableNETAnalyzers>" in content
+            assert "<AnalysisLevel>latest</AnalysisLevel>" in content
+            assert "<TreatWarningsAsErrors>true</TreatWarningsAsErrors>" in content
+
+    def test_csproj_declares_the_code_metrics_config(self) -> None:
+        """CodeMetricsConfig.txt is wired as an AdditionalFiles item.
+
+        The .NET SDK's CA1502 complexity rule reads its threshold from
+        an AdditionalFiles entry named exactly CodeMetricsConfig.txt
+        (written by the scripts generator — the pmd-ruleset.xml split);
+        without this item the <=10 gate would silently use the default
+        threshold of 25.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert '<AdditionalFiles Include="CodeMetricsConfig.txt" />' in content
+            # The numeric bound must NOT be duplicated here; its single
+            # home is CodeMetricsConfig.txt itself.
+            assert "CA1502: 10" not in content
+
+    def test_csproj_pins_netarchtest_for_the_architecture_template(self) -> None:
+        """NetArchTest.Rules backs plans/architecture/ArchitectureTest.cs.
+
+        Declared in the manifest (the ArchUnit/Konsist precedent) so the
+        parked template compiles as soon as it is copied into tests/.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert (
+                f'Include="NetArchTest.Rules" Version="{NETARCHTEST_RULES_VERSION}"'
+                in content
+            )
+
+    def test_csproj_pins_security_code_scan_analyzer(self) -> None:
+        """SecurityCodeScan runs as a Roslyn analyzer in every build."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            expected = (
+                'Include="SecurityCodeScan.VS2019" '
+                f'Version="{SECURITY_CODE_SCAN_VERSION}"'
+            )
+            assert expected in content
+
+    def test_csproj_documents_the_single_project_design(self) -> None:
+        """The csproj discloses that src/ and tests/ share one assembly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._csproj(tmpdir)
+            assert "Single-project layout" in content
+            assert "tests/" in content
 
 
 class TestCppDependencies:

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -186,8 +186,43 @@ class TestLanguageTools:
             "kotlin",
             "cpp",
             "java",
+            "csharp",
         }
         assert required_languages.issubset(set(LANGUAGE_TOOLS.keys()))
+
+    def test_csharp_tools(self) -> None:
+        """Test C# tool mappings (#370).
+
+        Each tool appears in exactly one category: Coverlet owns
+        coverage (the >=90% bound lives in the csproj), the Roslyn
+        CA1502 rule owns complexity (threshold in CodeMetricsConfig.txt),
+        SecurityCodeScan owns source-level security, the vulnerable-
+        package listing owns dependency CVEs, and Stryker.NET is a
+        periodic mutation gate like pitest/mull/muter.
+        """
+        tools = LANGUAGE_TOOLS["csharp"]
+        assert tools["coverage"] == "Coverlet (dotnet test /p:CollectCoverage=true)"
+        assert tools["mutation"] == "Stryker.NET (dotnet stryker)"
+        assert tools["complexity"] == "Roslyn CA1502 (CodeMetricsConfig.txt)"
+        assert tools["documentation"] == "DocFX"
+        assert tools["security"] == "SecurityCodeScan (Roslyn analyzer)"
+        assert tools["dependency_check"] == "dotnet list package --vulnerable"
+
+    def test_csharp_tools_do_not_double_list_across_categories(self) -> None:
+        """No C# tool is claimed by two metric categories."""
+        tools = LANGUAGE_TOOLS["csharp"]
+        names_per_category = {
+            "coverage": {"Coverlet"},
+            "complexity": {"CA1502"},
+            "security": {"SecurityCodeScan"},
+            "documentation": {"DocFX"},
+        }
+        for category, names in names_per_category.items():
+            for other_category, other_names in names_per_category.items():
+                if category != other_category:
+                    assert names.isdisjoint(other_names)
+            for name in names:
+                assert name in tools[category]
 
     def test_java_tools(self) -> None:
         """Test Java tool mappings (#367).

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -1006,6 +1006,136 @@ class TestGenerateWithJava:
         assert any("shellcheck-py" in url for url in repo_urls)
 
 
+class TestGenerateWithCsharp:
+    """Test content generation for C# projects (#370)."""
+
+    @staticmethod
+    def _parsed_repos(generator: PreCommitGenerator) -> list[dict[str, Any]]:
+        """Generate the csharp config and return its parsed repos list."""
+        config = GenerationConfig(
+            project_name="csharp-project",
+            language="csharp",
+            language_config={},
+        )
+        result = generator.generate(config)
+        yaml_content = "\n".join(
+            line for line in result["content"].split("\n") if not line.startswith("#")
+        )
+        parsed = yaml.safe_load(yaml_content)
+        return list(parsed["repos"])
+
+    def _local_repo(self, generator: PreCommitGenerator) -> dict[str, Any]:
+        """Return the ``repo: local`` block from the csharp config."""
+        repos = self._parsed_repos(generator)
+        return next(repo for repo in repos if repo.get("repo") == "local")
+
+    def test_generate_csharp_content_is_valid_yaml(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Generated csharp pre-commit config must be parseable YAML."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        assert isinstance(repos, list)
+        assert repos
+
+    def test_csharp_dotnet_format_hook_fails_on_unformatted(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """The formatter hook is check-mode and fails on unformatted files.
+
+        A bare ``dotnet format`` rewrites files and exits 0 either way,
+        so it could never fail a commit; the hook must use
+        ``--verify-no-changes``, which exits non-zero when formatting
+        is needed (scripts/format.sh keeps the fixing path).
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        local_repo = self._local_repo(generator)
+        formatter = next(
+            hook for hook in local_repo["hooks"] if hook.get("id") == "dotnet-format"
+        )
+        assert "--verify-no-changes" in formatter["entry"]
+        assert formatter["entry"].startswith("dotnet format")
+
+    def test_csharp_roslyn_hook_builds_with_manifest_owned_gate(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """The lint hook is a plain build; the csproj owns the policy.
+
+        Roslyn analyzers (SDK rules, CA1502 complexity, SecurityCodeScan)
+        all run inside the compiler, and the generated csproj sets
+        TreatWarningsAsErrors — so `dotnet build` IS the failing lint
+        gate and the hook must not restate any -warnaserror flag
+        (single home: the csproj).
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        local_repo = self._local_repo(generator)
+        linter = next(
+            hook for hook in local_repo["hooks"] if hook.get("id") == "roslyn-analyzers"
+        )
+        assert linter["entry"].startswith("dotnet build")
+        assert "warnaserror" not in linter["entry"]
+
+    def test_csharp_local_hooks_run_once_per_commit(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """dotnet hooks operate on the project, not on filenames.
+
+        ``dotnet format`` and ``dotnet build`` take a project (not a
+        file list), so the hooks must set ``pass_filenames: false`` and
+        scope themselves to C# sources via types — otherwise pre-commit
+        would append staged paths as misparsed CLI arguments.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        local_repo = self._local_repo(generator)
+        for hook in local_repo["hooks"]:
+            assert hook["pass_filenames"] is False, f"{hook['id']} passes filenames"
+            assert hook["language"] == "system", f"{hook['id']} not language: system"
+            assert hook["types"] == ["c#"], f"{hook['id']} missing c# types"
+
+    def test_generate_csharp_includes_check_xml(self, mock_orchestrator: Mock) -> None:
+        """The csproj manifest's XML well-formedness is gated via check-xml.
+
+        identify tags ``.csproj`` files as xml, so the stock check-xml
+        hook covers the manifest (the AndroidManifest/tizen-manifest
+        precedent) without a files override.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        standard_repo = next(
+            repo for repo in repos if "pre-commit-hooks" in repo.get("repo", "")
+        )
+        hook_ids = [hook.get("id", "") for hook in standard_repo.get("hooks", [])]
+        assert "check-xml" in hook_ids
+
+    def test_generate_csharp_includes_gitleaks(self, mock_orchestrator: Mock) -> None:
+        """Test generated csharp config includes the gitleaks secrets hook."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        gitleaks_repo = next(
+            (repo for repo in repos if "gitleaks/gitleaks" in repo.get("repo", "")),
+            None,
+        )
+        assert gitleaks_repo is not None
+        hook_ids = [hook.get("id", "") for hook in gitleaks_repo.get("hooks", [])]
+        assert "gitleaks" in hook_ids
+
+    def test_generate_csharp_includes_detect_secrets(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """csharp keeps the detect-secrets hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("Yelp/detect-secrets" in url for url in repo_urls)
+
+    def test_generate_csharp_includes_shellcheck(self, mock_orchestrator: Mock) -> None:
+        """csharp keeps the shellcheck hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("shellcheck-py" in url for url in repo_urls)
+
+
 class TestValidateLanguage:
     """Test language validation functionality."""
 
@@ -1151,11 +1281,19 @@ class TestGetSupportedLanguages:
         result = generator.get_supported_languages()
         assert "java" in result
 
+    def test_get_supported_languages_includes_csharp(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Test get_supported_languages includes csharp (#370)."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        result = generator.get_supported_languages()
+        assert "csharp" in result
+
     def test_get_supported_languages_exact_count(self, mock_orchestrator: Mock) -> None:
         """Test get_supported_languages returns expected count."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_supported_languages()
-        assert len(result) == 8
+        assert len(result) == 9
 
     def test_get_supported_languages_no_duplicates(
         self, mock_orchestrator: Mock

--- a/tests/unit/generators/test_readme.py
+++ b/tests/unit/generators/test_readme.py
@@ -633,6 +633,82 @@ class TestJavaReadme:
             assert "com.example.test_project" in content
 
 
+class TestCsharpReadme:
+    """Test the C# README content (#370)."""
+
+    @staticmethod
+    def _readme_content(tmpdir: str) -> str:
+        """Generate the csharp README and return its text.
+
+        Args:
+            tmpdir: Directory to generate into.
+
+        Returns:
+            The rendered README.md content.
+        """
+        config = ReadmeConfig(
+            project_name="test-project",
+            language="csharp",
+            package_name="test_project",
+        )
+        files = ReadmeGenerator(Path(tmpdir), config).generate()
+        readme_path: Path = files["README.md"]
+        return readme_path.read_text()
+
+    def test_csharp_readme_advertises_the_wired_quality_tooling(self) -> None:
+        """README advertises the #370 quality tooling as real.
+
+        With the #370 toolchain (dotnet format + Roslyn-analyzer
+        pre-commit hooks, quality scripts, the CA1502 complexity gate,
+        the NetArchTest architecture template) and the foundation CI
+        pipeline both generated, every roadmap item is real — the
+        Kotlin (#360) / C/C++ (#365) / Java (#367) precedent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "Planned / coming soon" not in content
+            assert ".github/workflows/ci.yml" in content
+            assert "./scripts/check-all.sh" in content
+            assert "NetArchTest" in content
+            assert "plans/architecture" in content
+            assert "CodeMetricsConfig.txt" in content
+
+    def test_csharp_readme_documents_dotnet_usage(self) -> None:
+        """README documents the dotnet CLI quality commands."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "dotnet test" in content
+            assert "dotnet build" in content
+            assert "dotnet format --verify-no-changes" in content
+            assert "dotnet test /p:CollectCoverage=true" in content
+
+    def test_csharp_readme_documents_threshold_homes(self) -> None:
+        """README points at the single homes of the numeric gates.
+
+        The >=90% coverage bound lives in the csproj and the <=10
+        complexity bound in CodeMetricsConfig.txt; the README must
+        direct readers there rather than inventing a third home.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "test-project.csproj" in content
+            assert "CA1502" in content
+
+    def test_csharp_readme_structure_matches_generated_tree(self) -> None:
+        """README's structure block names only files init generates.
+
+        The truthfulness contract: no solution (.sln) file is generated
+        and the test scaffold is tests/MainTests.cs, so the README must
+        not claim otherwise.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert ".sln" not in content
+            assert "UnitTests.cs" not in content
+            assert "MainTests.cs" in content
+            assert "src/Program.cs" in content or "Program.cs" in content
+
+
 class TestCppReadme:
     """Test C/C++ Tizen-specific README content (#361/#362)."""
 

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -1457,6 +1457,257 @@ class TestScriptsGeneratorJavaGeneration:
             assert existing.read_text() == "<ruleset />\n"
 
 
+class TestScriptsGeneratorCsharpGeneration:
+    """Test C# script generation (#370)."""
+
+    @staticmethod
+    def _generate(tmpdir: str) -> dict[str, Path]:
+        """Generate csharp scripts into ``tmpdir`` and return the mapping."""
+        config = ScriptConfig(
+            language="csharp",
+            package_name="my_dotnet_app",
+        )
+        generator = ScriptsGenerator(Path(tmpdir), config)
+        return generator.generate()
+
+    def test_generate_csharp_scripts_creates_files(self) -> None:
+        """Test generate creates the full csharp script set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            assert "check-all.sh" in scripts
+            assert "format.sh" in scripts
+            assert "lint.sh" in scripts
+            assert "test.sh" in scripts
+            assert "security.sh" in scripts
+
+    def test_csharp_shell_scripts_pass_bash_syntax_check(self) -> None:
+        """Every generated csharp shell script parses under bash -n.
+
+        The #362 lesson: this literal syntax check caught a real
+        template-escaping bug in the cpp scripts, so every new language
+        gets it from day one.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            for name, path in scripts.items():
+                if not name.endswith(".sh"):
+                    continue
+                bash = shutil.which("bash")
+                assert bash is not None, "bash not found on PATH"
+                result = subprocess.run(  # noqa: S603  # Issue #370: bash -n on generated content, no untrusted input
+                    [bash, "-n", str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, f"{name}: {result.stderr}"
+
+    def test_csharp_shell_scripts_pass_shellcheck(self) -> None:
+        """Every generated csharp shell script is clean under shellcheck.
+
+        bash -n only catches parse errors; shellcheck catches the
+        quoting/expansion bugs that have bitten generated scripts
+        before (#425/SC2059), so the linter itself gates the templates.
+        Skips only when shellcheck is not installed (it ships on the
+        GitHub ubuntu runners and via shellcheck-py in pre-commit).
+        """
+        shellcheck = shutil.which("shellcheck")
+        if shellcheck is None:
+            pytest.skip("shellcheck not on PATH (covered in CI)")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            for name, path in scripts.items():
+                if not name.endswith(".sh"):
+                    continue
+                result = subprocess.run(  # noqa: S603  # Issue #370: shellcheck on generated content, no untrusted input
+                    [shellcheck, str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, f"{name}: {result.stdout}"
+
+    def test_csharp_format_script_uses_dotnet_format(self) -> None:
+        """format.sh fixes by default and verifies with --verify-no-changes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "dotnet format" in content
+            assert "--verify-no-changes" in content
+
+    def test_csharp_format_script_requires_the_dotnet_cli(self) -> None:
+        """format.sh fails with install instructions when dotnet is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "command -v dotnet" in content
+            assert "brew install dotnet-sdk" in content
+
+    def test_csharp_lint_script_builds_with_manifest_owned_policy(self) -> None:
+        """lint.sh is a plain dotnet build; the csproj owns the policy.
+
+        All Roslyn analysis (SDK CA rules, the CA1502 complexity
+        ceiling, SecurityCodeScan) runs inside the compiler and the
+        csproj's TreatWarningsAsErrors makes the build fail on
+        findings — the script must not restate any -warnaserror flag.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "dotnet build --nologo" in content
+            assert "warnaserror" not in content
+            assert "TreatWarningsAsErrors" in content
+
+    def test_csharp_lint_script_documents_ca1502_as_complexity_owner(self) -> None:
+        """The complexity ceiling lives once, in CodeMetricsConfig.txt.
+
+        The Roslyn CA1502 rule owns the <=10 gate; lint.sh points at
+        the companion config rather than duplicating a threshold.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "CA1502" in content
+            assert "CodeMetricsConfig.txt" in content
+            # No shell-side duplicate of the bound.
+            assert "MAX_CCN" not in content
+
+    def test_csharp_test_script_runs_dotnet_test(self) -> None:
+        """test.sh runs the xUnit suite via plain `dotnet test`.
+
+        The literal string `dotnet test` doubles as the language marker
+        cli._scripts_dir_has_other_language probes for csharp.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "dotnet test" in content
+            assert "command -v dotnet" in content
+
+    def test_csharp_test_script_enforces_coverage_via_csproj_gate(self) -> None:
+        """Coverage mode activates Coverlet; the bound stays in the csproj.
+
+        ``dotnet test /p:CollectCoverage=true`` lets coverlet.msbuild
+        hook the test task itself, so a missed bound fails the
+        invocation directly (no standalone-goal/empty-report no-op
+        path). The >=90% number lives only in the csproj's
+        Threshold/ThresholdType/ThresholdStat properties, so the script
+        must not restate it.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "/p:CollectCoverage=true" in content
+            assert ".csproj" in content
+            assert "THRESHOLD=" not in content
+            assert "/p:Threshold=" not in content
+
+    def test_csharp_security_script_gates_on_vulnerable_packages(self) -> None:
+        """security.sh fails when the vulnerable-package listing reports hits.
+
+        ``dotnet list package --vulnerable`` kept exit code 0 even with
+        findings across several SDK lines (dotnet/sdk#25091), so the
+        gate greps the report line instead of trusting the exit code.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "dotnet list package --vulnerable" in content
+            assert "has the following vulnerable packages" in content
+
+    def test_csharp_security_script_warns_when_offline(self) -> None:
+        """The vulnerability scan needs the network; offline warns, not fails.
+
+        The listing queries the NuGet vulnerability database (and needs
+        a restore), so the pragmatic warn-first default skips with a
+        documented tighten-me path instead of failing a fresh offline
+        clone — the NVD_API_KEY precedent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "network" in content
+            assert "Tighten" in content
+
+    def test_csharp_security_script_documents_division_of_labor(self) -> None:
+        """security.sh discloses where the other security passes live."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "gitleaks" in content
+            assert "detect-secrets" in content
+            assert "SecurityCodeScan" in content
+
+    def test_csharp_check_all_runs_full_toolchain(self) -> None:
+        """check-all.sh runs format, lint, tests (with coverage), security."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["check-all.sh"].read_text()
+            assert 'run_check "Format" "format.sh"' in content
+            assert 'run_check "Linting" "lint.sh"' in content
+            assert 'run_check "Tests" "test.sh" --coverage' in content
+            assert 'run_check "Security" "security.sh"' in content
+
+    def test_csharp_writes_editorconfig_companion(self) -> None:
+        """.editorconfig lands at the project root and enables CA1502.
+
+        CA1502 ships with the .NET SDK analyzers but is disabled by
+        default; the .editorconfig severity switch is what turns the
+        complexity gate on (the threshold itself lives in
+        CodeMetricsConfig.txt).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            config = Path(tmpdir) / ".editorconfig"
+            assert config.exists()
+            content = config.read_text()
+            assert "dotnet_diagnostic.CA1502.severity = error" in content
+
+    def test_csharp_writes_code_metrics_config_companion(self) -> None:
+        """CodeMetricsConfig.txt is the single home of the <=10 bound.
+
+        The .NET SDK metrics analyzers read 'CA1502: 10' from this
+        AdditionalFiles entry; CA1502 fires when complexity EXCEEDS the
+        threshold, so 10 reports 11+ — the same ceiling the other
+        languages gate on.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            config = Path(tmpdir) / "CodeMetricsConfig.txt"
+            assert config.exists()
+            content = config.read_text()
+            assert "CA1502: 10" in content
+            assert "<= 10" in content
+
+    def test_csharp_companions_preserve_existing_files(self) -> None:
+        """Existing user companion configs are never overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing_editor = Path(tmpdir) / ".editorconfig"
+            existing_editor.write_text("root = true\n")
+            existing_metrics = Path(tmpdir) / "CodeMetricsConfig.txt"
+            existing_metrics.write_text("CA1502: 25\n")
+
+            self._generate(tmpdir)
+
+            assert existing_editor.read_text() == "root = true\n"
+            assert existing_metrics.read_text() == "CA1502: 25\n"
+
+
 class TestScriptsGeneratorLanguageFallback:
     """Test language fallback behavior."""
 
@@ -1761,6 +2012,20 @@ class TestMutationKillers:
             # Should generate java scripts with the pom-backed goals
             content = scripts["lint.sh"].read_text()
             assert "checkstyle:check" in content
+
+    def test_csharp_language_dispatches_to_csharp_generator(self) -> None:
+        """Test 'csharp' language dispatches to the C# generator (#370)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="csharp",
+                package_name="test",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            # Should generate csharp scripts with the dotnet CLI gates
+            content = scripts["lint.sh"].read_text()
+            assert "dotnet build" in content
 
     def test_generated_scripts_exact_count_python(self) -> None:
         """Test Python generator creates EXACTLY 12 scripts.

--- a/tests/unit/generators/test_structure.py
+++ b/tests/unit/generators/test_structure.py
@@ -458,6 +458,46 @@ class TestMultiLanguageStructure:
             content = files["src/Program.cs"].read_text()
             assert "Hello from" in content
 
+    def test_csharp_program_uses_shared_pascal_case_namespace(self) -> None:
+        """Program.cs derives its namespace from the shared helper (#370).
+
+        The structure, tests, and architecture generators must all
+        agree on the PascalCase root namespace (the C# convention) or
+        the scaffolded xUnit test and the NetArchTest template cannot
+        resolve ``Program``.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="csharp",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["src/Program.cs"].read_text()
+            assert "namespace TestProject" in content
+            assert "namespace test_project" not in content
+
+    def test_csharp_program_main_is_public(self) -> None:
+        """Program.Main is public so the scaffolded xUnit test can call it.
+
+        The generated tests/MainTests.cs invokes ``Program.Main(...)``
+        directly; an implicitly private Main would be a guaranteed
+        compile error in the generated project (#370).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="csharp",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["src/Program.cs"].read_text()
+            assert "public static void Main" in content
+
     def test_ruby_creates_gemfile(self) -> None:
         """Test Ruby generates Gemfile."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/generators/test_tests_generator.py
+++ b/tests/unit/generators/test_tests_generator.py
@@ -413,6 +413,28 @@ class TestMultiLanguageTests:
             content = files["tests/MainTests.cs"].read_text()
             assert "[Fact]" in content
 
+    def test_csharp_test_namespace_nests_under_program_namespace(self) -> None:
+        """The xUnit test namespace derives from the shared helper (#370).
+
+        ``MainTests`` lives in ``<Namespace>.Tests`` so C#'s enclosing-
+        namespace lookup resolves ``Program`` (declared in
+        ``<Namespace>`` by the structure generator) without a using
+        directive — but only when both generators agree on the
+        PascalCase namespace.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="csharp",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["tests/MainTests.cs"].read_text()
+            assert "namespace TestProject.Tests" in content
+            assert "Program.Main(" in content
+
     def test_ruby_test_has_describe_block(self) -> None:
         """Test Ruby spec file has describe block."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1519,6 +1519,23 @@ class TestGenerateSteps:
         assert mock_generator.generate.call_args.kwargs["language"] == "java"
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_csharp(
+        self, mock_generator_class: Mock
+    ) -> None:
+        """Test _generate_architecture_step generates rules for C#."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "csharp")
+
+        # csharp now has architecture parity (#370): the generator runs.
+        mock_generator.generate.assert_called_once()
+        assert mock_generator.generate.call_args.kwargs["language"] == "csharp"
+
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step_skips_unsupported(
         self, mock_generator_class: Mock
     ) -> None:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -332,12 +332,13 @@ class TestSequentialLanguageDetection:
 class TestGeneratorOnlyLanguagePipelineGates:
     """Pipeline steps skip gracefully for generator-only languages (#356).
 
-    csharp/ruby have structure/dependencies/tests/readme generators but
-    no pre-commit/scripts/metrics/architecture support — instead of
+    ruby has structure/dependencies/tests/readme generators but no
+    pre-commit/scripts/metrics/architecture support — instead of
     crashing init, those tooling steps must no-op with an informational
     message. Kotlin graduated from this set when #357 wired its quality
     tooling and #358 wired its CI workflow; java graduated with #367
-    (its CI workflow has been real since #366).
+    (its CI workflow has been real since #366); csharp graduated with
+    #370 (its CI workflow has been real since the foundation scaffold).
     """
 
     def test_precommit_step_writes_for_kotlin(self, tmp_path: Path) -> None:
@@ -527,4 +528,67 @@ class TestJavaPipelineGates:
         cli_mod._generate_architecture_step(tmp_path, "my-project", "java")
 
         template = tmp_path / "plans" / "architecture" / "ArchitectureTest.java"
+        assert template.exists()
+
+
+class TestCsharpPipelineGates:
+    """Pipeline steps all run for csharp after #370.
+
+    The foundation shipped structure/dependencies/tests/readme plus the
+    CI workflow (reference/ci/csharp.yml); #370 wired the pre-commit/
+    scripts/metrics/architecture tooling, so every step must now
+    generate real artifacts.
+    """
+
+    def test_precommit_step_writes_for_csharp(self, tmp_path: Path) -> None:
+        """csharp now generates a pre-commit config (#370)."""
+        cli_mod._generate_precommit_step(tmp_path, "my-project", "csharp")
+
+        config = tmp_path / ".pre-commit-config.yaml"
+        assert config.exists()
+        content = config.read_text()
+        assert "dotnet format" in content
+        assert "roslyn-analyzers" in content
+
+    def test_scripts_step_writes_csharp_scripts(self, tmp_path: Path) -> None:
+        """csharp now receives its own quality scripts (#370)."""
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "csharp")
+
+        test_script = tmp_path / "scripts" / "test.sh"
+        assert test_script.exists()
+        assert "dotnet test" in test_script.read_text()
+
+    def test_scripts_step_writes_analyzer_companions_at_project_root(
+        self, tmp_path: Path
+    ) -> None:
+        """The .editorconfig/CodeMetricsConfig.txt companions land at the root.
+
+        The csproj's AdditionalFiles entry and the Roslyn analyzers
+        resolve these files relative to the project root, not the
+        scripts directory.
+        """
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "csharp")
+
+        assert (tmp_path / ".editorconfig").exists()
+        assert (tmp_path / "CodeMetricsConfig.txt").exists()
+
+    def test_ci_step_writes_csharp_workflow(self, tmp_path: Path) -> None:
+        """The csharp CI workflow is generated (ci.py has a csharp config)."""
+        cli_mod._generate_ci_step(tmp_path, "my-project", "csharp", None)
+
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "C# Quality Checks" in ci_file.read_text()
+
+    def test_metrics_step_writes_csharp_dashboard(self, tmp_path: Path) -> None:
+        """The metrics dashboard is now generated for csharp (#370)."""
+        cli_mod._generate_metrics_dashboard_step(tmp_path, "my-project", "csharp")
+
+        assert (tmp_path / "docs" / "metrics.json").exists()
+
+    def test_architecture_step_writes_csharp_rules(self, tmp_path: Path) -> None:
+        """Architecture rules are now generated for csharp (#370)."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "csharp")
+
+        template = tmp_path / "plans" / "architecture" / "ArchitectureTest.cs"
         assert template.exists()

--- a/tests/unit/utils/test_csharp.py
+++ b/tests/unit/utils/test_csharp.py
@@ -1,0 +1,86 @@
+"""Tests for the C# naming helper and NuGet version pins (#370).
+
+The :func:`csharp_namespace` helper is the single source of truth for
+the PascalCase root namespace shared by the structure, tests,
+dependencies, and architecture generators, so the scaffolded sources,
+the xUnit tests, and the NetArchTest template can never drift apart.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from start_green_stay_green.utils import csharp
+
+
+class TestCsharpNamespace:
+    """Tests for csharp_namespace sanitization rules."""
+
+    @pytest.mark.parametrize(
+        ("package_name", "expected"),
+        [
+            ("wrist_ledger", "WristLedger"),
+            ("test_project", "TestProject"),
+            ("myapp", "Myapp"),
+            ("my-app", "MyApp"),
+            ("My_App", "MyApp"),
+        ],
+    )
+    def test_pascal_case_namespace(self, package_name: str, expected: str) -> None:
+        """Snake/kebab-case package names become PascalCase namespaces."""
+        assert csharp.csharp_namespace(package_name) == expected
+
+    def test_leading_digit_gets_app_prefix(self) -> None:
+        """A namespace cannot start with a digit (C# identifier rules)."""
+        result = csharp.csharp_namespace("2048_game")
+        assert not result[0].isdigit()
+        assert result == "App2048Game"
+
+    def test_empty_input_falls_back_to_app(self) -> None:
+        """A name with no usable characters falls back to ``App``."""
+        assert csharp.csharp_namespace("---") == "App"
+
+    def test_invalid_characters_are_dropped(self) -> None:
+        """Characters invalid in a C# identifier are treated as separators."""
+        result = csharp.csharp_namespace("my.app!name")
+        assert result == "MyAppName"
+
+
+class TestNuGetVersionPins:
+    """The pinned NuGet versions exist and follow SemVer-ish shapes."""
+
+    @pytest.mark.parametrize(
+        "constant",
+        [
+            "XUNIT_VERSION",
+            "XUNIT_RUNNER_VERSION",
+            "TEST_SDK_VERSION",
+            "COVERLET_MSBUILD_VERSION",
+            "NETARCHTEST_RULES_VERSION",
+            "SECURITY_CODE_SCAN_VERSION",
+        ],
+    )
+    def test_pin_is_a_dotted_version_string(self, constant: str) -> None:
+        """Every pin is a non-empty dotted version string."""
+        value = getattr(csharp, constant)
+        assert isinstance(value, str)
+        parts = value.split(".")
+        assert len(parts) >= 2
+        assert all(part.isdigit() for part in parts)
+
+    def test_coverlet_msbuild_pin_matches_net8_line(self) -> None:
+        """coverlet.msbuild stays on the 8.x line that matches net8.0.
+
+        Verified live on nuget.org (2026-06): 8.0.1 is the newest 8.x
+        release; the 10.x line tracks the .NET 10 SDK the scaffold does
+        not target yet.
+        """
+        assert csharp.COVERLET_MSBUILD_VERSION == "8.0.1"
+
+    def test_netarchtest_rules_pin_is_latest_stable(self) -> None:
+        """NetArchTest.Rules pins the latest stable (live-verified)."""
+        assert csharp.NETARCHTEST_RULES_VERSION == "1.3.2"
+
+    def test_security_code_scan_pin_is_latest_stable(self) -> None:
+        """SecurityCodeScan.VS2019 pins the latest stable (live-verified)."""
+        assert csharp.SECURITY_CODE_SCAN_VERSION == "5.6.7"


### PR DESCRIPTION
## Summary

Wires the C# quality toolchain across all four generators — the fifth language to follow the proven shape, closest to the Java precedent (csharp was already registered with scaffold + real CI, like Java was):

- **Minimal foundation glue (the scaffold didn't compile, making any gate vacuous)**: new `utils/csharp.py` with `csharp_namespace()` unifying the raw-snake_case Program.cs namespace with the test's PascalCase one; `Program.Main` made public for the existing scaffolded test. Four surgical `reference/ci/csharp.yml` fixes: SDK matrix drops 7.0 (can't build net8.0), the coverage step stops restating the threshold, the "Run StyleCop" step renamed to what it actually runs, and the Codecov upload made best-effort (the #368 precedent).
- **precommit.py** — `dotnet format --verify-no-changes` (check-mode that actually fails — the #430 formatter lesson applied preemptively) + `dotnet build` Roslyn-lint local hooks with `pass_filenames: false`; config passes `pre-commit validate-config`.
- **scripts.py** — the ≥90% Coverlet bound lives solely in the csproj (manifest-owned, Kover/JaCoCo precedent) and fails the test task directly — no empty-report no-op path. Complexity ≤10 via Roslyn CA1502 with `CodeMetricsConfig.txt` as the bound's single home. `security.sh` gates `dotnet list package --vulnerable` on the report line (its exit code is unreliable — dotnet/sdk#25091) with warn-and-skip offline. All scripts pass **bash -n and shellcheck**, test-pinned.
- **metrics.py** — Coverlet / Stryker.NET (periodic) / CA1502 / DocFX / SecurityCodeScan / vulnerable-listing, each in exactly one category.
- **architecture.py** — **NetArchTest** `ArchitectureTest.cs` (xUnit, layers from `csharp_namespace`); flat copy into `tests/` is correct since C# namespaces need no directory match (the Java lesson, inverted and noted); limits documented including that the C# compiler does not reject namespace cycles.
- **dependencies.py** — coverlet.msbuild 8.0.1, NetArchTest.Rules 1.3.2, SecurityCodeScan 5.6.7 — all live-verified on nuget.org.

## Test plan

- TDD: **93 new test functions** including a 34-test `test_csharp_init_integration.py` (java-suite shape), shellcheck/bash-n pins, and parse-validation throughout.
- `./scripts/check-all.sh`: all 7 checks pass — **2,544 tests**, coverage **95.02%** (≥90% gate). e2e across all 9 languages green.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#371 (tests/deeper CI hardening) and #372 (docs) remain.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
