### PR TITLE
test(csharp): fill cross-language matrix gaps and pin the reference scripts (#371)

### DIFF
--- a/reference/scripts/csharp/lint.sh
+++ b/reference/scripts/csharp/lint.sh
@@ -3,4 +3,10 @@ set -euo pipefail
 echo "=== Running C# Linters ==="
 echo "Running dotnet format..."
 dotnet format --verify-no-changes
+# All Roslyn analysis (CA rules, the CA1502 complexity ceiling,
+# SecurityCodeScan) runs inside the compiler with warnings as errors
+# per the csproj, so the build IS the analyzer gate — without it the
+# lint script could never see an analyzer finding.
+echo "Running Roslyn analyzers (dotnet build)..."
+dotnet build --nologo
 echo "✓ All linters passed!"

--- a/reference/scripts/csharp/test.sh
+++ b/reference/scripts/csharp/test.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "=== Running C# Tests ==="
-dotnet test /p:CollectCoverage=true /p:Threshold=90 /p:ThresholdType=line
+# /p:CollectCoverage=true activates the Coverlet gate; the >=90% line
+# bound lives in the csproj (Threshold/ThresholdType/ThresholdStat —
+# its single home), so this invocation enforces it without restating
+# the number.
+dotnet test /p:CollectCoverage=true
 echo "✓ Tests passed with required coverage!"

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -1638,6 +1638,10 @@ _LANG_SETUP_STEPS: dict[str, list[str]] = {
     # Android Wear scaffold; the watch APK needs Android tooling
     # (Android Studio / Gradle), which init cannot install (#366).
     "java": ["mvn test"],
+    # `dotnet test` restores, builds (Roslyn analyzers as errors), and
+    # runs the xUnit suite in one invocation — the csproj owns the whole
+    # quality policy (#370), so the single command verifies the scaffold.
+    "csharp": ["dotnet test"],
 }
 
 

--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -101,6 +101,7 @@ class TestPreCommitGeneratorIntegration:
             "kotlin",
             "cpp",
             "java",
+            "csharp",
         ]
 
         for language in languages:

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -2277,3 +2277,151 @@ class TestJavaReferenceTemplate:
         run_commands = _all_run_commands(parsed)
         assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
         assert not any("GITHUB_PATH" in cmd for cmd in run_commands)
+
+
+class TestCsharpReferenceTemplate:
+    """Tests for the C# reference CI workflow (#370/#371).
+
+    The csharp scaffold is a single-project net8.0 console app whose
+    csproj is the single home of the quality policy: Roslyn analyzers
+    as errors, the Coverlet >=90% line-coverage bound, and the CA1502
+    complexity ceiling. Every assertion here checks that the workflow
+    runs thin dotnet invocations against that policy and restates none
+    of it — the same manifest-owned shape the Kotlin/Java workflows
+    follow.
+    """
+
+    @pytest.fixture
+    def csharp_workflow(self) -> CIWorkflow:
+        """Render the deterministic C# reference workflow."""
+        return CIGenerator(language="csharp").generate_workflow_from_template()
+
+    def test_workflow_is_valid_yaml(self, csharp_workflow: CIWorkflow) -> None:
+        """Rendered workflow parses with yaml.safe_load and validates."""
+        parsed = yaml.safe_load(csharp_workflow.content)
+        assert csharp_workflow.is_valid
+        assert isinstance(parsed, dict)
+        assert parsed["name"] == "C# Quality Checks"
+
+    def test_workflow_has_quality_and_build_jobs(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """Workflow declares exactly the quality and build jobs."""
+        parsed = yaml.safe_load(csharp_workflow.content)
+        assert set(parsed["jobs"]) == {"quality", "build"}
+
+    def test_all_jobs_run_on_ubuntu(self, csharp_workflow: CIWorkflow) -> None:
+        """Every job runs on ubuntu: the .NET SDK needs no macOS."""
+        parsed = yaml.safe_load(csharp_workflow.content)
+        for name, job in parsed["jobs"].items():
+            assert job["runs-on"] == "ubuntu-latest", f"{name} must run on ubuntu"
+
+    def test_sdk_matrix_pins_the_line_that_builds_net8(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """The quality job matrixes over exactly the 8.0 SDK line.
+
+        The generated csproj targets net8.0, which older SDKs cannot
+        build (the 7.0 matrix entry was dropped for that reason); the
+        matrix extends together with the TargetFramework.
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        matrix = parsed["jobs"]["quality"]["strategy"]["matrix"]
+        assert matrix["dotnet-version"] == ["8.0"]
+
+    def test_setup_actions_are_pinned_to_majors(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """checkout and setup-dotnet are pinned to major versions."""
+        content = csharp_workflow.content
+        assert "actions/checkout@v4" in content
+        assert "actions/setup-dotnet@v4" in content
+
+    def test_quality_job_runs_every_csproj_backed_gate(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """CI runs the restore/build/format/test gates the csproj backs.
+
+        The plain build doubles as the lint gate (the csproj treats
+        analyzer warnings as errors), and the coverage-collecting test
+        run reuses its output via --no-build so the suite executes
+        exactly once (the Swift no-double-test-run lesson).
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        quality_commands = [
+            cmd.strip()
+            for step in parsed["jobs"]["quality"]["steps"]
+            if (cmd := step.get("run"))
+        ]
+        assert "dotnet restore" in quality_commands
+        assert "dotnet build --no-restore" in quality_commands
+        assert "dotnet format --verify-no-changes" in quality_commands
+        test_runs = [c for c in quality_commands if c.startswith("dotnet test")]
+        assert len(test_runs) == 1
+        assert "--no-build" in test_runs[0]
+        assert "/p:CollectCoverage=true" in test_runs[0]
+
+    def test_coverage_step_defers_the_bound_to_the_csproj(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """No run command restates the Coverlet coverage threshold.
+
+        The >=90% bound lives in the csproj
+        (Threshold/ThresholdType/ThresholdStat — its single home);
+        /p:CollectCoverage=true activates the gate without duplicating
+        the number, so the workflow cannot drift from the manifest.
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("Threshold" in cmd for cmd in run_commands)
+
+    def test_codecov_upload_cannot_fail_ci(self, csharp_workflow: CIWorkflow) -> None:
+        """The tokenless Codecov upload is best-effort, never a gate.
+
+        A fresh project has no CODECOV_TOKEN secret, so a failing
+        upload must not start the project red; the enforced coverage
+        gate is the csproj-backed Coverlet run in the test step.
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert len(codecov_steps) == 1
+        assert codecov_steps[0]["with"]["fail_ci_if_error"] is False
+
+    def test_build_job_packages_without_rerunning_tests(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """The build job publishes the app; the suite ran once in quality.
+
+        The Release build feeds dotnet publish via --no-build, and no
+        dotnet test invocation appears — the single coverage-gated test
+        execution lives in the quality job.
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        build_commands = [
+            step.get("run", "") for step in parsed["jobs"]["build"]["steps"]
+        ]
+        publish_runs = [c for c in build_commands if "dotnet publish" in c]
+        assert len(publish_runs) == 1
+        assert "--no-build" in publish_runs[0]
+        assert not any("dotnet test" in c for c in build_commands)
+
+    def test_workflow_writes_nothing_to_github_env(
+        self, csharp_workflow: CIWorkflow
+    ) -> None:
+        """Nothing discovered at runtime is exported to GITHUB_ENV.
+
+        The Swift PR #414 review flagged unvalidated GITHUB_ENV writes
+        as the documented Actions env-injection vector; like the
+        Kotlin, cpp, and java workflows, every value here is a static
+        literal, so there is no dynamic discovery and no
+        GITHUB_ENV/GITHUB_PATH write to guard.
+        """
+        parsed = yaml.safe_load(csharp_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
+        assert not any("GITHUB_PATH" in cmd for cmd in run_commands)

--- a/tests/unit/reference/test_reference_assets.py
+++ b/tests/unit/reference/test_reference_assets.py
@@ -96,9 +96,7 @@ class TestScriptsReferences:
             assert script_path.is_file()
             assert script_path.stat().st_size > 0, f"Empty Python script: {script}"
 
-    def test_java_lint_script_compiles_before_spotbugs(
-        self, scripts_dir: Path
-    ) -> None:
+    def test_java_lint_script_compiles_before_spotbugs(self, scripts_dir: Path) -> None:
         """The java reference lint script's SpotBugs run is no no-op (#368).
 
         SpotBugs reads bytecode: a bare ``mvn spotbugs:check`` silently
@@ -116,6 +114,45 @@ class TestScriptsReferences:
         for command in commands:
             assert "compile" in command
             assert command.index("compile") < command.index("spotbugs:check")
+
+    def test_csharp_lint_script_runs_the_roslyn_analyzers(
+        self, scripts_dir: Path
+    ) -> None:
+        """The csharp reference lint script is more than a format check (#371).
+
+        All Roslyn analysis (CA rules, the CA1502 complexity ceiling,
+        SecurityCodeScan) runs inside the compiler, so without a
+        ``dotnet build`` the lint gate could never see an analyzer
+        finding — parity with the generated scripts/lint.sh and
+        reference/ci/csharp.yml, where the build IS the lint gate.
+        """
+        content = (scripts_dir / "csharp" / "lint.sh").read_text()
+        commands = [
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        ]
+        assert any("dotnet format --verify-no-changes" in c for c in commands)
+        assert any("dotnet build" in c for c in commands)
+
+    def test_csharp_test_script_defers_the_coverage_bound_to_the_csproj(
+        self, scripts_dir: Path
+    ) -> None:
+        """The csharp reference test script never restates the threshold (#371).
+
+        The >=90% Coverlet bound lives in the generated csproj
+        (Threshold/ThresholdType/ThresholdStat — its single home);
+        ``/p:CollectCoverage=true`` activates the gate without
+        duplicating the number, matching reference/ci/csharp.yml and
+        the generated scripts/test.sh.
+        """
+        content = (scripts_dir / "csharp" / "test.sh").read_text()
+        commands = [
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        ]
+        test_runs = [c for c in commands if "dotnet test" in c]
+        assert test_runs, "test.sh must run dotnet test"
+        for command in test_runs:
+            assert "/p:CollectCoverage=true" in command
+            assert "Threshold" not in command
 
 
 class TestSkillsReferences:

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -9,7 +9,8 @@ from start_green_stay_green.cli import _venv_activation_command
 
 # Languages exercised by the per-language common-tail tests. The
 # unknown-language default path is covered separately with "ruby"
-# (java gained its own Maven step with #366).
+# (java gained its own Maven step with #366, csharp its dotnet step
+# with #371).
 ALL_LANGUAGES = (
     "python",
     "typescript",
@@ -19,6 +20,7 @@ ALL_LANGUAGES = (
     "kotlin",
     "cpp",
     "java",
+    "csharp",
 )
 
 
@@ -220,6 +222,20 @@ class TestGetSetupInstructions:
         instructions = _get_setup_instructions(("java",), Path("/home/user/wear-proj"))
         assert "mvn test" in instructions
         assert not any("gradle" in c for c in instructions)
+
+    def test_csharp_runs_the_dotnet_test_suite(self) -> None:
+        """csharp setup verifies the scaffold with one dotnet test run (#370).
+
+        ``dotnet test`` implicitly restores and builds with the csproj's
+        Roslyn analyzers as errors, so no separate restore/build steps
+        appear — the csproj is the single home of the quality policy.
+        """
+        instructions = _get_setup_instructions(
+            ("csharp",), Path("/home/user/dotnet-proj")
+        )
+        assert "dotnet test" in instructions
+        assert not any("dotnet restore" in c for c in instructions)
+        assert not any("dotnet build" in c for c in instructions)
 
     def test_unknown_language_has_sensible_default(self) -> None:
         """Unknown languages should still get pre-commit + check-all."""

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -162,7 +162,7 @@ class TestMultiLanguageGeneration:
 
 class TestMultiLanguageArchitectureParity:
     """Go (#341), Rust (#342), Swift (#352), Kotlin (#357), cpp (#362),
-    java (#367)."""
+    java (#367), csharp (#370)."""
 
     def test_go_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
         """Go must emit an architecture-enforcement config like py/ts."""
@@ -206,9 +206,26 @@ class TestMultiLanguageArchitectureParity:
         config = tmp_path / "plans" / "architecture" / "ArchitectureTest.java"
         assert config.exists(), "java init must emit the ArchUnit test template"
 
+    def test_csharp_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
+        """csharp must emit an architecture-enforcement config like py/ts/go."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "csharp")
+
+        config = tmp_path / "plans" / "architecture" / "ArchitectureTest.cs"
+        assert config.exists(), "csharp init must emit the NetArchTest template"
+
     @pytest.mark.parametrize(
         "language",
-        ["python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java"],
+        [
+            "python",
+            "typescript",
+            "go",
+            "rust",
+            "swift",
+            "kotlin",
+            "cpp",
+            "java",
+            "csharp",
+        ],
     )
     def test_supported_languages_emit_architecture_config(
         self, tmp_path: Path, language: str


### PR DESCRIPTION
## Summary

Survey-first execution (fifth of its kind): #370 already delivered the integration suite, pipeline-gate tests, e2e matrices with the self-consistent file set, and the conftest mapping. The genuine gaps, all filled:

- **`_LANG_SETUP_STEPS["csharp"]`** — csharp setup instructions previously fell into the unknown-language default path; now `["dotnet test"]` (the java `mvn test` precedent), pinned via `ALL_LANGUAGES` + a dedicated test.
- **Matrices** — csharp in the architecture-parity parametrize (+ `test_csharp_exercises_architecture_enforcement`), the precommit multi-language workflow list.
- **`TestCsharpReferenceTemplate`** (10 tests, the established per-language CI-template suite): net8.0-only matrix, csproj-backed gates, single test run, no threshold restatement, best-effort Codecov, no GITHUB_ENV writes.
- **Reference-script corrections (test-pinned, the #368/#431 class)**: `reference/scripts/csharp/lint.sh` gains the Roslyn analyzer gate (`dotnet build`) — format-only linting could never see an analyzer finding, the spotbugs-on-empty-classes class of bug — and `test.sh` drops the inline threshold restatement (the csproj is the bound's single home, the same fix #370 made to the workflow).

## Mutation testing (honest status)

Re-verified: mutmut 3.6.0 still crashes on the repo's 2.x-style config. Known tracked gap; no score claimed.

## Test plan

- `./scripts/check-all.sh`: all 7 checks pass — **2,561 tests**, coverage **95.02%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
