### PR TITLE
feat(ruby): wire quality tooling across precommit/scripts/metrics/architecture (#373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Start Green Stay Green is a meta-tool that scaffolds new software projects with 
 
 - **Enterprise-Grade Quality**: 90%+ code coverage, mutation testing, comprehensive linting
 - **AI Integration**: Pre-configured AI subagent profiles and code review workflows
-- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), C/C++ (Tizen), Java (Wear OS legacy), and C# (.NET)
-- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), an include-boundary checker (C/C++), ArchUnit (Java), and NetArchTest (C#)
+- **Multi-Language Support**: Python, TypeScript, Go, Rust, Swift (watchOS), Kotlin (Wear OS), C/C++ (Tizen), Java (Wear OS legacy), C# (.NET), and Ruby
+- **Architecture Enforcement**: import-linter (Python), dependency-cruiser (TypeScript), go-arch-lint (Go), cargo-deny (Rust), SwiftLint custom rules (Swift), Konsist (Kotlin), an include-boundary checker (C/C++), ArchUnit (Java), NetArchTest (C#), and Packwerk (Ruby)
 - **Complete CI/CD**: GitHub Actions workflows with quality gates
 - **Additive Init**: Safe to re-run in existing directories — preserves your files
 - **Developer Experience**: Rich console output, interactive prompts, dry-run mode

--- a/docs/GENERATOR_GUIDE.md
+++ b/docs/GENERATOR_GUIDE.md
@@ -83,7 +83,7 @@ output_path.write_text(yaml_content)
 
 **Configuration Options**:
 - `project_name`: Name of the project
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, or csharp
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp, ruby, or ruby
 - `language_config`: Language-specific settings (dict)
 
 **Output**: `.pre-commit-config.yaml` with hooks for:
@@ -138,7 +138,7 @@ scripts = generator.generate()
 - `complexity.sh` - Code complexity analysis
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp, ruby
 - `package_name`: Python package name (snake_case)
 
 ### CIGenerator (AI-powered)
@@ -178,7 +178,7 @@ workflows_dir.mkdir(parents=True, exist_ok=True)
 - Documentation validation
 
 **Configuration Options**:
-- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp
+- `language`: python, typescript, go, rust, swift, kotlin, cpp, java, csharp, ruby
 
 ### SkillsGenerator
 
@@ -377,6 +377,7 @@ generator.generate(language="python", project_name="my-app")
 - C/C++: include-boundary checker (stdlib Python script)
 - Java: ArchUnit architecture test
 - C#: NetArchTest architecture test
+- Ruby: Packwerk package configuration (packwerk.yml + package.yml)
 
 ### GitHubActionsReviewGenerator (AI-powered)
 

--- a/reference/ci/ruby.yml
+++ b/reference/ci/ruby.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.1", "3.2", "3.3"]
+        # The Ruby lines still receiving upstream maintenance (3.1/3.2
+        # reached EOL); bump together with the generated .rubocop.yml's
+        # TargetRubyVersion.
+        ruby-version: ["3.3", "3.4"]
 
     steps:
       - name: Checkout code
@@ -26,50 +29,43 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          # bundler-cache runs `bundle install` and caches the gems —
+          # no separate install step needed.
           bundler-cache: true
 
-      - name: Install dependencies
-        run: bundle install
-
+      # The full cop set: format (Layout), lint (Lint/Style), the
+      # Metrics/CyclomaticComplexity <=10 ceiling, and the Security cop
+      # department. .rubocop.yml is the single home of the policy —
+      # the same file the pre-commit hook and scripts/lint.sh read —
+      # so this invocation restates none of it.
       - name: Run RuboCop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --force-exclusion
 
-      - name: Run Reek
-        run: bundle exec reek
+      # Dependency CVE scan against the ruby-advisory-db. CI runners
+      # have network access, so the update is a hard gate here (the
+      # generated scripts/security.sh warn-and-skips offline instead).
+      # Brakeman is deliberately absent: it is Rails-specific and
+      # errors on plain-Ruby projects — add it alongside Rails.
+      - name: Run bundler-audit security check
+        run: bundle exec bundler-audit update && bundle exec bundler-audit check
 
-      - name: Run Brakeman security check
-        run: bundle exec brakeman --no-pager
+      # COVERAGE=true activates the SimpleCov gate; the >=90% line
+      # bound lives in spec/spec_helper.rb — its single home — so this
+      # invocation enforces it without restating the number. SimpleCov
+      # fails the rspec run directly when the bound is missed.
+      - name: Run RSpec with SimpleCov (>=90% gate in spec_helper.rb)
+        run: COVERAGE=true bundle exec rspec --format documentation
 
-      - name: Run RSpec with SimpleCov
-        run: |
-          bundle exec rspec --format documentation
-
+      # Best-effort: a fresh `green init` project ships no
+      # CODECOV_TOKEN secret, so a failing upload must not start the
+      # project red; the real coverage gate is the SimpleCov run above.
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         with:
-          file: ./coverage/.resultset.json
-          fail_ci_if_error: true
+          files: ./coverage/.resultset.json
+          fail_ci_if_error: false
 
-      - name: Check coverage threshold
-        run: |
-          bundle exec rspec --format progress --require simplecov --minimum-coverage 90
-
-  build:
-    name: Build and Install Gem
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-
-      - name: Build gem
-        run: gem build *.gemspec
-
-      - name: Install gem
-        run: gem install ./*.gem
+  # No packaging job: the generated scaffold is a plain-Ruby project
+  # without a .gemspec, so a `gem build` job would be red on every
+  # push. Add a packaging job together with the gemspec when the
+  # project becomes a gem.

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -944,10 +944,23 @@ def _scripts_dir_has_other_language(scripts_dir: Path, language: str) -> bool:
 
 # Languages with native quality-script templates in ScriptsGenerator.
 # The generator falls back to *Python* scripts for anything else, which
-# would be wrong for e.g. a Ruby project, so the init pipeline skips
-# the step instead.
+# would be wrong for e.g. a PHP project, so the init pipeline skips
+# the step instead. Every base.SUPPORTED_LANGUAGES entry now has native
+# templates (ruby joined with #373); the gate remains for typo'd or
+# future languages.
 _SCRIPTS_STEP_LANGUAGES: frozenset[str] = frozenset(
-    {"python", "typescript", "go", "rust", "swift", "kotlin", "cpp", "java", "csharp"}
+    {
+        "python",
+        "typescript",
+        "go",
+        "rust",
+        "swift",
+        "kotlin",
+        "cpp",
+        "java",
+        "csharp",
+        "ruby",
+    }
 )
 
 
@@ -962,9 +975,9 @@ def _generate_scripts_step(
 
     If scripts/ already contains scripts from a different language,
     automatically uses scripts/{language}/ subdirectory to avoid conflicts.
-    Languages without native script templates (ruby)
-    are skipped with an informational message instead of receiving the
-    generator's Python fallback.
+    Languages without native script templates (none of the supported
+    set since ruby joined with #373) are skipped with an informational
+    message instead of receiving the generator's Python fallback.
 
     Args:
         project_path: Project root directory.
@@ -1010,9 +1023,9 @@ def _generate_precommit_step(
 ) -> None:
     """Generate pre-commit configuration, merging with existing if present.
 
-    Languages PreCommitGenerator does not support yet (ruby)
-    are skipped with an informational message instead of aborting the
-    whole init run.
+    Languages PreCommitGenerator does not support yet (none of the
+    supported set since ruby joined with #373) are skipped with an
+    informational message instead of aborting the whole init run.
     """
     if language not in PRECOMMIT_LANGUAGE_CONFIGS:
         console.print(
@@ -1257,11 +1270,11 @@ def _generate_architecture_step(
     Python, dependency-cruiser for TypeScript, go-arch-lint for Go,
     cargo-deny for Rust, SwiftLint custom rules for Swift, a Konsist test
     for Kotlin, an include-boundary checker for C/C++, an ArchUnit test
-    for Java, a NetArchTest test for C#). Runs regardless of API key
-    availability; only Python, TypeScript, Go, Rust, Swift, Kotlin,
-    C/C++, Java, and C# projects produce output. The previous
-    ``orchestrator`` argument was unused and has been removed from this
-    private helper.
+    for Java, a NetArchTest test for C#, a Packwerk package config for
+    Ruby). Runs regardless of API key availability; only Python,
+    TypeScript, Go, Rust, Swift, Kotlin, C/C++, Java, C#, and Ruby
+    projects produce output. The previous ``orchestrator`` argument was
+    unused and has been removed from this private helper.
     """
     supported = {
         "python",
@@ -1273,11 +1286,12 @@ def _generate_architecture_step(
         "cpp",
         "java",
         "csharp",
+        "ruby",
     }
     if language not in supported:
         # The generator only supports these languages; surface a dim info
         # line so users understand why no architecture rules were generated
-        # for, e.g., a Ruby project rather than seeing silence.
+        # for, e.g., a PHP project rather than seeing silence.
         console.print(
             f"[dim]Architecture rules unavailable for {language} "
             f"(supported: {', '.join(sorted(supported))})[/dim]"
@@ -1436,9 +1450,10 @@ def _generate_metrics_dashboard_step(
 ) -> None:
     """Generate live metrics dashboard and workflow.
 
-    Languages MetricsGenerator does not support yet (ruby)
-    are skipped with an informational message instead of aborting init
-    when ``--enable-live-dashboard`` is passed.
+    Languages MetricsGenerator does not support yet (none of the
+    supported set since ruby joined with #373) are skipped with an
+    informational message instead of aborting init when
+    ``--enable-live-dashboard`` is passed.
     """
     if language not in METRICS_LANGUAGE_TOOLS:
         console.print(
@@ -1642,6 +1657,12 @@ _LANG_SETUP_STEPS: dict[str, list[str]] = {
     # runs the xUnit suite in one invocation — the csproj owns the whole
     # quality policy (#370), so the single command verifies the scaffold.
     "csharp": ["dotnet test"],
+    # bundle install provisions the pinned quality gems (rspec,
+    # rubocop, simplecov, bundler-audit, packwerk) and `bundle exec
+    # rspec` verifies the scaffold (#373) — the csharp #371 lesson:
+    # never leave a supported language on the unknown-language default
+    # path.
+    "ruby": ["bundle install", "bundle exec rspec"],
 }
 
 

--- a/start_green_stay_green/generators/architecture.py
+++ b/start_green_stay_green/generators/architecture.py
@@ -32,7 +32,7 @@ class ArchitectureResult:
         output_dir: Directory containing generated files.
         files_created: List of files created.
         language: Target language (python, typescript, go, rust, swift,
-            kotlin, cpp, java, csharp).
+            kotlin, cpp, java, csharp, ruby).
     """
 
     output_dir: Path
@@ -193,6 +193,28 @@ _LANGUAGE_TOOLING: dict[str, _LanguageTooling] = {
         docs_url="https://github.com/BenMorris/NetArchTest",
         display_name="C#",
     ),
+    "ruby": _LanguageTooling(
+        # Packwerk (the issue's choice; Shopify's boundary enforcer)
+        # reads packwerk.yml from the working directory — no config
+        # flag exists, so run_cmd carries no {config_file} placeholder
+        # and the one-time wiring (copy packwerk.yml + the root
+        # package.yml to the project root) lives in install_cmd, the
+        # Konsist/ArchUnit/NetArchTest parked-template precedent. The
+        # packwerk gem is already pinned in the generated Gemfile. The
+        # generated configs document the enforcement limits explicitly:
+        # Packwerk targets Zeitwerk-style autoloaded codebases, so on
+        # this plain-Ruby scaffold the check stays vacuous until
+        # packages (and Zeitwerk-conventional paths) are defined.
+        tool="Packwerk",
+        config_file="packwerk.yml",
+        install_cmd=(
+            "cp plans/architecture/packwerk.yml "
+            "plans/architecture/package.yml . && bundle install"
+        ),
+        run_cmd="bundle exec packwerk check",
+        docs_url="https://github.com/Shopify/packwerk",
+        display_name="Ruby",
+    ),
 }
 
 
@@ -203,8 +225,9 @@ class ArchitectureEnforcementGenerator:
     config for TypeScript, go-arch-lint config for Go, cargo-deny
     config for Rust, SwiftLint custom rules for Swift, a Konsist
     test for Kotlin, a runnable include-boundary checker for C/C++,
-    an ArchUnit test for Java, and a NetArchTest test for C# to
-    enforce layer separation and prevent circular dependencies.
+    an ArchUnit test for Java, a NetArchTest test for C#, and a
+    Packwerk package configuration for Ruby to enforce layer
+    separation and prevent circular dependencies.
 
     Attributes:
         orchestrator: AI orchestrator for content generation.
@@ -252,7 +275,7 @@ class ArchitectureEnforcementGenerator:
 
         Args:
             language: Target language (python, typescript, go, rust,
-                swift, kotlin, cpp, java, csharp).
+                swift, kotlin, cpp, java, csharp, ruby).
             project_name: Name of the project.
 
         Returns:
@@ -281,6 +304,7 @@ class ArchitectureEnforcementGenerator:
             "cpp": self._generate_cpp_config,
             "java": partial(self._generate_java_config, project_name),
             "csharp": partial(self._generate_csharp_config, project_name),
+            "ruby": partial(self._generate_ruby_config, project_name),
         }
         files_created = config_builders[language]()
 
@@ -1224,6 +1248,123 @@ namespace {namespace}.Architecture
         config_path.write_text(config_content)
         return [config_path]
 
+    def _generate_ruby_config(self, project_name: str) -> list[Path]:
+        """Generate the Packwerk package configuration for Ruby.
+
+        Packwerk (the issue's choice; Shopify's boundary enforcer)
+        expresses architecture rules as packages: ``packwerk.yml``
+        configures the tool and each ``package.yml`` declares a
+        package and the packages it may depend on. Both files are
+        parked templates in ``plans/architecture`` (the Konsist/
+        ArchUnit/NetArchTest precedent): they only enforce once copied
+        to the project root (the ``packwerk`` gem is already pinned in
+        the generated Gemfile).
+
+        The configs document their enforcement limits explicitly and
+        honestly: Packwerk performs static constant-reference analysis
+        and assumes Zeitwerk-style autoload paths to resolve constants
+        — it is built for Rails/Zeitwerk codebases, and on this
+        plain-Ruby scaffold (a single flat ``lib/``) the dependency
+        check passes vacuously until packages are defined and the code
+        follows Zeitwerk conventions (a tighten-me note, the
+        ``withOptionalLayers(true)`` analogue). They also note WHY a
+        boundary tool matters in Ruby: unlike a compiler, Ruby's
+        ``require`` does NOT reject circular requires at load time — a
+        require cycle silently yields a partially-defined module at
+        runtime — so static boundary enforcement is the only early
+        signal.
+
+        Args:
+            project_name: Name of the project (used in the generated
+                file headers).
+
+        Returns:
+            List of files created.
+        """
+        packwerk_path = self.output_dir / "packwerk.yml"
+        packwerk_content = f"""\
+# Packwerk configuration for {project_name}.
+#
+# Generated by Start Green Stay Green (#373). This file and the root
+# package.yml beside it are parked templates: copy BOTH to the project
+# root to activate enforcement (plans/architecture/run-check.sh
+# documents the same wiring):
+#
+#   cp plans/architecture/packwerk.yml plans/architecture/package.yml .
+#   bundle install        # packwerk is already pinned in the Gemfile
+#   bundle exec packwerk check
+#
+# ENFORCEMENT LIMITS — read before relying on the gate:
+#
+# - Packwerk performs STATIC constant-reference analysis. Constants
+#   reached via metaprogramming (const_get, send, method_missing) are
+#   invisible to it.
+# - Packwerk is built for Zeitwerk-style autoloaded codebases (Rails
+#   apps get this for free). Constant resolution assumes
+#   Zeitwerk-conventional file paths; on this plain-Ruby scaffold (a
+#   single flat lib/ with explicit requires) the check passes
+#   VACUOUSLY until packages are defined and the load paths follow
+#   Zeitwerk conventions. Tighten as the codebase grows: split lib/
+#   into package directories, give each its own package.yml with an
+#   explicit dependencies list, and adopt Zeitwerk
+#   (https://github.com/fxn/zeitwerk) for autoloading.
+# - WHY a boundary tool at all: unlike a compiler, Ruby's require does
+#   NOT reject circular requires at load time — a require cycle
+#   silently yields a partially-defined module at runtime (constants
+#   missing until the cycle unwinds). Packwerk's acyclic package graph
+#   (validated by `bundle exec packwerk validate`) is the only EARLY
+#   signal; Ruby itself will not give a load-time error.
+
+# Patterns for folder paths to include in the analysis.
+include:
+  - "**/*.{{rb,rake,erb}}"
+
+# Patterns for folder paths to exclude.
+exclude:
+  - "{{bin,node_modules,script,tmp,vendor}}/**/*"
+
+# Where to find package configuration files (each package.yml defines
+# one package; the root package.yml makes the whole app one package
+# until you split it).
+package_paths: "**/"
+
+# Fork parsing out to subprocesses for speed.
+parallel: true
+"""
+        packwerk_path.write_text(packwerk_content)
+
+        package_path = self.output_dir / "package.yml"
+        package_content = f"""\
+# Root package definition for {project_name} (Packwerk).
+#
+# Generated by Start Green Stay Green (#373). Copy to the project root
+# together with packwerk.yml (see that file for the full wiring and
+# enforcement-limit notes).
+#
+# This declares the whole application as ONE package with dependency
+# enforcement switched on. With a single package there are no
+# boundaries to violate yet — the gate is vacuous by construction.
+# Tighten it by adding a package.yml to each component directory, e.g.:
+#
+#   # lib/billing/package.yml
+#   enforce_dependencies: true
+#   dependencies:
+#     - lib/accounts
+#
+# After that, any constant reference that crosses a package boundary
+# without a declared dependency fails `bundle exec packwerk check`,
+# and `bundle exec packwerk validate` rejects cycles in the declared
+# dependency graph (presentation -> application -> domain layering is
+# expressed by listing only lower layers as dependencies).
+enforce_dependencies: true
+
+# Packages this package may depend on (none: it is the root).
+dependencies: []
+"""
+        package_path.write_text(package_content)
+
+        return [packwerk_path, package_path]
+
     def _generate_readme(self, language: str, project_name: str) -> Path:
         """Generate README with usage instructions.
 
@@ -1313,6 +1454,7 @@ Edit the configuration file:
 - C/C++: `check_architecture.py` (the ALLOWED_DEPENDENCIES matrix at the top)
 - Java: `ArchitectureTest.java` (the layered-architecture rules in the test)
 - C#: `ArchitectureTest.cs` (the NetArchTest rules in the test)
+- Ruby: `packwerk.yml` / `package.yml` (the Packwerk package boundaries)
 
 See documentation:
 - Python: https://import-linter.readthedocs.io/
@@ -1324,6 +1466,7 @@ See documentation:
 - C/C++: the header comment in check_architecture.py (self-documented)
 - Java: https://www.archunit.org/
 - C#: https://github.com/BenMorris/NetArchTest
+- Ruby: https://github.com/Shopify/packwerk
 
 ## Integration
 

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -157,8 +157,15 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         "test_framework": "rspec",
         "linters": ["rubocop"],
         "formatters": ["rubocop"],
-        "security_tools": ["brakeman"],
-        "supported_versions": ["3.1", "3.2"],
+        # bundler-audit owns dependency CVE scanning (#373); Brakeman is
+        # Rails-specific and errors on the plain-Ruby scaffold, so it is
+        # documented (scripts/security.sh) rather than wired.
+        "security_tools": ["bundler-audit"],
+        # The Ruby lines still receiving upstream maintenance (3.1/3.2
+        # reached EOL; verified against ruby-lang.org's branch table).
+        # Bump together with reference/ci/ruby.yml's matrix and the
+        # generated .rubocop.yml TargetRubyVersion.
+        "supported_versions": ["3.3", "3.4"],
         "package_manager": "bundler",
     },
 }

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -44,6 +44,7 @@ from start_green_stay_green.utils.kotlin import KONSIST_VERSION
 from start_green_stay_green.utils.kotlin import KOTLIN_VERSION
 from start_green_stay_green.utils.kotlin import KOVER_VERSION
 from start_green_stay_green.utils.kotlin import WEAR_COMPOSE_VERSION
+from start_green_stay_green.utils.ruby import ruby_gemfile
 from start_green_stay_green.utils.swift import package_swift
 
 if TYPE_CHECKING:
@@ -89,12 +90,10 @@ class DependenciesGenerator(BaseGenerator):
     target project's language and tooling.
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
-    ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
-    pipeline.
+    ruby, swift, kotlin, cpp) are available at the generator level, and all
+    of them run the full CLI pipeline (``sgsg init``): Kotlin graduated
+    with #357/#358, C/C++ with #362/#363, Java with #366/#367, C# with
+    #370, and Ruby with #373.
 
     Attributes:
         output_dir: Directory where dependency files will be written
@@ -904,22 +903,16 @@ Version="{SECURITY_CODE_SCAN_VERSION}">
     def _ruby_gemfile(self) -> str:
         """Generate Ruby Gemfile content.
 
+        Delegates to the shared
+        :func:`~start_green_stay_green.utils.ruby.ruby_gemfile` helper
+        so the structure and dependencies generators emit an identical
+        manifest from one source of truth (#373) — before #373 the two
+        emitted diverging Gemfiles with stale, unpinned tool lines.
+
         Returns:
             Content for Gemfile with gem dependencies
         """
-        return """# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-# Specify your gem's dependencies in gemspec if building a gem
-# gemspec
-
-group :development, :test do
-  gem "rspec", "~> 3.12"
-  gem "rubocop", "~> 1.57"
-  gem "simplecov", "~> 0.22"
-end
-"""
+        return ruby_gemfile()
 
     def _generate_swift_dependencies(self) -> dict[str, Path]:
         """Generate Swift dependency files.

--- a/start_green_stay_green/generators/metrics.py
+++ b/start_green_stay_green/generators/metrics.py
@@ -529,6 +529,27 @@ LANGUAGE_TOOLS: dict[str, dict[str, str]] = {
         "security": "SecurityCodeScan (Roslyn analyzer)",
         "dependency_check": "dotnet list package --vulnerable",
     },
+    # Ruby (#373): coverage is SimpleCov, activated by COVERAGE=true
+    # with the >=90% bound living in spec/spec_helper.rb (the
+    # manifest-owned precedent of the JaCoCo/Kover/Coverlet gates).
+    # RuboCop's Metrics/CyclomaticComplexity cop owns the <=10
+    # complexity gate (.rubocop.yml is its single home; flog is the
+    # documented standalone alternative). mutant is a periodic mutation
+    # gate like pitest/mull/muter/Stryker, not a per-commit hook. Each
+    # tool appears in exactly one category: bundler-audit owns security
+    # (dependency CVEs against the ruby-advisory-db — RuboCop's
+    # Security cop department runs inside the complexity/lint pass and
+    # Brakeman applies only once Rails is adopted, so neither is
+    # double-listed here) and `bundle outdated` owns dependency
+    # staleness (the cargo-outdated/npm-check-updates analogue).
+    "ruby": {
+        "coverage": "SimpleCov (COVERAGE=true bundle exec rspec)",
+        "mutation": "mutant (bundle exec mutant run)",
+        "complexity": "RuboCop Metrics/CyclomaticComplexity (.rubocop.yml)",
+        "documentation": "YARD",
+        "security": "bundler-audit (bundle exec bundler-audit check)",
+        "dependency_check": "bundle outdated",
+    },
 }
 
 

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -26,7 +26,7 @@ class GenerationConfig:
     Attributes:
         project_name: Name of the project.
         language: Programming language (python, typescript, go, rust,
-            swift, kotlin, cpp, java, csharp).
+            swift, kotlin, cpp, java, csharp, ruby).
         language_config: Additional language-specific configuration.
     """
 
@@ -726,6 +726,85 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
         ],
         "default_language_version": {},
     },
+    "ruby": {
+        "hooks": [
+            {
+                "repo": "https://github.com/pre-commit/pre-commit-hooks",
+                "rev": "v4.5.0",
+                "hooks": [
+                    {"id": "trailing-whitespace"},
+                    {"id": "end-of-file-fixer"},
+                    {"id": "check-yaml"},
+                    {"id": "check-json"},
+                    {"id": "check-added-large-files", "args": ["--maxkb=500"]},
+                    {"id": "check-case-conflict"},
+                    {"id": "check-merge-conflict"},
+                    {"id": "check-symlinks"},
+                    {"id": "detect-private-key"},
+                    {"id": "fix-byte-order-marker"},
+                    {"id": "mixed-line-ending", "args": ["--fix=lf"]},
+                    {"id": "no-commit-to-branch", "args": ["--branch", "main"]},
+                ],
+            },
+            # RuboCop is the one official-hook language in the matrix:
+            # rubocop/rubocop ships a .pre-commit-hooks.yaml at its repo
+            # root (verified at the pinned tag), so no `repo: local`
+            # system hook is needed. `language: ruby` means pre-commit
+            # builds an isolated gem environment from the pinned tag —
+            # a Ruby runtime must be on PATH, but the RuboCop version
+            # can never drift from this rev.
+            #
+            # The manifest's DEFAULT args include --autocorrect, which
+            # rewrites correctable offenses and would let them through
+            # (the #430 formatter lesson: a fixing-mode hook can fail
+            # only via pre-commit's file-modified detection, and silently
+            # passes once files are clean-but-unchecked-in). Overriding
+            # args to --force-exclusion alone makes the hook check-mode:
+            # plain `rubocop` exits non-zero on ANY offense.
+            # scripts/format.sh keeps the --autocorrect fixing path.
+            #
+            # One hook covers format (Layout cops), lint (Lint/Style),
+            # complexity (Metrics/CyclomaticComplexity <=10), and the
+            # source-level Security cops — .rubocop.yml at the project
+            # root is the single home of that policy, shared with
+            # scripts/lint.sh and CI; no flag here restates any of it.
+            {
+                "repo": "https://github.com/rubocop/rubocop",
+                "rev": "v1.87.0",
+                "hooks": [
+                    {
+                        "id": "rubocop",
+                        "args": ["--force-exclusion"],
+                    },
+                ],
+            },
+            {
+                "repo": "https://github.com/gitleaks/gitleaks",
+                "rev": "v8.18.4",
+                "hooks": [
+                    {"id": "gitleaks"},
+                ],
+            },
+            {
+                "repo": "https://github.com/shellcheck-py/shellcheck-py",
+                "rev": "v0.9.0.6",
+                "hooks": [
+                    {"id": "shellcheck"},
+                ],
+            },
+            {
+                "repo": "https://github.com/Yelp/detect-secrets",
+                "rev": "v1.4.0",
+                "hooks": [
+                    {
+                        "id": "detect-secrets",
+                        "args": ["--baseline", ".secrets.baseline"],
+                    },
+                ],
+            },
+        ],
+        "default_language_version": {},
+    },
     "cpp": {
         "hooks": [
             {
@@ -851,7 +930,7 @@ class PreCommitGenerator(BaseGenerator):
     Includes formatting, linting, security, and general file quality checks.
 
     Supports: Python, TypeScript, Go, Rust, Swift, Kotlin, C/C++ (cpp),
-    Java, C# (csharp), and other languages.
+    Java, C# (csharp), Ruby, and other languages.
 
     Attributes:
         orchestrator: Optional AI orchestrator for enhanced generation.

--- a/start_green_stay_green/generators/readme.py
+++ b/start_green_stay_green/generators/readme.py
@@ -68,12 +68,10 @@ class ReadmeGenerator(BaseGenerator):
     for the quality tools included in the project.
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
-    ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
-    pipeline.
+    ruby, swift, kotlin, cpp) are available at the generator level, and all
+    of them run the full CLI pipeline (``sgsg init``): Kotlin graduated
+    with #357/#358, C/C++ with #362/#363, Java with #366/#367, C# with
+    #370, and Ruby with #373.
 
     Attributes:
         output_dir: Directory where README.md will be created
@@ -1216,11 +1214,20 @@ Generated with [Start Green Stay Green](https://github.com/Geoffe-Ga/start_green
     def _ruby_readme_content(self) -> str:
         """Generate Ruby README.md content.
 
+        Only artifacts the scaffold actually generates carry a
+        checkmark (the truthfulness contract). With the #373 quality
+        toolchain (RuboCop via pre-commit and scripts, the SimpleCov
+        ≥90% coverage gate in spec_helper.rb, bundler-audit, the
+        Packwerk architecture configs) every advertised item is real;
+        the pre-#373 claims (Reek, Sorbet/RBS, Brakeman, lib/main.rb,
+        Gemfile.lock) named tools and files init never emits.
+
         Returns:
             Content for README.md
         """
         # Convert project name to title case for display
         display_name = self.config.project_name.replace("-", " ").title()
+        package_name = self.config.package_name
 
         return f"""# {self.config.project_name}
 
@@ -1229,14 +1236,26 @@ Start Green Stay Green.
 
 ## Description
 
-This project was generated with maximum quality standards from day one, including:
+This project was generated with maximum quality standards from day one,
+including:
 
-- ✅ Comprehensive testing infrastructure (RSpec with 90%+ coverage requirement)
-- ✅ Code quality tools (RuboCop, Reek)
-- ✅ Security scanning (Bundler Audit)
-- ✅ Type checking (Sorbet or RBS)
-- ✅ Pre-commit hooks (quality checks)
-- ✅ CI/CD pipeline (GitHub Actions)
+- ✅ Comprehensive testing infrastructure (RSpec with a 90%+ SimpleCov
+  coverage gate, activated by `COVERAGE=true` — the bound lives in
+  `spec/spec_helper.rb`)
+- ✅ Code quality tools (RuboCop: format, lint, complexity ≤10 via
+  `Metrics/CyclomaticComplexity`, and the Security cop department —
+  policy in `.rubocop.yml`)
+- ✅ Security scanning (bundler-audit dependency CVE scan via
+  `./scripts/security.sh`; gitleaks + detect-secrets in pre-commit.
+  Brakeman applies once Rails is adopted — it errors on plain-Ruby
+  projects, so it is documented rather than wired.)
+- ✅ Architecture enforcement (Packwerk configs in `plans/architecture/`
+  — see `packwerk.yml` there for the activation step and honest
+  enforcement limits)
+- ✅ Pre-commit hooks (RuboCop check-mode plus shared hygiene and
+  secret scanning)
+- ✅ Quality scripts (`./scripts/check-all.sh`)
+- ✅ CI/CD pipeline (`.github/workflows/ci.yml`)
 - ✅ AI-assisted development (Claude Code skills and subagents)
 
 ## Installation
@@ -1258,7 +1277,7 @@ pre-commit install
 Run the Hello World application:
 
 ```bash
-bundle exec ruby lib/main.rb
+bundle exec ruby lib/{package_name}.rb
 ```
 
 Expected output:
@@ -1271,34 +1290,42 @@ Hello from {self.config.project_name}!
 ### Running Quality Checks
 
 ```bash
+# Run everything (format check, lint, coverage-gated tests, security)
+./scripts/check-all.sh
+
 # Run all tests
 bundle exec rspec
 
-# Run tests with coverage
-bundle exec rspec --format documentation
+# Run tests with the >=90% coverage gate
+./scripts/test.sh --coverage
 
-# Run RuboCop
+# Run RuboCop (full cop set: lint, style, complexity, security cops)
 bundle exec rubocop
 
-# Run RuboCop with auto-correct
-bundle exec rubocop -a
+# Auto-fix correctable offenses
+./scripts/format.sh
 
-# Run Reek (code smell detector)
-bundle exec reek
+# Run the dependency CVE scan
+./scripts/security.sh
 
-# Run security scan
-bundle exec bundle-audit check --update
+# Run the architecture check (after the one-time wiring documented in
+# plans/architecture/packwerk.yml)
+./plans/architecture/run-check.sh
 ```
 
 ### Quality Tools
 
 This project includes:
 
-- **RSpec**: Testing framework with 90%+ coverage requirement
-- **SimpleCov**: Code coverage tool
-- **RuboCop**: Ruby linter and code formatter
-- **Reek**: Code smell detector
-- **Bundler Audit**: Security vulnerability scanner
+- **RSpec**: Testing framework
+- **SimpleCov**: Code coverage with a ≥90% bound (single home:
+  `spec/spec_helper.rb`)
+- **RuboCop**: Formatter, linter, complexity gate (≤10), and
+  source-level security cops (single home: `.rubocop.yml`)
+- **bundler-audit**: Dependency CVE scanning against the
+  ruby-advisory-db
+- **Packwerk**: Package boundary enforcement (configs parked in
+  `plans/architecture/`)
 - **Bundler**: Dependency management
 
 ### Project Structure
@@ -1306,16 +1333,16 @@ This project includes:
 ```
 {self.config.project_name}/
 ├── lib/                  # Application source code
-│   └── main.rb
+│   └── {package_name}.rb
 ├── spec/                 # Test suite
-│   ├── spec_helper.rb
-│   └── main_spec.rb
+│   ├── spec_helper.rb    # RSpec config + the SimpleCov >=90% bound
+│   └── {package_name}_spec.rb
 ├── scripts/              # Quality control scripts
+├── plans/architecture/   # Packwerk configs (parked; see packwerk.yml)
 ├── .github/workflows/    # CI/CD pipelines
 ├── .claude/              # AI subagents and skills
-├── Gemfile               # Dependency definition
-├── Gemfile.lock          # Dependency lock file
-└── .rubocop.yml          # RuboCop configuration
+├── Gemfile               # Dependency definition (quality gems pinned)
+└── .rubocop.yml          # RuboCop policy (complexity <=10 lives here)
 ```
 
 ### Testing
@@ -1324,14 +1351,14 @@ This project includes:
 # Run all tests
 bundle exec rspec
 
-# Run tests with coverage
-bundle exec rspec
+# Run tests with the coverage gate (the bound lives in spec_helper.rb)
+COVERAGE=true bundle exec rspec
 
-# View coverage report
+# View the coverage report
 open coverage/index.html
 
-# Run specific test file
-bundle exec rspec spec/main_spec.rb
+# Run a specific spec file
+bundle exec rspec spec/{package_name}_spec.rb
 
 # Run tests with documentation format
 bundle exec rspec --format documentation
@@ -1341,10 +1368,13 @@ bundle exec rspec --format documentation
 
 This project maintains MAXIMUM QUALITY standards:
 
-- **Test Coverage**: ≥90% required
-- **Code Style**: Enforced by RuboCop
+- **Test Coverage**: ≥90% required (SimpleCov, gated in CI and
+  `./scripts/test.sh --coverage`)
+- **Code Style**: Enforced by RuboCop (check-mode in pre-commit;
+  `./scripts/format.sh` owns the fixing path)
+- **Complexity**: ≤10 per method (`Metrics/CyclomaticComplexity` in
+  `.rubocop.yml`)
 - **All Linters**: Must pass with zero violations
-- **Code Smells**: Detected and resolved with Reek
 
 ## License
 

--- a/start_green_stay_green/generators/scripts.py
+++ b/start_green_stay_green/generators/scripts.py
@@ -207,6 +207,7 @@ class ScriptsGenerator:
             "cpp": self._generate_cpp_scripts,
             "java": self._generate_java_scripts,
             "csharp": self._generate_csharp_scripts,
+            "ruby": self._generate_ruby_scripts,
         }
         # Fallback to Python scripts for unknown languages.
         builder = builders.get(self.config.language, self._generate_python_scripts)
@@ -575,6 +576,51 @@ class ScriptsGenerator:
         self._write_companion_config(
             "CodeMetricsConfig.txt", self._CODE_METRICS_CONFIG_TEMPLATE
         )
+
+        return scripts
+
+    def _generate_ruby_scripts(self) -> dict[str, Path]:
+        """Generate Ruby-specific quality control scripts (#373).
+
+        Emits check/format/lint/test/security scripts plus a companion
+        ``.rubocop.yml`` at the project root — the single home of the
+        RuboCop policy (including the Metrics/CyclomaticComplexity
+        <=10 bound) shared by the pre-commit rubocop hook, these
+        scripts, and CI. Like the Java/C# scripts, most gates are owned
+        by project-level config rather than CLI flags: the >=90%
+        SimpleCov coverage bound lives in ``spec/spec_helper.rb`` (the
+        manifest-owned precedent) and every RuboCop threshold lives in
+        ``.rubocop.yml``, so the scripts are thin ``bundle exec``
+        invocations that cannot drift from the policy.
+
+        Returns:
+            Dictionary mapping script names to file paths
+        """
+        scripts: dict[str, Path] = {}
+
+        scripts["check-all.sh"] = self._write_script(
+            "check-all.sh",
+            self._ruby_check_all_script(),
+        )
+        scripts["format.sh"] = self._write_script(
+            "format.sh",
+            self._ruby_format_script(),
+        )
+        scripts["lint.sh"] = self._write_script(
+            "lint.sh",
+            self._ruby_lint_script(),
+        )
+        scripts["test.sh"] = self._write_script(
+            "test.sh",
+            self._ruby_test_script(),
+        )
+        scripts["security.sh"] = self._write_script(
+            "security.sh",
+            self._ruby_security_script(),
+        )
+        # Companion RuboCop config — written at the project root, not
+        # added to the scripts dict (it isn't an executable).
+        self._write_companion_config(".rubocop.yml", self._RUBOCOP_CONFIG_TEMPLATE)
 
         return scripts
 
@@ -5390,6 +5436,505 @@ dotnet_diagnostic.CA1502.severity = error
 # that bound (.editorconfig only flips the rule's severity, and the
 # .csproj only wires this file in via AdditionalFiles).
 CA1502: 10
+"""
+
+    def _ruby_check_all_script(self) -> str:
+        """Generate Ruby check-all.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/check-all.sh - Run all quality checks
+# Usage: ./scripts/check-all.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run all quality checks in sequence.
+
+Runs:
+  1. Format check (RuboCop Layout cops, check mode)
+  2. Lint + complexity <=10 + Security cops (full RuboCop run;
+     .rubocop.yml holds the whole policy)
+  3. Tests + coverage >=90% (RSpec + SimpleCov; the bound lives in
+     spec/spec_helper.rb)
+  4. Security (bundler-audit dependency CVE scan)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           One or more checks failed
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+VERBOSE_FLAG=""
+if $VERBOSE; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+echo "=== Running All Quality Checks ==="
+echo ""
+
+FAILED_CHECKS=()
+PASSED_CHECKS=()
+
+run_check() {
+    local check_name=$1
+    local script=$2
+    shift 2
+
+    echo "Running: $check_name"
+    # "${@}" is safe under set -u even when no extra args remain
+    # (unlike a named local array, which needs the
+    # ${args[@]+"${args[@]}"} guard the python template uses).
+    if "$SCRIPT_DIR/$script" "${@}" $VERBOSE_FLAG; then
+        PASSED_CHECKS+=("$check_name")
+        echo "✓ $check_name passed"
+    else
+        FAILED_CHECKS+=("$check_name")
+        echo "✗ $check_name failed" >&2
+    fi
+    echo ""
+}
+
+run_check "Format" "format.sh" --check
+run_check "Linting" "lint.sh"
+run_check "Tests" "test.sh" --coverage
+run_check "Security" "security.sh"
+
+echo "=== Quality Checks Summary ==="
+echo "Passed: ${#PASSED_CHECKS[@]}"
+echo "Failed: ${#FAILED_CHECKS[@]}"
+
+if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+    exit 1
+else
+    echo "✓ All quality checks passed!"
+    exit 0
+fi
+"""
+
+    def _ruby_format_script(self) -> str:
+        """Generate Ruby format.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/format.sh - Format Ruby code
+# Usage: ./scripts/format.sh [--fix] [--check] [--verbose] [--help]
+# Default (no flags) writes formatting in place, same as --fix; use
+# --check for a non-mutating verification pass.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+FIX=false
+CHECK=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --fix)
+            FIX=true
+            shift
+            ;;
+        --check)
+            CHECK=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Format Ruby code using RuboCop — the same tool (and the same
+.rubocop.yml policy) the pre-commit hook and scripts/lint.sh use, so
+the three can never disagree. This script owns the FIXING path
+(--autocorrect); the pre-commit hook deliberately runs check-mode
+because a fixing-mode hook can never fail on correctable offenses.
+
+OPTIONS:
+    --fix       Apply formatting (default; --autocorrect writes safe
+                corrections in place and still exits non-zero if
+                uncorrectable offenses remain)
+    --check     Check only, fail if formatting is needed (runs the
+                Layout cop department — RuboCop's formatter slice —
+                in check mode; lint.sh runs the full cop set)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Code is properly formatted
+    1           Formatting issues found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v bundle &> /dev/null; then
+    echo "✗ bundler not found" >&2
+    echo "  Install Ruby (brew install ruby / apt-get install ruby-full)" >&2
+    echo "  then: gem install bundler && bundle install" >&2
+    exit 1
+fi
+
+echo "=== Formatting (RuboCop) ==="
+
+# Fixing is the default; an explicit --fix overrides --check.
+if $CHECK && ! $FIX; then
+    bundle exec rubocop --only Layout --force-exclusion || \
+        { echo "✗ Format check failed" >&2; exit 1; }
+    echo "✓ Code formatting check passed"
+else
+    bundle exec rubocop --autocorrect --force-exclusion || \
+        { echo "✗ Formatting failed (uncorrectable offenses remain)" >&2; exit 1; }
+    echo "✓ Code formatted successfully"
+fi
+exit 0
+"""
+
+    def _ruby_lint_script(self) -> str:
+        """Generate Ruby lint.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/lint.sh - Static analysis: RuboCop (full cop set)
+# Usage: ./scripts/lint.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run static analysis. RuboCop's full cop set IS the lint gate —
+.rubocop.yml at the project root is the single source of the policy
+and this script restates none of it:
+  - Lint + Style departments (correctness and idiom checks)
+  - Complexity <=10: Metrics/CyclomaticComplexity, bounded in
+    .rubocop.yml (the single home; nothing else restates the number;
+    flog is the documented standalone alternative if you want a
+    second opinion on hotspots)
+  - Security department (source-level security cops: Security/Eval,
+    Security/Open, ... — scripts/security.sh covers dependency CVEs
+    instead, so the two never double-report. Brakeman applies only
+    when Rails is adopted; it errors on plain-Ruby projects.)
+
+The pre-commit rubocop hook runs the same tool against the same
+config, so local commits and this script can never disagree.
+
+Install: bundle install (rubocop is pinned in the Gemfile)
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All checks passed
+    1           RuboCop offenses found
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v bundle &> /dev/null; then
+    echo "✗ bundler not found - RuboCop runs via bundle exec" >&2
+    echo "  Install Ruby (brew install ruby / apt-get install ruby-full)" >&2
+    echo "  then: gem install bundler && bundle install" >&2
+    exit 1
+fi
+
+echo "=== Static Analysis (RuboCop) ==="
+
+bundle exec rubocop --force-exclusion || \
+    { echo "✗ RuboCop found offenses" >&2; exit 1; }
+
+echo "✓ Linting checks passed"
+exit 0
+"""
+
+    def _ruby_test_script(self) -> str:
+        """Generate Ruby test.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/test.sh - Run Ruby tests via RSpec
+# Usage: ./scripts/test.sh [--coverage] [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+COVERAGE=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --coverage)
+            COVERAGE=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run the RSpec suite (bundle exec rspec).
+
+OPTIONS:
+    --coverage  Enforce >=90% line coverage via SimpleCov
+                (COVERAGE=true activates the gate; the bound lives in
+                spec/spec_helper.rb — its single home; this script
+                never restates the number. SimpleCov's at_exit hook
+                fails the rspec invocation directly when the bound is
+                missed, so there is no standalone-report no-op path.)
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           All tests passed (and coverage met, with --coverage)
+    1           Test failures or coverage below threshold
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v bundle &> /dev/null; then
+    echo "✗ bundler not found - the test suite runs via bundle exec rspec" >&2
+    echo "  Install Ruby (brew install ruby / apt-get install ruby-full)" >&2
+    echo "  then: gem install bundler && bundle install" >&2
+    exit 1
+fi
+
+echo "=== Running Tests (RSpec) ==="
+
+if $COVERAGE; then
+    COVERAGE=true bundle exec rspec || \
+        { echo "✗ Tests or coverage gate failed" >&2; exit 1; }
+else
+    bundle exec rspec || { echo "✗ Tests failed" >&2; exit 1; }
+fi
+
+echo "✓ Tests passed"
+exit 0
+"""
+
+    def _ruby_security_script(self) -> str:
+        """Generate Ruby security.sh script."""
+        return """#!/usr/bin/env bash
+# scripts/security.sh - Security checks for Ruby
+# Usage: ./scripts/security.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run security checks.
+
+Division of labor:
+  - Secret scanning (gitleaks + detect-secrets) runs in pre-commit.
+  - Source-level security analysis is RuboCop's Security cop
+    department, configured in .rubocop.yml: it runs inside every
+    full RuboCop pass (scripts/lint.sh, the pre-commit hook, CI), so
+    this script does not re-run it. Brakeman is the deeper scanner to
+    add WHEN the project adopts Rails — it is Rails-specific and
+    errors on plain-Ruby projects, so it is not wired here.
+  - This script owns dependency CVE scanning via bundler-audit.
+
+bundler-audit checks Gemfile.lock against the ruby-advisory-db, which
+must first be fetched/updated over the network; when the update cannot
+run (offline) the scan is skipped with a warning rather than failing a
+fresh clone.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           No issues found (or the CVE scan skipped; see above)
+    1           Vulnerable gems reported
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+if $VERBOSE; then
+    set -x
+fi
+
+if ! command -v bundle &> /dev/null; then
+    echo "✗ bundler not found - the security checks run via bundle exec" >&2
+    echo "  Install Ruby (brew install ruby / apt-get install ruby-full)" >&2
+    echo "  then: gem install bundler && bundle install" >&2
+    exit 1
+fi
+
+echo "=== Security (bundler-audit dependency CVE scan) ==="
+
+# bundler-audit needs Gemfile.lock; materialize it on a fresh clone.
+if [ ! -f Gemfile.lock ]; then
+    bundle lock >/dev/null 2>&1 || {
+        echo "⚠ Could not generate Gemfile.lock (bundle lock failed)" >&2
+        echo "⚠ - skipping the dependency CVE scan" >&2
+        echo "✓ Security checks passed"
+        exit 0
+    }
+fi
+
+# Pragmatic default: the advisory database lives at
+# https://github.com/rubysec/ruby-advisory-db and `bundler-audit update`
+# needs network access to fetch it. When the update cannot run
+# (offline), warn and skip so a fresh clone passes check-all.sh out of
+# the box. Tighten by replacing the warning block with 'exit 1' once
+# network access is guaranteed everywhere (including CI).
+if bundle exec bundler-audit update >/dev/null 2>&1; then
+    bundle exec bundler-audit check || \
+        { echo "✗ Vulnerable gems found" >&2; exit 1; }
+    echo "✓ No vulnerable gems reported"
+else
+    echo "⚠ Could not update the ruby-advisory-db" >&2
+    echo "⚠ (bundler-audit needs network access to fetch it)" >&2
+    echo "⚠ - skipping the dependency CVE scan" >&2
+fi
+
+echo "✓ Security checks passed"
+exit 0
+"""
+
+    # .rubocop.yml companion — the SINGLE home of the RuboCop policy
+    # shared by the pre-commit rubocop hook, scripts/format.sh,
+    # scripts/lint.sh, and CI (mirroring the pmd-ruleset.xml /
+    # CodeMetricsConfig.txt companion split). It carries the
+    # cyclomatic-complexity <=10 bound the other languages gate via
+    # radon/eslint/gocyclo/clippy/SwiftLint/detekt/lizard/PMD/CA1502;
+    # neither the scripts nor the hooks restate the number.
+    _RUBOCOP_CONFIG_TEMPLATE = """\
+# .rubocop.yml generated by Start Green Stay Green.
+#
+# The pre-commit rubocop hook, scripts/format.sh, scripts/lint.sh, and
+# CI all read this file, so the style/lint/complexity/security policy
+# has exactly one home.
+
+AllCops:
+  # Match the oldest Ruby line still receiving upstream maintenance
+  # (verified against ruby-lang.org's branch table); bump together
+  # with the CI matrix in .github/workflows/ci.yml.
+  TargetRubyVersion: 3.3
+  # Opt into new cops as RuboCop releases them - maximum quality means
+  # adopting new checks by default rather than pinning to old behavior.
+  NewCops: enable
+  # Keep the run reproducible: do not prompt about extension gems.
+  SuggestExtensions: false
+
+# The <=10 cyclomatic-complexity ceiling every supported language
+# gates on. This is the bound's SINGLE home - the scripts and hooks
+# never restate it. (flog is the documented standalone alternative for
+# complexity hotspot analysis; it is deliberately not wired so the
+# bound keeps one home.)
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+# RSpec example groups and Gemfile/gemspec DSL blocks are naturally
+# long; excluding them here mirrors the rubocop-rspec community
+# default without pulling in the extension gem.
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+    - "Gemfile"
+
+# The generated scaffold uses double-quoted strings throughout (the
+# Gemfile convention); keep the project consistent with it.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
 """
 
     # Language-agnostic script generators

--- a/start_green_stay_green/generators/structure.py
+++ b/start_green_stay_green/generators/structure.py
@@ -21,6 +21,8 @@ from start_green_stay_green.utils.csharp import csharp_namespace
 from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
+from start_green_stay_green.utils.ruby import ruby_gemfile
+from start_green_stay_green.utils.ruby import ruby_module_name
 from start_green_stay_green.utils.swift import package_swift
 
 if TYPE_CHECKING:
@@ -65,12 +67,10 @@ class StructureGenerator(BaseGenerator):
     __init__.py, Hello World starter code) for the target project's language.
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
-    ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
-    pipeline.
+    ruby, swift, kotlin, cpp) are available at the generator level, and all
+    of them run the full CLI pipeline (``sgsg init``): Kotlin graduated
+    with #357/#358, C/C++ with #362/#363, Java with #366/#367, C# with
+    #370, and Ruby with #373.
 
     Attributes:
         output_dir: Directory where structure will be created
@@ -850,16 +850,21 @@ namespace {namespace}
     def _ruby_lib_rb(self) -> str:
         """Generate Ruby library file content.
 
+        The module name comes from the shared
+        :func:`~start_green_stay_green.utils.ruby.ruby_module_name`
+        helper so the RSpec scaffold (tests generator) describes the
+        same constant this file declares (#373). The module carries a
+        documentation comment so the scaffold passes RuboCop's
+        ``Style/Documentation`` cop out of the box.
+
         Returns:
             Content for main Ruby library file
         """
-        # Convert package_name to module name (capitalize each part)
-        module_name = "".join(
-            word.capitalize() for word in self.config.package_name.split("_")
-        )
+        module_name = ruby_module_name(self.config.package_name)
 
         return f"""# frozen_string_literal: true
 
+# Entry point module for {self.config.project_name}.
 module {module_name}
   VERSION = "0.1.0"
 
@@ -875,17 +880,15 @@ end
     def _ruby_gemfile(self) -> str:
         """Generate Ruby Gemfile content.
 
+        Delegates to the shared
+        :func:`~start_green_stay_green.utils.ruby.ruby_gemfile` helper
+        so the structure and dependencies generators emit an identical
+        manifest from one source of truth (#373).
+
         Returns:
             Content for Gemfile
         """
-        return """# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "rake", "~> 13.0"
-gem "rspec", "~> 3.0"
-gem "rubocop", "~> 1.0"
-"""
+        return ruby_gemfile()
 
     def _generate_swift_structure(self) -> dict[str, Path]:
         """Generate Swift watchOS project structure.

--- a/start_green_stay_green/generators/tests_gen.py
+++ b/start_green_stay_green/generators/tests_gen.py
@@ -19,6 +19,7 @@ from start_green_stay_green.utils.csharp import csharp_namespace
 from start_green_stay_green.utils.java import android_package
 from start_green_stay_green.utils.java import android_package_path
 from start_green_stay_green.utils.naming import pascal_case
+from start_green_stay_green.utils.ruby import ruby_module_name
 
 if TYPE_CHECKING:
     from start_green_stay_green.utils.file_writer import FileWriter
@@ -62,12 +63,10 @@ class TestsGenerator(BaseGenerator):
     tests/test_main.py) with a passing test for the Hello World code.
 
     All 10 supported languages (python, typescript, go, rust, java, csharp,
-    ruby, swift, kotlin, cpp) are available at the generator level. Note that
-    the full CLI pipeline (``sgsg init``) skips the pre-commit, scripts,
-    architecture, and metrics steps for ruby —
-    the CI workflow step covers every language. Kotlin (#357/#358),
-    C/C++ (#362/#363), Java (#366/#367), and C# (#370) run the full
-    pipeline.
+    ruby, swift, kotlin, cpp) are available at the generator level, and all
+    of them run the full CLI pipeline (``sgsg init``): Kotlin graduated
+    with #357/#358, C/C++ with #362/#363, Java with #366/#367, C# with
+    #370, and Ruby with #373.
 
     Attributes:
         output_dir: Directory where tests structure will be created
@@ -532,26 +531,35 @@ namespace {namespace}.Tests
     def _ruby_test_spec_rb(self) -> str:
         """Generate Ruby spec file content.
 
+        The described constant comes from the shared
+        :func:`~start_green_stay_green.utils.ruby.ruby_module_name`
+        helper, and the spec exercises ``.hello`` — the method the
+        structure scaffold actually defines. Before #373 the spec
+        described ``package_name.capitalize()`` (``My_project``) and
+        called ``.main``, neither of which exists in the generated
+        ``lib/`` file: a guaranteed ``NameError`` on first run.
+
         Returns:
             Content for {package_name}_spec.rb with RSpec test
         """
+        module_name = ruby_module_name(self.config.package_name)
         return f"""# frozen_string_literal: true
 
-require 'spec_helper'
-require_relative '../lib/{self.config.package_name}'
+require "spec_helper"
+require_relative "../lib/{self.config.package_name}"
 
-RSpec.describe {self.config.package_name.capitalize()} do
-  describe '.main' do
-    it 'runs without error' do
-      # Test that main method exists and can be called
-      # This verifies the Hello World entry point works correctly
-      expect {{ {self.config.package_name.capitalize()}.main }}.not_to raise_error
+RSpec.describe {module_name} do
+  describe ".hello" do
+    it "runs without error" do
+      # Test that the hello method exists and can be called.
+      # This verifies the Hello World entry point works correctly.
+      expect {{ described_class.hello }}.not_to raise_error
     end
 
-    it 'prints hello message' do
-      # Capture stdout to verify the hello message
+    it "prints hello message" do
+      # Capture stdout to verify the hello message.
       pattern = /Hello from {self.config.project_name}/
-      expect {{ {self.config.package_name.capitalize()}.main }}
+      expect {{ described_class.hello }}
         .to output(pattern).to_stdout
     end
   end
@@ -561,12 +569,34 @@ end
     def _ruby_spec_helper_rb(self) -> str:
         """Generate Ruby spec_helper.rb content.
 
+        ``spec_helper.rb`` is the single home of the >=90% SimpleCov
+        line-coverage bound (#373, the manifest-owned precedent of the
+        Kover/JaCoCo/Coverlet gates). The gate is activated by setting
+        ``COVERAGE=true`` (``scripts/test.sh --coverage`` does this),
+        so a plain ``bundle exec rspec`` stays a fast test run;
+        SimpleCov's at_exit hook fails the rspec invocation directly
+        when the bound is missed — no standalone-report no-op path.
+        Nothing else (scripts, hooks, CI) restates the number.
+
         Returns:
             Content for spec_helper.rb with RSpec configuration
         """
         return f"""# frozen_string_literal: true
 
 # RSpec configuration for {self.config.project_name}
+
+# Coverage gate, activated by COVERAGE=true (scripts/test.sh --coverage
+# and the CI workflow set it). This block is the SINGLE home of the
+# >=90% line-coverage bound — scripts, hooks, and CI never restate the
+# number. SimpleCov must start before the application code is loaded,
+# which holds because every spec requires this helper first.
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/spec/"
+    minimum_coverage 90
+  end
+end
 
 RSpec.configure do |config|
   # Use the expect syntax
@@ -583,7 +613,7 @@ RSpec.configure do |config|
   config.color = true
 
   # Use the documentation formatter for detailed output
-  config.default_formatter = 'doc' if config.files_to_run.one?
+  config.default_formatter = "doc" if config.files_to_run.one?
 
   # Randomize test order
   config.order = :random

--- a/start_green_stay_green/utils/ruby.py
+++ b/start_green_stay_green/utils/ruby.py
@@ -1,0 +1,124 @@
+"""Ruby naming helpers and pinned gem versions (#373).
+
+Provides a single source of truth for the CamelCase Ruby module name
+derived from a project's package name, shared by the Ruby scaffold's
+structure and tests generators: the ``module`` declaration in
+``lib/{package_name}.rb`` and the constant the RSpec scaffold
+describes both derive from :func:`ruby_module_name`, so they can
+never drift apart (the ``utils.csharp.csharp_namespace`` precedent —
+before #373 the spec described ``package_name.capitalize()`` while
+the lib file declared a per-word-capitalized module, a guaranteed
+``NameError`` in the generated project).
+
+The pinned gem version constraints for the generated ``Gemfile`` live
+here for the same reason (the ``utils.java`` / ``utils.csharp``
+version-pin precedent), as does the canonical Gemfile content shared
+by the structure and dependencies generators. All pins were verified
+against the live rubygems.org API before being recorded.
+"""
+
+from __future__ import annotations
+
+import re
+
+from start_green_stay_green.utils.naming import pascal_case
+
+# Pinned gem version constraints for the generated Gemfile (pessimistic
+# ``~>`` bounds; live-verified latest stable on rubygems.org).
+# rake backs the conventional default task runner.
+RAKE_VERSION = "13.4"
+# RSpec is the test framework; SimpleCov hooks into the suite and owns
+# the >=90% coverage bound via spec/spec_helper.rb (#373).
+RSPEC_VERSION = "3.13"
+SIMPLECOV_VERSION = "0.22"
+# RuboCop owns formatting (--autocorrect via scripts/format.sh), lint,
+# the Metrics/CyclomaticComplexity <=10 gate, and the Security cops;
+# .rubocop.yml is the single home of its policy (#373).
+RUBOCOP_VERSION = "1.87"
+# bundler-audit owns dependency CVE scanning (scripts/security.sh).
+BUNDLER_AUDIT_VERSION = "0.9"
+# Packwerk backs the architecture boundary rules generated into
+# plans/architecture (#373). It pulls in activesupport/zeitwerk as
+# runtime dependencies; see plans/architecture/packwerk.yml for its
+# enforcement limits on a plain-Ruby (non-Zeitwerk) scaffold.
+PACKWERK_VERSION = "3.3"
+
+# Characters that split a package name into module-name words.
+_SEPARATORS = re.compile(r"[^a-zA-Z0-9]+")
+
+
+def ruby_module_name(package_name: str) -> str:
+    """Derive a valid CamelCase Ruby module name from a package name.
+
+    Separator characters (hyphens, dots, anything not alphanumeric) are
+    normalized to underscores and the result runs through the shared
+    :func:`~start_green_stay_green.utils.naming.pascal_case` helper
+    (``wrist_ledger`` -> ``WristLedger``). On top of that, Ruby's
+    constant rules apply: a constant must start with an uppercase
+    letter, so a name that would start with a digit gains an ``App``
+    prefix, and a name with no usable characters falls back to ``App``.
+
+    Args:
+        package_name: The project's package identifier (e.g.
+            ``wrist_ledger`` or ``wrist-ledger``).
+
+    Returns:
+        A CamelCase module name such as ``WristLedger``.
+    """
+    module_name = pascal_case(_SEPARATORS.sub("_", package_name))
+    if not module_name:
+        return "App"
+    if module_name[0].isdigit():
+        return f"App{module_name}"
+    return module_name
+
+
+def ruby_gemfile() -> str:
+    """Return the canonical Gemfile for the generated Ruby scaffold.
+
+    Shared by the structure and dependencies generators so the two
+    emit an identical manifest from one source of truth (the
+    ``utils.swift.package_swift`` precedent — before #373 they emitted
+    two diverging Gemfiles).
+
+    The development/test group wires the full #373 quality toolchain:
+    RSpec + SimpleCov (coverage, bound in spec/spec_helper.rb), RuboCop
+    (format/lint/complexity/security cops via .rubocop.yml),
+    bundler-audit (dependency CVEs), and Packwerk (architecture
+    boundaries; see plans/architecture). Brakeman is deliberately NOT
+    included: it is a Rails-specific scanner that errors out on a
+    plain-Ruby project — add it alongside Rails if the project adopts
+    the framework.
+
+    Returns:
+        Content for the generated ``Gemfile``.
+    """
+    return f"""# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake", "~> {RAKE_VERSION}"
+
+group :development, :test do
+  # Test framework; SimpleCov hooks the suite and enforces the >=90%
+  # coverage bound declared in spec/spec_helper.rb (its single home).
+  gem "rspec", "~> {RSPEC_VERSION}"
+  gem "simplecov", "~> {SIMPLECOV_VERSION}", require: false
+
+  # Formatter, linter, complexity (<=10 via Metrics cops), and
+  # source-level security cops in one tool; .rubocop.yml is the single
+  # home of the policy shared by pre-commit, scripts, and CI.
+  gem "rubocop", "~> {RUBOCOP_VERSION}", require: false
+
+  # Dependency CVE scanning against the ruby-advisory-db
+  # (scripts/security.sh). Brakeman is deliberately absent: it is a
+  # Rails-specific scanner that errors on plain-Ruby projects — add it
+  # here together with Rails if the project adopts the framework.
+  gem "bundler-audit", "~> {BUNDLER_AUDIT_VERSION}", require: false
+
+  # Architecture boundary enforcement (plans/architecture). Packwerk
+  # targets Zeitwerk-style autoloaded codebases; see the generated
+  # packwerk.yml for its enforcement limits on this plain-Ruby layout.
+  gem "packwerk", "~> {PACKWERK_VERSION}", require: false
+end
+"""

--- a/tests/e2e/test_language_e2e.py
+++ b/tests/e2e/test_language_e2e.py
@@ -3,14 +3,12 @@
 Tests the complete sgsg init flow for supported languages, verifying
 that the CLI produces valid project structures end-to-end.
 
-Note: ruby is supported at the generator level, but the quality-tooling
-pipeline steps (PreCommitGenerator, scripts, metrics, architecture)
-skip it. Kotlin completed the pipeline with #357/#358, C/C++ followed
-with #362 (quality tooling) and #363 (CI workflow), Java with #366
-(Wear OS foundation + CI) and #367 (quality tooling), and C# with #370
-(quality tooling on top of the foundation scaffold + CI), so all four
-join CLI_SUPPORTED_LANGUAGES below
-(test_language_generators.py covers the generator-only languages).
+Note: every base.SUPPORTED_LANGUAGES entry now runs the full pipeline.
+Kotlin completed it with #357/#358, C/C++ followed with #362 (quality
+tooling) and #363 (CI workflow), Java with #366 (Wear OS foundation +
+CI) and #367 (quality tooling), C# with #370 (quality tooling on top
+of the foundation scaffold + CI), and Ruby with #373, so all of them
+join CLI_SUPPORTED_LANGUAGES below.
 
 All tests use an environment with API keys stripped and a null keyring
 backend to prevent real Anthropic API calls. See Issue #196.
@@ -37,6 +35,7 @@ CLI_SUPPORTED_LANGUAGES = (
     "cpp",
     "java",
     "csharp",
+    "ruby",
 )
 
 # Expected key files per language that sgsg init should create
@@ -124,6 +123,19 @@ EXPECTED_KEY_FILES: dict[str, list[str]] = {
         ".pre-commit-config.yaml",
         "scripts/check-all.sh",
         "plans/architecture/ArchitectureTest.cs",
+        ".github/workflows/ci.yml",
+        "README.md",
+    ],
+    "ruby": [
+        "Gemfile",
+        "lib/test_project.rb",
+        "spec/test_project_spec.rb",
+        "spec/spec_helper.rb",
+        ".rubocop.yml",
+        ".pre-commit-config.yaml",
+        "scripts/check-all.sh",
+        "plans/architecture/packwerk.yml",
+        "plans/architecture/package.yml",
         ".github/workflows/ci.yml",
         "README.md",
     ],

--- a/tests/integration/generators/test_ruby_init_integration.py
+++ b/tests/integration/generators/test_ruby_init_integration.py
@@ -1,0 +1,367 @@
+"""Integration tests for ``sgsg init --language ruby`` (#373).
+
+Runs the full init flow once via the Typer CliRunner and asserts the
+generated Ruby project tree, the Gemfile manifest, and the
+quality-tooling artifacts. The AI orchestrator is patched to ``None``
+so no real Anthropic API calls are made (Issue #196); the null keyring
+backend is enforced globally by ``tests/conftest.py``.
+
+These tests are structural only — they never invoke the Ruby
+toolchain — so they pass on CI runners without a Ruby install,
+mirroring ``test_csharp_init_integration.py`` (#370).
+
+With #373 the quality toolchain (pre-commit config, quality scripts,
+the .rubocop.yml policy companion, the Packwerk architecture configs)
+is generated for ruby alongside the foundation scaffold and its CI
+workflow, so this suite locks in the presence of every pipeline
+artifact.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green.cli import app
+from start_green_stay_green.utils.ruby import ruby_module_name
+
+# Project name chosen to exercise the hyphen sanitization path:
+# wrist-ledger -> package wrist_ledger -> module WristLedger.
+_PROJECT_NAME = "wrist-ledger"
+_MODULE_NAME = ruby_module_name("wrist_ledger")
+
+
+@pytest.fixture(scope="module")
+def ruby_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Run ``sgsg init --language ruby`` once and return the project root.
+
+    Args:
+        tmp_path_factory: Pytest factory for a module-scoped temp directory.
+
+    Returns:
+        Path to the generated project directory.
+    """
+    output_dir = tmp_path_factory.mktemp("ruby-init")
+    runner = CliRunner()
+    with patch(
+        "start_green_stay_green.cli._initialize_orchestrator", return_value=None
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                _PROJECT_NAME,
+                "--language",
+                "ruby",
+                "--output-dir",
+                str(output_dir),
+                "--no-interactive",
+            ],
+        )
+    assert result.exit_code == 0, f"sgsg init failed for ruby: {result.output}"
+    return output_dir / _PROJECT_NAME
+
+
+class TestRubyInitTree:
+    """Assert the generated Ruby project tree."""
+
+    def test_project_directory_created(self, ruby_project: Path) -> None:
+        """Init creates the project directory."""
+        assert ruby_project.is_dir()
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            "Gemfile",
+            "lib/wrist_ledger.rb",
+            "spec/wrist_ledger_spec.rb",
+            "spec/spec_helper.rb",
+            "README.md",
+            # The CI workflow is real: ci.py has a ruby config and
+            # reference/ci/ruby.yml backs it.
+            ".github/workflows/ci.yml",
+        ],
+    )
+    def test_expected_file_generated(
+        self, ruby_project: Path, relative_path: str
+    ) -> None:
+        """Every expected ruby project file exists and is non-empty."""
+        file_path = ruby_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # Quality tooling (#373) is now generated alongside the
+            # foundation scaffold.
+            ".pre-commit-config.yaml",
+            ".rubocop.yml",
+            "scripts/check-all.sh",
+            "scripts/format.sh",
+            "scripts/lint.sh",
+            "scripts/test.sh",
+            "scripts/security.sh",
+            "plans/architecture/packwerk.yml",
+            "plans/architecture/package.yml",
+            "plans/architecture/run-check.sh",
+        ],
+    )
+    def test_quality_tooling_artifact_generated(
+        self, ruby_project: Path, relative_path: str
+    ) -> None:
+        """#373 quality-tooling artifacts exist and are non-empty."""
+        file_path = ruby_project / relative_path
+        assert file_path.is_file(), f"Missing {relative_path}"
+        assert file_path.read_text(), f"Empty {relative_path}"
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        [
+            # The metrics dashboard is opt-in (--enable-live-dashboard).
+            "docs/metrics.json",
+            # No lockfile or gemspec is generated (plain-Ruby scaffold;
+            # the lockfile materializes on the user's first
+            # `bundle install`).
+            "Gemfile.lock",
+            f"{_PROJECT_NAME}.gemspec",
+        ],
+    )
+    def test_out_of_scope_artifact_not_generated(
+        self, ruby_project: Path, relative_path: str
+    ) -> None:
+        """The scaffold must not emit opt-in or unadvertised artifacts."""
+        assert not (ruby_project / relative_path).exists()
+
+
+class TestRubyInitQualityTooling:
+    """Assert the generated quality-tooling configs are valid (#373)."""
+
+    def test_precommit_config_parses_and_includes_rubocop_hook(
+        self, ruby_project: Path
+    ) -> None:
+        """.pre-commit-config.yaml parses and wires the Ruby toolchain."""
+        content = (ruby_project / ".pre-commit-config.yaml").read_text()
+        parsed = yaml.safe_load(
+            "\n".join(line for line in content.split("\n") if not line.startswith("#"))
+        )
+        rubocop_repo = next(
+            repo
+            for repo in parsed["repos"]
+            if "rubocop/rubocop" in repo.get("repo", "")
+        )
+        hook_ids = {hook["id"] for hook in rubocop_repo["hooks"]}
+        assert hook_ids == {"rubocop"}
+
+    def test_precommit_rubocop_hook_is_check_mode(self, ruby_project: Path) -> None:
+        """The rubocop hook can actually fail on offenses.
+
+        The upstream manifest defaults to --autocorrect (fixing mode);
+        the generated hook must override args to plain check-mode so
+        offenses fail the commit (scripts/format.sh keeps the fixing
+        path).
+        """
+        content = (ruby_project / ".pre-commit-config.yaml").read_text()
+        parsed = yaml.safe_load(
+            "\n".join(line for line in content.split("\n") if not line.startswith("#"))
+        )
+        rubocop_repo = next(
+            repo
+            for repo in parsed["repos"]
+            if "rubocop/rubocop" in repo.get("repo", "")
+        )
+        hook = next(h for h in rubocop_repo["hooks"] if h["id"] == "rubocop")
+        assert "--autocorrect" not in hook.get("args", [])
+
+    def test_rubocop_config_carries_the_complexity_bound(
+        self, ruby_project: Path
+    ) -> None:
+        """.rubocop.yml is the single home of the <=10 bound."""
+        parsed = yaml.safe_load((ruby_project / ".rubocop.yml").read_text())
+        assert parsed["Metrics/CyclomaticComplexity"]["Max"] == 10
+
+    def test_spec_helper_carries_the_coverage_bound(self, ruby_project: Path) -> None:
+        """spec_helper.rb is the single home of the >=90% coverage bound."""
+        content = (ruby_project / "spec" / "spec_helper.rb").read_text()
+        assert "minimum_coverage 90" in content
+        assert 'if ENV["COVERAGE"]' in content
+
+    def test_check_all_script_runs_the_ruby_toolchain(self, ruby_project: Path) -> None:
+        """check-all.sh chains format, lint, coverage-gated tests, security."""
+        content = (ruby_project / "scripts" / "check-all.sh").read_text()
+        assert 'run_check "Tests" "test.sh" --coverage' in content
+
+    def test_architecture_configs_parse_and_document_limits(
+        self, ruby_project: Path
+    ) -> None:
+        """The Packwerk configs parse as YAML and disclose their limits."""
+        packwerk = ruby_project / "plans" / "architecture" / "packwerk.yml"
+        package = ruby_project / "plans" / "architecture" / "package.yml"
+        packwerk_parsed = yaml.safe_load(packwerk.read_text())
+        package_parsed = yaml.safe_load(package.read_text())
+        assert packwerk_parsed["package_paths"] == "**/"
+        assert package_parsed["enforce_dependencies"] is True
+        # Honest enforcement-limit disclosure (no overclaiming).
+        assert "Zeitwerk" in packwerk.read_text()
+        assert "NOT reject circular requires" in packwerk.read_text()
+
+
+class TestRubyInitManifest:
+    """Assert the Gemfile manifest and the CI workflow."""
+
+    def test_gemfile_pins_the_quality_toolchain(self, ruby_project: Path) -> None:
+        """The Gemfile declares the pinned #373 quality gems."""
+        content = (ruby_project / "Gemfile").read_text()
+        for gem_name in ("rspec", "simplecov", "rubocop", "bundler-audit", "packwerk"):
+            assert f'gem "{gem_name}"' in content
+
+    def test_ci_workflow_parses_and_gates_via_spec_helper(
+        self, ruby_project: Path
+    ) -> None:
+        """ci.yml parses as YAML and never restates the coverage bound.
+
+        The >=90% number lives in spec/spec_helper.rb (single home), so
+        the CI coverage step only sets COVERAGE=true.
+        """
+        content = (ruby_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "Ruby Quality Checks"
+        assert "COVERAGE=true bundle exec rspec" in content
+        assert "--minimum-coverage" not in content
+
+    def test_ci_matrix_runs_only_maintained_rubies(self, ruby_project: Path) -> None:
+        """The Ruby matrix has no EOL entries.
+
+        3.1 and 3.2 reached upstream EOL (verified against
+        ruby-lang.org, 2026-06), so their matrix legs would test
+        unsupported runtimes.
+        """
+        content = (ruby_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        matrix = parsed["jobs"]["quality"]["strategy"]["matrix"]["ruby-version"]
+        assert "3.1" not in matrix
+        assert "3.2" not in matrix
+        assert matrix, "matrix must not be empty"
+
+    def test_ci_runs_bundler_audit_not_brakeman(self, ruby_project: Path) -> None:
+        """CI gates on bundler-audit; Brakeman would error on plain Ruby.
+
+        brakeman exits with an error when pointed at a non-Rails
+        project, so a Brakeman step would be red on every push of the
+        generated scaffold.
+        """
+        content = (ruby_project / ".github" / "workflows" / "ci.yml").read_text()
+        assert "bundler-audit check" in content
+        assert "bundle exec brakeman" not in content
+
+    def test_ci_codecov_upload_cannot_fail_a_fresh_project(
+        self, ruby_project: Path
+    ) -> None:
+        """The Codecov upload is best-effort in generated projects.
+
+        A fresh `green init` project ships no CODECOV_TOKEN secret, so
+        `fail_ci_if_error: true` would start the project red; the real
+        coverage gate is the spec_helper-backed SimpleCov run (#368
+        lesson). The action is pinned to >=v6 (the #435 note).
+        """
+        content = (ruby_project / ".github" / "workflows" / "ci.yml").read_text()
+        parsed = yaml.safe_load(content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert codecov_steps, "CI must still upload coverage to Codecov"
+        for step in codecov_steps:
+            assert step["with"]["fail_ci_if_error"] is False
+            action_version = int(step["uses"].rsplit("@v", maxsplit=1)[1])
+            assert action_version >= 6
+
+
+class TestRubyInitSources:
+    """Assert the generated Ruby source and spec files."""
+
+    def test_lib_module_name_and_entry_point(self, ruby_project: Path) -> None:
+        """lib/wrist_ledger.rb declares the shared module with .hello."""
+        source = (ruby_project / "lib" / "wrist_ledger.rb").read_text()
+        assert f"module {_MODULE_NAME}" in source
+        assert "def self.hello" in source
+        assert f'"Hello from {_PROJECT_NAME}!"' in source
+
+    def test_generated_spec_resolves_the_module(self, ruby_project: Path) -> None:
+        """The spec describes the module the lib file declares.
+
+        Both sides derive the constant from utils.ruby.ruby_module_name
+        (#373) — the pre-#373 spec described a constant that did not
+        exist and called a method the lib never defined.
+        """
+        source = (ruby_project / "spec" / "wrist_ledger_spec.rb").read_text()
+        assert f"RSpec.describe {_MODULE_NAME}" in source
+        assert "described_class.hello" in source
+        assert 'require_relative "../lib/wrist_ledger"' in source
+
+
+class TestRubyInitReadme:
+    """Assert the generated README stays truthful (#373)."""
+
+    def test_readme_advertises_373_tooling_as_real(self, ruby_project: Path) -> None:
+        """README advertises the now-generated #373 quality tooling.
+
+        Every artifact the README checkmarks must exist next to it —
+        the truthfulness contract.
+        """
+        readme = (ruby_project / "README.md").read_text()
+        assert "./scripts/check-all.sh" in readme
+        assert (ruby_project / "scripts" / "check-all.sh").is_file()
+        assert "plans/architecture" in readme
+        assert (ruby_project / "plans" / "architecture" / "packwerk.yml").is_file()
+        assert ".github/workflows/ci.yml" in readme
+        assert (ruby_project / ".github" / "workflows" / "ci.yml").is_file()
+
+    def test_readme_structure_block_is_truthful(self, ruby_project: Path) -> None:
+        """README never names tools or files the scaffold does not emit."""
+        readme = (ruby_project / "README.md").read_text()
+        assert "Reek" not in readme
+        assert "Sorbet" not in readme
+        assert "Gemfile.lock" not in readme
+        assert "lib/main.rb" not in readme
+
+
+class TestRubyInitConsoleOutput:
+    """Assert init's console output reflects the #373 wiring."""
+
+    def test_init_skips_no_pipeline_steps(self, tmp_path: Path) -> None:
+        """Init prints no skip notice for any ruby pipeline step.
+
+        The pre-commit, scripts, and architecture steps gained ruby
+        support with #373 (CI has been real since the foundation), so
+        every "unavailable" notice must be gone.
+        """
+        runner = CliRunner()
+        with patch(
+            "start_green_stay_green.cli._initialize_orchestrator",
+            return_value=None,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "init",
+                    "--project-name",
+                    "skip-check",
+                    "--language",
+                    "ruby",
+                    "--output-dir",
+                    str(tmp_path),
+                    "--no-interactive",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Pre-commit config unavailable for ruby" not in result.output
+        assert "Quality scripts unavailable for ruby" not in result.output
+        assert "Architecture rules unavailable for ruby" not in result.output
+        assert "CI pipeline unavailable for ruby" not in result.output
+        assert "Generated CI pipeline" in result.output

--- a/tests/unit/generators/test_architecture.py
+++ b/tests/unit/generators/test_architecture.py
@@ -94,11 +94,15 @@ class TestArchitectureEnforcementGeneratorGenerate:
         assert dc_file.exists()
 
     def test_generate_raises_on_unsupported_language(self) -> None:
-        """Test generate raises ValueError for unsupported languages."""
+        """Test generate raises ValueError for unsupported languages.
+
+        ruby graduated to a real Packwerk config with #373, so the
+        probe uses php — a language with no architecture tooling.
+        """
         generator = ArchitectureEnforcementGenerator()
 
         with pytest.raises(ValueError, match="Unsupported language"):
-            generator.generate(language="ruby", project_name="test")
+            generator.generate(language="php", project_name="test")
 
     def test_generate_creates_readme_with_usage_instructions(
         self,
@@ -1603,6 +1607,154 @@ class TestArchitectureEnforcementGeneratorCsharp:
         assert result.language == "csharp"
 
 
+class TestArchitectureEnforcementGeneratorRuby:
+    """Test Ruby-specific architecture rules (#373)."""
+
+    @staticmethod
+    def _generate(tmp_path: Path, project_name: str = "my-gem") -> Path:
+        """Generate the Ruby architecture config and return its directory."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+        generator.generate(language="ruby", project_name=project_name)
+        return output_dir
+
+    def test_generate_ruby_creates_packwerk_configs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test generating the Packwerk configuration pair for Ruby."""
+        output_dir = self._generate(tmp_path)
+
+        assert (output_dir / "packwerk.yml").exists()
+        assert (output_dir / "package.yml").exists()
+
+        # Should create README and run script
+        assert (output_dir / "README.md").exists()
+        assert (output_dir / "run-check.sh").exists()
+
+    def test_ruby_packwerk_config_parses_as_yaml(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """packwerk.yml must parse as YAML with Packwerk's documented keys.
+
+        Parse-validation guardrail: every generated artifact must be
+        loadable by the tool that will read it.
+        """
+        output_dir = self._generate(tmp_path)
+
+        parsed = yaml.safe_load((output_dir / "packwerk.yml").read_text())
+        assert parsed["include"] == ["**/*.{rb,rake,erb}"]
+        assert parsed["package_paths"] == "**/"
+        assert parsed["parallel"] is True
+
+    def test_ruby_package_config_enforces_dependencies(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """package.yml parses as YAML and switches enforcement on."""
+        output_dir = self._generate(tmp_path)
+
+        parsed = yaml.safe_load((output_dir / "package.yml").read_text())
+        assert parsed["enforce_dependencies"] is True
+        assert parsed["dependencies"] == []
+
+    def test_ruby_config_documents_zeitwerk_limit(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The config discloses Packwerk's Zeitwerk assumption honestly.
+
+        Packwerk is built for Zeitwerk-style autoloaded codebases; on
+        the plain-Ruby scaffold the check passes vacuously until
+        packages are defined, and the config must say so (no
+        overclaiming) with a tighten-me path.
+        """
+        output_dir = self._generate(tmp_path)
+
+        content = (output_dir / "packwerk.yml").read_text()
+        assert "Zeitwerk" in content
+        assert "VACUOUSLY" in content
+        assert "Tighten" in content
+
+    def test_ruby_config_documents_static_analysis_limit(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The config discloses the static-analysis blind spot."""
+        output_dir = self._generate(tmp_path)
+
+        content = (output_dir / "packwerk.yml").read_text()
+        assert "STATIC" in content
+        assert "const_get" in content
+
+    def test_ruby_config_documents_circular_require_hazard(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The config explains Ruby's load-time behavior accurately.
+
+        Ruby's require does NOT reject circular requires at load time —
+        the cycle silently yields a partially-defined module at
+        runtime — so the config must document boundary enforcement as
+        the only early signal, without overclaiming a compiler-style
+        rejection.
+        """
+        output_dir = self._generate(tmp_path)
+
+        content = (output_dir / "packwerk.yml").read_text()
+        assert "NOT reject circular requires" in content
+        assert "partially-defined module" in content
+
+    def test_ruby_config_documents_wiring_requirement(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Both files document the copy-to-root activation step."""
+        output_dir = self._generate(tmp_path)
+
+        packwerk = (output_dir / "packwerk.yml").read_text()
+        package = (output_dir / "package.yml").read_text()
+        assert "cp plans/architecture/packwerk.yml" in packwerk
+        assert "bundle exec packwerk check" in packwerk
+        assert "project root" in package
+
+    def test_ruby_readme_mentions_packwerk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The architecture README names Packwerk and its docs."""
+        output_dir = self._generate(tmp_path)
+
+        content = (output_dir / "README.md").read_text()
+        assert "Packwerk" in content
+        assert "https://github.com/Shopify/packwerk" in content
+
+    def test_ruby_run_script_probes_bundler(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """run-check.sh guards on the bundle binary before running."""
+        output_dir = self._generate(tmp_path)
+
+        content = (output_dir / "run-check.sh").read_text()
+        assert "command -v bundle" in content
+        assert "bundle exec packwerk check" in content
+
+    def test_ruby_result_reports_ruby_language(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test the result object records the ruby language."""
+        output_dir = tmp_path / "plans" / "architecture"
+        generator = ArchitectureEnforcementGenerator(output_dir=output_dir)
+
+        result = generator.generate(language="ruby", project_name="my-gem")
+
+        assert result.language == "ruby"
+        assert len(result.files_created) == 4
+
+
 class TestArchitectureEnforcementGeneratorTypeScript:
     """Test TypeScript-specific architecture rules."""
 
@@ -1654,6 +1806,7 @@ class TestLanguageTooling:
             ("cpp", "C/C++"),
             ("java", "Java"),
             ("csharp", "C#"),
+            ("ruby", "Ruby"),
         ],
     )
     def test_each_tooling_carries_a_display_name(
@@ -1712,6 +1865,21 @@ class TestLanguageTooling:
         tooling = _LANGUAGE_TOOLING["csharp"]
         assert "{config_file}" not in tooling.run_cmd
         assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
+        assert "{package_path}" not in tooling.install_cmd
+
+    def test_ruby_install_cmd_carries_the_config_path(self) -> None:
+        """Ruby references its config via install_cmd, not run_cmd (#373).
+
+        Packwerk reads packwerk.yml from the working directory (no
+        config flag exists), so the run command takes no config-file
+        placeholder and the wiring step — copying packwerk.yml and the
+        root package.yml to the project root — lives in install_cmd,
+        the Konsist/ArchUnit/NetArchTest parked-template precedent.
+        """
+        tooling = _LANGUAGE_TOOLING["ruby"]
+        assert "{config_file}" not in tooling.run_cmd
+        assert f"plans/architecture/{tooling.config_file}" in tooling.install_cmd
+        assert "package.yml" in tooling.install_cmd
         assert "{package_path}" not in tooling.install_cmd
 
     def test_java_install_cmd_resolves_package_matched_path(self) -> None:
@@ -1797,6 +1965,6 @@ class TestLanguageTooling:
             result = generator.generate(language=language, project_name="myapp")
             assert result.language == language
 
-        assert "ruby" not in _LANGUAGE_TOOLING
+        assert "php" not in _LANGUAGE_TOOLING
         with pytest.raises(ValueError, match="Unsupported language"):
-            generator.generate(language="ruby", project_name="myapp")
+            generator.generate(language="php", project_name="myapp")

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -1135,12 +1135,21 @@ jobs:
         assert LANGUAGE_CONFIGS["ruby"]["formatters"] == ["rubocop"]
 
     def test_ruby_security_tools_exact(self) -> None:
-        """Test Ruby security_tools list is exact."""
-        assert LANGUAGE_CONFIGS["ruby"]["security_tools"] == ["brakeman"]
+        """Test Ruby security_tools list is exact.
+
+        bundler-audit owns the generated security gate (#373); Brakeman
+        is Rails-specific and errors on the plain-Ruby scaffold, so it
+        must not be advertised as wired tooling.
+        """
+        assert LANGUAGE_CONFIGS["ruby"]["security_tools"] == ["bundler-audit"]
 
     def test_ruby_supported_versions_exact(self) -> None:
-        """Test Ruby supported_versions list is exact."""
-        assert LANGUAGE_CONFIGS["ruby"]["supported_versions"] == ["3.1", "3.2"]
+        """Test Ruby supported_versions list is exact.
+
+        3.1 and 3.2 reached upstream EOL; 3.3/3.4 are the maintained
+        lines (verified against ruby-lang.org, 2026-06).
+        """
+        assert LANGUAGE_CONFIGS["ruby"]["supported_versions"] == ["3.3", "3.4"]
 
     def test_ruby_package_manager_exact(self) -> None:
         """Test Ruby package_manager is exactly bundler."""

--- a/tests/unit/generators/test_dependencies.py
+++ b/tests/unit/generators/test_dependencies.py
@@ -34,6 +34,12 @@ from start_green_stay_green.utils.kotlin import JUNIT_VERSION
 from start_green_stay_green.utils.kotlin import KONSIST_VERSION
 from start_green_stay_green.utils.kotlin import KOTLIN_VERSION
 from start_green_stay_green.utils.kotlin import KOVER_VERSION
+from start_green_stay_green.utils.ruby import BUNDLER_AUDIT_VERSION
+from start_green_stay_green.utils.ruby import PACKWERK_VERSION
+from start_green_stay_green.utils.ruby import RSPEC_VERSION
+from start_green_stay_green.utils.ruby import RUBOCOP_VERSION
+from start_green_stay_green.utils.ruby import SIMPLECOV_VERSION
+from start_green_stay_green.utils.ruby import ruby_gemfile
 from start_green_stay_green.utils.swift import package_swift
 
 # Expected primary dependency file per language
@@ -393,6 +399,48 @@ class TestMultiLanguageDependencies:
 
             content = files["Gemfile"].read_text()
             assert "source" in content
+
+    def test_ruby_gemfile_pins_quality_toolchain(self) -> None:
+        """The Gemfile wires the #373 quality gems with live pins.
+
+        rspec/simplecov/rubocop/bundler-audit/packwerk back the test,
+        coverage, lint/complexity, dependency-CVE, and architecture
+        gates; the pessimistic pins come from utils.ruby (verified
+        against rubygems.org).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = DependencyConfig(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = DependenciesGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["Gemfile"].read_text()
+            assert f'gem "rspec", "~> {RSPEC_VERSION}"' in content
+            assert f'gem "simplecov", "~> {SIMPLECOV_VERSION}"' in content
+            assert f'gem "rubocop", "~> {RUBOCOP_VERSION}"' in content
+            assert f'gem "bundler-audit", "~> {BUNDLER_AUDIT_VERSION}"' in content
+            assert f'gem "packwerk", "~> {PACKWERK_VERSION}"' in content
+
+    def test_ruby_gemfile_matches_structure_generator(self) -> None:
+        """The dependencies and structure generators emit one Gemfile.
+
+        Both delegate to utils.ruby.ruby_gemfile (#373) so the two can
+        never drift apart again (before #373 they emitted diverging
+        manifests with stale tool lines).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = DependencyConfig(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = DependenciesGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            assert files["Gemfile"].read_text() == ruby_gemfile()
 
     def test_swift_package_swift_has_manifest(self) -> None:
         """Test Swift Package.swift contains an SPM manifest for watchOS."""

--- a/tests/unit/generators/test_metrics.py
+++ b/tests/unit/generators/test_metrics.py
@@ -187,6 +187,7 @@ class TestLanguageTools:
             "cpp",
             "java",
             "csharp",
+            "ruby",
         }
         assert required_languages.issubset(set(LANGUAGE_TOOLS.keys()))
 
@@ -216,6 +217,48 @@ class TestLanguageTools:
             "complexity": {"CA1502"},
             "security": {"SecurityCodeScan"},
             "documentation": {"DocFX"},
+        }
+        for category, names in names_per_category.items():
+            for other_category, other_names in names_per_category.items():
+                if category != other_category:
+                    assert names.isdisjoint(other_names)
+            for name in names:
+                assert name in tools[category]
+
+    def test_ruby_tools(self) -> None:
+        """Test Ruby tool mappings (#373).
+
+        Each tool appears in exactly one category: SimpleCov owns
+        coverage (the >=90% bound lives in spec/spec_helper.rb),
+        RuboCop's Metrics/CyclomaticComplexity cop owns complexity
+        (threshold in .rubocop.yml), bundler-audit owns security
+        (dependency CVEs; Brakeman applies only once Rails is adopted),
+        `bundle outdated` owns dependency staleness, and mutant is a
+        periodic mutation gate like pitest/mull/muter/Stryker.
+        """
+        tools = LANGUAGE_TOOLS["ruby"]
+        assert tools["coverage"] == "SimpleCov (COVERAGE=true bundle exec rspec)"
+        assert tools["mutation"] == "mutant (bundle exec mutant run)"
+        assert tools["complexity"] == (
+            "RuboCop Metrics/CyclomaticComplexity (.rubocop.yml)"
+        )
+        assert tools["documentation"] == "YARD"
+        assert tools["security"] == "bundler-audit (bundle exec bundler-audit check)"
+        assert tools["dependency_check"] == "bundle outdated"
+
+    def test_ruby_tools_do_not_double_list_across_categories(self) -> None:
+        """No Ruby tool is claimed by two metric categories.
+
+        bundler-audit in particular owns exactly one category
+        (security); dependency staleness goes to `bundle outdated`.
+        """
+        tools = LANGUAGE_TOOLS["ruby"]
+        names_per_category = {
+            "coverage": {"SimpleCov"},
+            "complexity": {"Metrics/CyclomaticComplexity"},
+            "security": {"bundler-audit"},
+            "documentation": {"YARD"},
+            "dependency_check": {"bundle outdated"},
         }
         for category, names in names_per_category.items():
             for other_category, other_names in names_per_category.items():

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -1136,6 +1136,107 @@ class TestGenerateWithCsharp:
         assert any("shellcheck-py" in url for url in repo_urls)
 
 
+class TestGenerateWithRuby:
+    """Test content generation for Ruby projects (#373)."""
+
+    @staticmethod
+    def _parsed_repos(generator: PreCommitGenerator) -> list[dict[str, Any]]:
+        """Generate the ruby config and return its parsed repos list."""
+        config = GenerationConfig(
+            project_name="ruby-project",
+            language="ruby",
+            language_config={},
+        )
+        result = generator.generate(config)
+        yaml_content = "\n".join(
+            line for line in result["content"].split("\n") if not line.startswith("#")
+        )
+        parsed = yaml.safe_load(yaml_content)
+        return list(parsed["repos"])
+
+    def _rubocop_repo(self, generator: PreCommitGenerator) -> dict[str, Any]:
+        """Return the rubocop repo block from the ruby config."""
+        repos = self._parsed_repos(generator)
+        return next(repo for repo in repos if "rubocop/rubocop" in repo.get("repo", ""))
+
+    def test_generate_ruby_content_is_valid_yaml(self, mock_orchestrator: Mock) -> None:
+        """Generated ruby pre-commit config must be parseable YAML."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        assert isinstance(repos, list)
+        assert repos
+
+    def test_ruby_uses_the_official_rubocop_hook_repo(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """RuboCop comes from its official hook repo at a pinned tag.
+
+        rubocop/rubocop ships a .pre-commit-hooks.yaml at its repo root
+        (verified at the pinned tag), so unlike the other languages no
+        `repo: local` system hook is needed — pre-commit builds an
+        isolated gem environment from the tag, and the RuboCop version
+        can never drift from the rev.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        rubocop_repo = self._rubocop_repo(generator)
+        assert rubocop_repo["rev"].startswith("v")
+        hook_ids = {hook["id"] for hook in rubocop_repo["hooks"]}
+        assert hook_ids == {"rubocop"}
+
+    def test_ruby_rubocop_hook_is_check_mode(self, mock_orchestrator: Mock) -> None:
+        """The rubocop hook can actually fail on offenses.
+
+        The upstream manifest's DEFAULT args include --autocorrect — a
+        fixing mode that rewrites correctable offenses instead of
+        failing on them (the #430 formatter lesson). The hook must
+        override args so plain check-mode rubocop runs, exiting
+        non-zero on ANY offense; scripts/format.sh keeps the
+        --autocorrect fixing path.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        rubocop_repo = self._rubocop_repo(generator)
+        hook = next(h for h in rubocop_repo["hooks"] if h["id"] == "rubocop")
+        assert "--autocorrect" not in hook["args"]
+        assert "-a" not in hook["args"]
+        assert "--force-exclusion" in hook["args"]
+
+    def test_ruby_hook_restates_no_thresholds(self, mock_orchestrator: Mock) -> None:
+        """.rubocop.yml is the single home of the RuboCop policy.
+
+        The complexity bound (Metrics/CyclomaticComplexity <=10) and
+        every other cop setting live in the generated .rubocop.yml; the
+        hook must not restate any of it via CLI flags.
+        """
+        generator = PreCommitGenerator(mock_orchestrator)
+        rubocop_repo = self._rubocop_repo(generator)
+        hook = next(h for h in rubocop_repo["hooks"] if h["id"] == "rubocop")
+        assert not any("--only" in arg for arg in hook["args"])
+        assert not any("Metrics" in arg for arg in hook["args"])
+
+    def test_generate_ruby_includes_gitleaks(self, mock_orchestrator: Mock) -> None:
+        """ruby keeps the gitleaks hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("gitleaks" in url for url in repo_urls)
+
+    def test_generate_ruby_includes_detect_secrets(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """ruby keeps the detect-secrets hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("Yelp/detect-secrets" in url for url in repo_urls)
+
+    def test_generate_ruby_includes_shellcheck(self, mock_orchestrator: Mock) -> None:
+        """ruby keeps the shellcheck hook shared by every language."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        repos = self._parsed_repos(generator)
+        repo_urls = [repo.get("repo", "") for repo in repos]
+        assert any("shellcheck-py" in url for url in repo_urls)
+
+
 class TestValidateLanguage:
     """Test language validation functionality."""
 
@@ -1290,10 +1391,10 @@ class TestGetSupportedLanguages:
         assert "csharp" in result
 
     def test_get_supported_languages_exact_count(self, mock_orchestrator: Mock) -> None:
-        """Test get_supported_languages returns expected count."""
+        """get_supported_languages count is exact (ruby joined with #373)."""
         generator = PreCommitGenerator(mock_orchestrator)
         result = generator.get_supported_languages()
-        assert len(result) == 9
+        assert len(result) == 10
 
     def test_get_supported_languages_no_duplicates(
         self, mock_orchestrator: Mock

--- a/tests/unit/generators/test_readme.py
+++ b/tests/unit/generators/test_readme.py
@@ -709,6 +709,98 @@ class TestCsharpReadme:
             assert "src/Program.cs" in content or "Program.cs" in content
 
 
+class TestRubyReadme:
+    """Test the Ruby README content (#373)."""
+
+    @staticmethod
+    def _readme_content(tmpdir: str) -> str:
+        """Generate the ruby README and return its text.
+
+        Args:
+            tmpdir: Directory to generate into.
+
+        Returns:
+            The rendered README.md content.
+        """
+        config = ReadmeConfig(
+            project_name="test-project",
+            language="ruby",
+            package_name="test_project",
+        )
+        files = ReadmeGenerator(Path(tmpdir), config).generate()
+        readme_path: Path = files["README.md"]
+        return readme_path.read_text()
+
+    def test_ruby_readme_advertises_the_wired_quality_tooling(self) -> None:
+        """README advertises the #373 quality tooling as real.
+
+        With the #373 toolchain (the RuboCop pre-commit hook, quality
+        scripts, the SimpleCov coverage gate, the Packwerk architecture
+        configs) and the foundation CI pipeline both generated, every
+        advertised item is real — the Kotlin (#360) / C/C++ (#365) /
+        Java (#367) / C# (#370) precedent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert ".github/workflows/ci.yml" in content
+            assert "./scripts/check-all.sh" in content
+            assert "Packwerk" in content
+            assert "plans/architecture" in content
+            assert ".rubocop.yml" in content
+
+    def test_ruby_readme_documents_bundler_usage(self) -> None:
+        """README documents the bundler-driven quality commands."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "bundle install" in content
+            assert "bundle exec rspec" in content
+            assert "bundle exec rubocop" in content
+            assert "COVERAGE=true bundle exec rspec" in content
+
+    def test_ruby_readme_documents_threshold_homes(self) -> None:
+        """README points at the single homes of the numeric gates.
+
+        The >=90% coverage bound lives in spec/spec_helper.rb and the
+        <=10 complexity bound in .rubocop.yml; the README must direct
+        readers there rather than inventing a third home.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "spec_helper.rb" in content
+            assert "Metrics/CyclomaticComplexity" in content
+
+    def test_ruby_readme_structure_matches_generated_tree(self) -> None:
+        """README's structure block names only files init generates.
+
+        The truthfulness contract: the scaffold is lib/{package}.rb and
+        spec/{package}_spec.rb, no Gemfile.lock is generated, and Reek/
+        Sorbet/RBS are not wired — the pre-#373 README claimed all of
+        them.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "lib/main.rb" not in content
+            assert "main_spec.rb" not in content
+            assert "Gemfile.lock" not in content
+            assert "Reek" not in content
+            assert "Sorbet" not in content
+            assert "lib/test_project.rb" in content
+            assert "test_project_spec.rb" in content
+
+    def test_ruby_readme_is_honest_about_brakeman(self) -> None:
+        """Brakeman is documented as Rails-only, not advertised as wired.
+
+        brakeman errors on non-Rails projects, so the README must
+        position it as the add-on for when Rails is adopted while
+        bundler-audit is the real generated security gate.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            content = self._readme_content(tmpdir)
+            assert "bundler-audit" in content
+            assert "Brakeman" in content
+            assert "Rails" in content
+
+
 class TestCppReadme:
     """Test C/C++ Tizen-specific README content (#361/#362)."""
 

--- a/tests/unit/generators/test_scripts.py
+++ b/tests/unit/generators/test_scripts.py
@@ -1708,15 +1708,283 @@ class TestScriptsGeneratorCsharpGeneration:
             assert existing_metrics.read_text() == "CA1502: 25\n"
 
 
+class TestScriptsGeneratorRubyGeneration:
+    """Test Ruby script generation (#373)."""
+
+    @staticmethod
+    def _generate(tmpdir: str) -> dict[str, Path]:
+        """Generate ruby scripts into ``tmpdir`` and return the mapping."""
+        config = ScriptConfig(
+            language="ruby",
+            package_name="my_gem",
+        )
+        generator = ScriptsGenerator(Path(tmpdir), config)
+        return generator.generate()
+
+    def test_generate_ruby_scripts_creates_files(self) -> None:
+        """Test generate creates the full ruby script set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            assert "check-all.sh" in scripts
+            assert "format.sh" in scripts
+            assert "lint.sh" in scripts
+            assert "test.sh" in scripts
+            assert "security.sh" in scripts
+
+    def test_ruby_shell_scripts_pass_bash_syntax_check(self) -> None:
+        """Every generated ruby shell script parses under bash -n.
+
+        The #362 lesson: this literal syntax check caught a real
+        template-escaping bug in the cpp scripts, so every new language
+        gets it from day one.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            for name, path in scripts.items():
+                if not name.endswith(".sh"):
+                    continue
+                bash = shutil.which("bash")
+                assert bash is not None, "bash not found on PATH"
+                result = subprocess.run(  # noqa: S603  # Issue #373: bash -n on generated content, no untrusted input
+                    [bash, "-n", str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, f"{name}: {result.stderr}"
+
+    def test_ruby_shell_scripts_pass_shellcheck(self) -> None:
+        """Every generated ruby shell script is clean under shellcheck.
+
+        bash -n only catches parse errors; shellcheck catches the
+        quoting/expansion bugs that have bitten generated scripts
+        before (#425/SC2059), so the linter itself gates the templates.
+        Skips only when shellcheck is not installed (it ships on the
+        GitHub ubuntu runners and via shellcheck-py in pre-commit).
+        """
+        shellcheck = shutil.which("shellcheck")
+        if shellcheck is None:
+            pytest.skip("shellcheck not on PATH (covered in CI)")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            for name, path in scripts.items():
+                if not name.endswith(".sh"):
+                    continue
+                result = subprocess.run(  # noqa: S603  # Issue #373: shellcheck on generated content, no untrusted input
+                    [shellcheck, str(path)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, f"{name}: {result.stdout}"
+
+    def test_ruby_format_script_owns_the_fixing_path(self) -> None:
+        """format.sh fixes with --autocorrect; the hook stays check-mode.
+
+        The issue's "--autocorrect" belongs here, in the fixing path —
+        NOT in the pre-commit hook, where a fixing-mode formatter could
+        never fail a commit (the #430 lesson).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "bundle exec rubocop --autocorrect" in content
+
+    def test_ruby_format_check_mode_runs_the_layout_slice(self) -> None:
+        """--check verifies the Layout (formatting) cop department only.
+
+        lint.sh owns the full cop set, so the two checks in
+        check-all.sh never double-report the same offenses.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "bundle exec rubocop --only Layout" in content
+
+    def test_ruby_format_script_requires_bundler(self) -> None:
+        """format.sh fails with install instructions when bundler is absent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["format.sh"].read_text()
+            assert "command -v bundle" in content
+            assert "gem install bundler" in content
+
+    def test_ruby_lint_script_runs_full_rubocop_with_config_owned_policy(
+        self,
+    ) -> None:
+        """lint.sh is a plain full RuboCop run; .rubocop.yml owns the policy.
+
+        The complexity bound, the Security cop department, and every
+        style decision live in the companion config — the script must
+        not restate any threshold via CLI flags.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "bundle exec rubocop --force-exclusion" in content
+            assert ".rubocop.yml" in content
+            assert "--only" not in content.replace("--only Layout", "")
+            assert "MAX_CCN" not in content
+
+    def test_ruby_lint_script_documents_complexity_and_flog_alternative(
+        self,
+    ) -> None:
+        """The <=10 ceiling lives once, in .rubocop.yml.
+
+        Metrics/CyclomaticComplexity owns the gate; flog is named as
+        the documented standalone alternative without being wired, so
+        the bound keeps a single home.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["lint.sh"].read_text()
+            assert "Metrics/CyclomaticComplexity" in content
+            assert "flog" in content
+
+    def test_ruby_test_script_runs_rspec(self) -> None:
+        """test.sh runs the suite via plain `bundle exec rspec`.
+
+        The literal string `rspec` doubles as the language marker
+        cli._scripts_dir_has_other_language probes for ruby.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "bundle exec rspec" in content
+            assert "command -v bundle" in content
+
+    def test_ruby_test_script_enforces_coverage_via_spec_helper_gate(self) -> None:
+        """Coverage mode sets COVERAGE=true; the bound stays in spec_helper.
+
+        SimpleCov hooks rspec's exit, so a missed bound fails the
+        invocation directly (no standalone-report no-op path). The
+        >=90% number lives only in spec/spec_helper.rb, so the script
+        must not restate it.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["test.sh"].read_text()
+            assert "COVERAGE=true bundle exec rspec" in content
+            assert "spec/spec_helper.rb" in content
+            assert "THRESHOLD=" not in content
+            assert "--minimum-coverage" not in content
+
+    def test_ruby_security_script_gates_on_bundler_audit(self) -> None:
+        """security.sh owns dependency CVEs via bundler-audit."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "bundle exec bundler-audit update" in content
+            assert "bundle exec bundler-audit check" in content
+
+    def test_ruby_security_script_warns_when_offline(self) -> None:
+        """The advisory-db update needs the network; offline warns, not fails.
+
+        bundler-audit checks against the ruby-advisory-db, which must
+        be fetched over the network, so the pragmatic warn-first
+        default skips with a documented tighten-me path instead of
+        failing a fresh offline clone — the NVD_API_KEY precedent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "network" in content
+            assert "Tighten" in content
+
+    def test_ruby_security_script_documents_division_of_labor(self) -> None:
+        """security.sh discloses where the other security passes live.
+
+        Source-level security is RuboCop's Security cop department
+        (inside lint.sh's full run); Brakeman is documented as the
+        Rails-only deeper scanner rather than wired into a plain-Ruby
+        scaffold where it can only error.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["security.sh"].read_text()
+            assert "gitleaks" in content
+            assert "detect-secrets" in content
+            assert "Security cop" in content
+            assert "Brakeman" in content
+            assert "Rails" in content
+
+    def test_ruby_check_all_runs_full_toolchain(self) -> None:
+        """check-all.sh runs format check, lint, coverage-gated tests, security."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts = self._generate(tmpdir)
+
+            content = scripts["check-all.sh"].read_text()
+            assert 'run_check "Format" "format.sh" --check' in content
+            assert 'run_check "Linting" "lint.sh"' in content
+            assert 'run_check "Tests" "test.sh" --coverage' in content
+            assert 'run_check "Security" "security.sh"' in content
+
+    def test_ruby_writes_rubocop_config_companion(self) -> None:
+        """.rubocop.yml lands at the project root with the <=10 bound.
+
+        The companion is the single home of the RuboCop policy shared
+        by the pre-commit hook, format.sh, lint.sh, and CI; it must
+        parse as YAML (the parse-validation guardrail).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            config = Path(tmpdir) / ".rubocop.yml"
+            assert config.exists()
+            parsed = yaml.safe_load(config.read_text())
+            assert parsed["Metrics/CyclomaticComplexity"]["Max"] == 10
+            assert parsed["AllCops"]["NewCops"] == "enable"
+
+    def test_ruby_rubocop_config_excludes_specs_from_block_length(self) -> None:
+        """RSpec files are excluded from Metrics/BlockLength.
+
+        RSpec example groups are naturally long blocks; without the
+        exclusion the scaffold's own spec files would fail the lint
+        gate out of the box.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._generate(tmpdir)
+
+            parsed = yaml.safe_load((Path(tmpdir) / ".rubocop.yml").read_text())
+            assert "spec/**/*" in parsed["Metrics/BlockLength"]["Exclude"]
+
+    def test_ruby_companion_preserves_existing_file(self) -> None:
+        """An existing user .rubocop.yml is never overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing = Path(tmpdir) / ".rubocop.yml"
+            existing.write_text("AllCops:\n  NewCops: disable\n")
+
+            self._generate(tmpdir)
+
+            assert existing.read_text() == "AllCops:\n  NewCops: disable\n"
+
+
 class TestScriptsGeneratorLanguageFallback:
     """Test language fallback behavior."""
 
     def test_unknown_language_falls_back_to_python(self) -> None:
-        """Test unknown language falls back to Python scripts."""
+        """Test unknown language falls back to Python scripts.
+
+        ruby graduated to its own template set with #373, so the probe
+        uses php — a language with no native script templates.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             config = ScriptConfig(
-                language="ruby",
-                package_name="my_gem",
+                language="php",
+                package_name="my_package",
             )
             generator = ScriptsGenerator(Path(tmpdir), config)
             scripts = generator.generate()
@@ -2026,6 +2294,20 @@ class TestMutationKillers:
             # Should generate csharp scripts with the dotnet CLI gates
             content = scripts["lint.sh"].read_text()
             assert "dotnet build" in content
+
+    def test_ruby_language_dispatches_to_ruby_generator(self) -> None:
+        """Test 'ruby' language dispatches to the Ruby generator (#373)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(
+                language="ruby",
+                package_name="test",
+            )
+            generator = ScriptsGenerator(Path(tmpdir), config)
+            scripts = generator.generate()
+
+            # Should generate ruby scripts with the bundler-driven gates
+            content = scripts["lint.sh"].read_text()
+            assert "bundle exec rubocop" in content
 
     def test_generated_scripts_exact_count_python(self) -> None:
         """Test Python generator creates EXACTLY 12 scripts.

--- a/tests/unit/generators/test_structure.py
+++ b/tests/unit/generators/test_structure.py
@@ -11,6 +11,7 @@ from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.structure import StructureConfig
 from start_green_stay_green.generators.structure import StructureGenerator
 from start_green_stay_green.utils.cpp import tizen_app_id
+from start_green_stay_green.utils.ruby import ruby_module_name
 from start_green_stay_green.utils.swift import package_swift
 
 # Expected source directories per language
@@ -512,6 +513,50 @@ class TestMultiLanguageStructure:
             assert "Gemfile" in files
             content = files["Gemfile"].read_text()
             assert "source" in content
+
+    def test_ruby_lib_module_uses_shared_naming_helper(self) -> None:
+        """The lib module declares the ruby_module_name constant (#373).
+
+        The RSpec scaffold describes the same constant via the shared
+        helper, so the two can never drift apart (the pre-#373 drift —
+        per-word capitalization here, ``capitalize()`` in the spec —
+        was a guaranteed NameError in the generated project).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["lib/test_project.rb"].read_text()
+            assert f"module {ruby_module_name('test_project')}" in content
+            assert "def self.hello" in content
+
+    def test_ruby_lib_module_carries_documentation_comment(self) -> None:
+        """The module has a doc comment so Style/Documentation passes.
+
+        RuboCop's Style/Documentation cop (on by default, and the
+        generated .rubocop.yml keeps it on) requires a comment above
+        top-level module definitions; the scaffold must be green out
+        of the box (#373).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = StructureConfig(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = StructureGenerator(Path(tmpdir), config)
+            files = generator.generate()
+
+            lines = files["lib/test_project.rb"].read_text().splitlines()
+            module_index = next(
+                i for i, line in enumerate(lines) if line.startswith("module ")
+            )
+            assert lines[module_index - 1].startswith("#")
 
     def test_swift_creates_package_swift(self) -> None:
         """Test Swift generates an SPM Package.swift manifest."""

--- a/tests/unit/generators/test_tests_generator.py
+++ b/tests/unit/generators/test_tests_generator.py
@@ -9,6 +9,7 @@ import pytest
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.tests_gen import TestsConfig as Config
 from start_green_stay_green.generators.tests_gen import TestsGenerator as Generator
+from start_green_stay_green.utils.ruby import ruby_module_name
 
 # Expected test file patterns per language
 EXPECTED_TEST_FILES: dict[str, list[str]] = {
@@ -448,6 +449,49 @@ class TestMultiLanguageTests:
 
             content = files["spec/test_project_spec.rb"].read_text()
             assert "describe" in content or "RSpec.describe" in content
+
+    def test_ruby_spec_describes_the_scaffolded_module(self) -> None:
+        """The spec describes the constant the lib file declares (#373).
+
+        Both sides derive the name from utils.ruby.ruby_module_name and
+        the spec exercises ``.hello`` — the method the structure
+        scaffold actually defines (the pre-#373 spec called ``.main``
+        on a constant that did not exist).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["spec/test_project_spec.rb"].read_text()
+            assert f"RSpec.describe {ruby_module_name('test_project')}" in content
+            assert "described_class.hello" in content
+            assert ".main" not in content
+
+    def test_ruby_spec_helper_owns_the_coverage_bound(self) -> None:
+        """spec_helper.rb is the single home of the >=90% bound (#373).
+
+        SimpleCov starts only when COVERAGE is set (scripts/test.sh
+        --coverage), so a plain rspec run stays fast while the gated
+        run fails the invocation directly when the bound is missed.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = Config(
+                project_name="test-project",
+                language="ruby",
+                package_name="test_project",
+            )
+            generator = Generator(Path(tmpdir), config)
+            files = generator.generate()
+
+            content = files["spec/spec_helper.rb"].read_text()
+            assert 'if ENV["COVERAGE"]' in content
+            assert 'require "simplecov"' in content
+            assert "minimum_coverage 90" in content
 
     def test_swift_test_has_xctest_case(self) -> None:
         """Test Swift test file uses XCTest with an XCTestCase subclass."""

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1546,7 +1546,7 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_architecture_step(mock_path, "my-project", "ruby")
+            cli._generate_architecture_step(mock_path, "my-project", "php")
 
         mock_generator.generate.assert_not_called()
 

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -8,9 +8,9 @@ from start_green_stay_green.cli import _get_setup_instructions
 from start_green_stay_green.cli import _venv_activation_command
 
 # Languages exercised by the per-language common-tail tests. The
-# unknown-language default path is covered separately with "ruby"
+# unknown-language default path is covered separately with "php"
 # (java gained its own Maven step with #366, csharp its dotnet step
-# with #371).
+# with #371, ruby its bundler steps with #373).
 ALL_LANGUAGES = (
     "python",
     "typescript",
@@ -21,6 +21,7 @@ ALL_LANGUAGES = (
     "cpp",
     "java",
     "csharp",
+    "ruby",
 )
 
 
@@ -237,10 +238,26 @@ class TestGetSetupInstructions:
         assert not any("dotnet restore" in c for c in instructions)
         assert not any("dotnet build" in c for c in instructions)
 
-    def test_unknown_language_has_sensible_default(self) -> None:
-        """Unknown languages should still get pre-commit + check-all."""
+    def test_ruby_includes_bundler_steps(self) -> None:
+        """Ruby instructions provision gems and verify the scaffold (#373).
+
+        `bundle install` provisions the pinned quality gems and
+        `bundle exec rspec` verifies the scaffold — the csharp #371
+        lesson: a supported language must not sit on the
+        unknown-language default path.
+        """
         instructions = _get_setup_instructions(("ruby",), Path("/home/user/ruby-proj"))
-        assert instructions[0] == "cd /home/user/ruby-proj"
+        assert "bundle install" in instructions
+        assert "bundle exec rspec" in instructions
+
+    def test_unknown_language_has_sensible_default(self) -> None:
+        """Unknown languages should still get pre-commit + check-all.
+
+        ruby gained its own bundler steps with #373, so the probe uses
+        php — a language with no setup-step entry.
+        """
+        instructions = _get_setup_instructions(("php",), Path("/home/user/php-proj"))
+        assert instructions[0] == "cd /home/user/php-proj"
         assert "pre-commit install" in instructions
         assert "./scripts/check-all.sh" in instructions
 

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -349,13 +349,13 @@ class TestSequentialLanguageDetection:
 class TestGeneratorOnlyLanguagePipelineGates:
     """Pipeline steps skip gracefully for generator-only languages (#356).
 
-    ruby has structure/dependencies/tests/readme generators but no
-    pre-commit/scripts/metrics/architecture support — instead of
-    crashing init, those tooling steps must no-op with an informational
-    message. Kotlin graduated from this set when #357 wired its quality
-    tooling and #358 wired its CI workflow; java graduated with #367
-    (its CI workflow has been real since #366); csharp graduated with
-    #370 (its CI workflow has been real since the foundation scaffold).
+    A language outside the supported pipeline set must not crash init:
+    the tooling steps no-op with an informational message. Every
+    base.SUPPORTED_LANGUAGES entry now runs the full pipeline — Kotlin
+    graduated when #357 wired its quality tooling and #358 its CI
+    workflow; java with #367 (CI real since #366); csharp with #370;
+    ruby with #373 — so the skip path is probed with php, a language
+    with reference assets but no pipeline support.
     """
 
     def test_precommit_step_writes_for_kotlin(self, tmp_path: Path) -> None:
@@ -366,9 +366,17 @@ class TestGeneratorOnlyLanguagePipelineGates:
         assert config.exists()
         assert "ktlint" in config.read_text()
 
-    def test_precommit_step_skips_ruby_without_writing(self, tmp_path: Path) -> None:
-        """No .pre-commit-config.yaml is written and no error is raised."""
+    def test_precommit_step_writes_for_ruby(self, tmp_path: Path) -> None:
+        """Ruby now generates a pre-commit config (#373)."""
         cli_mod._generate_precommit_step(tmp_path, "my-project", "ruby")
+
+        config = tmp_path / ".pre-commit-config.yaml"
+        assert config.exists()
+        assert "rubocop" in config.read_text()
+
+    def test_precommit_step_skips_php_without_writing(self, tmp_path: Path) -> None:
+        """No .pre-commit-config.yaml is written and no error is raised."""
+        cli_mod._generate_precommit_step(tmp_path, "my-project", "php")
 
         assert not (tmp_path / ".pre-commit-config.yaml").exists()
 
@@ -386,11 +394,19 @@ class TestGeneratorOnlyLanguagePipelineGates:
         assert test_script.exists()
         assert "gradlew" in test_script.read_text()
 
-    def test_scripts_step_skips_ruby_without_python_fallback(
+    def test_scripts_step_writes_ruby_scripts(self, tmp_path: Path) -> None:
+        """Ruby now receives its own quality scripts (#373)."""
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "ruby")
+
+        test_script = tmp_path / "scripts" / "test.sh"
+        assert test_script.exists()
+        assert "rspec" in test_script.read_text()
+
+    def test_scripts_step_skips_php_without_python_fallback(
         self, tmp_path: Path
     ) -> None:
-        """Ruby must not receive the Python-fallback quality scripts."""
-        cli_mod._generate_scripts_step(tmp_path, "my-project", "ruby")
+        """PHP must not receive the Python-fallback quality scripts."""
+        cli_mod._generate_scripts_step(tmp_path, "my-project", "php")
 
         assert not (tmp_path / "scripts").exists()
 
@@ -408,9 +424,15 @@ class TestGeneratorOnlyLanguagePipelineGates:
 
         assert (tmp_path / "docs" / "metrics.json").exists()
 
-    def test_metrics_step_skips_ruby_without_dashboard(self, tmp_path: Path) -> None:
-        """No metrics dashboard is written for unsupported languages."""
+    def test_metrics_step_writes_ruby_dashboard(self, tmp_path: Path) -> None:
+        """The metrics dashboard is now generated for ruby (#373)."""
         cli_mod._generate_metrics_dashboard_step(tmp_path, "my-project", "ruby")
+
+        assert (tmp_path / "docs" / "metrics.json").exists()
+
+    def test_metrics_step_skips_php_without_dashboard(self, tmp_path: Path) -> None:
+        """No metrics dashboard is written for unsupported languages."""
+        cli_mod._generate_metrics_dashboard_step(tmp_path, "my-project", "php")
 
         assert not (tmp_path / "docs" / "metrics.json").exists()
 
@@ -420,9 +442,16 @@ class TestGeneratorOnlyLanguagePipelineGates:
 
         assert (tmp_path / "plans" / "architecture" / "ArchitectureTest.kt").exists()
 
-    def test_architecture_step_skips_ruby(self, tmp_path: Path) -> None:
-        """No architecture rules are generated for unsupported languages."""
+    def test_architecture_step_writes_ruby_rules(self, tmp_path: Path) -> None:
+        """Architecture rules are now generated for ruby (#373)."""
         cli_mod._generate_architecture_step(tmp_path, "my-project", "ruby")
+
+        assert (tmp_path / "plans" / "architecture" / "packwerk.yml").exists()
+        assert (tmp_path / "plans" / "architecture" / "package.yml").exists()
+
+    def test_architecture_step_skips_php(self, tmp_path: Path) -> None:
+        """No architecture rules are generated for unsupported languages."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "php")
 
         assert not (tmp_path / "plans" / "architecture").exists()
 

--- a/tests/unit/utils/test_ruby.py
+++ b/tests/unit/utils/test_ruby.py
@@ -1,0 +1,127 @@
+"""Tests for the Ruby naming helper, gem pins, and Gemfile source (#373).
+
+The :func:`ruby_module_name` helper is the single source of truth for
+the CamelCase module name shared by the structure and tests
+generators, so the scaffolded ``module`` declaration and the constant
+the RSpec scaffold describes can never drift apart. The
+:func:`ruby_gemfile` helper is likewise the one home of the generated
+Gemfile, shared by the structure and dependencies generators.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from start_green_stay_green.utils import ruby
+
+
+class TestRubyModuleName:
+    """Tests for ruby_module_name sanitization rules."""
+
+    @pytest.mark.parametrize(
+        ("package_name", "expected"),
+        [
+            ("wrist_ledger", "WristLedger"),
+            ("test_project", "TestProject"),
+            ("myapp", "Myapp"),
+            ("my-app", "MyApp"),
+            ("My_App", "MyApp"),
+        ],
+    )
+    def test_camel_case_module_name(self, package_name: str, expected: str) -> None:
+        """Snake/kebab-case package names become CamelCase module names."""
+        assert ruby.ruby_module_name(package_name) == expected
+
+    def test_leading_digit_gets_app_prefix(self) -> None:
+        """A Ruby constant cannot start with a digit."""
+        result = ruby.ruby_module_name("2048_game")
+        assert not result[0].isdigit()
+        assert result == "App2048Game"
+
+    def test_empty_input_falls_back_to_app(self) -> None:
+        """A name with no usable characters falls back to ``App``."""
+        assert ruby.ruby_module_name("---") == "App"
+
+    def test_invalid_characters_are_dropped(self) -> None:
+        """Characters invalid in a Ruby constant are treated as separators."""
+        assert ruby.ruby_module_name("my.app!name") == "MyAppName"
+
+
+class TestGemVersionPins:
+    """The pinned gem constraints exist and follow version shapes."""
+
+    @pytest.mark.parametrize(
+        "constant",
+        [
+            "RAKE_VERSION",
+            "RSPEC_VERSION",
+            "SIMPLECOV_VERSION",
+            "RUBOCOP_VERSION",
+            "BUNDLER_AUDIT_VERSION",
+            "PACKWERK_VERSION",
+        ],
+    )
+    def test_pin_is_a_dotted_version_string(self, constant: str) -> None:
+        """Every pin is a non-empty dotted version string."""
+        value = getattr(ruby, constant)
+        assert isinstance(value, str)
+        parts = value.split(".")
+        assert len(parts) >= 2
+        assert all(part.isdigit() for part in parts)
+
+    def test_rubocop_pin_is_current_stable_line(self) -> None:
+        """RuboCop pins the live-verified stable line (2026-06: 1.87.0)."""
+        assert ruby.RUBOCOP_VERSION == "1.87"
+
+    def test_rspec_pin_is_current_stable_line(self) -> None:
+        """RSpec pins the live-verified stable line (2026-06: 3.13.2)."""
+        assert ruby.RSPEC_VERSION == "3.13"
+
+    def test_packwerk_pin_is_current_stable_line(self) -> None:
+        """Packwerk pins the live-verified stable line (2026-06: 3.3.0)."""
+        assert ruby.PACKWERK_VERSION == "3.3"
+
+
+class TestRubyGemfile:
+    """Tests for the canonical Gemfile content."""
+
+    def test_gemfile_sources_rubygems(self) -> None:
+        """The Gemfile pulls from rubygems.org with frozen literals."""
+        content = ruby.ruby_gemfile()
+        assert content.startswith("# frozen_string_literal: true")
+        assert 'source "https://rubygems.org"' in content
+
+    @pytest.mark.parametrize(
+        ("gem_name", "version"),
+        [
+            ("rake", ruby.RAKE_VERSION),
+            ("rspec", ruby.RSPEC_VERSION),
+            ("simplecov", ruby.SIMPLECOV_VERSION),
+            ("rubocop", ruby.RUBOCOP_VERSION),
+            ("bundler-audit", ruby.BUNDLER_AUDIT_VERSION),
+            ("packwerk", ruby.PACKWERK_VERSION),
+        ],
+    )
+    def test_gemfile_pins_quality_toolchain(self, gem_name: str, version: str) -> None:
+        """Every quality gem is declared with its pessimistic pin."""
+        content = ruby.ruby_gemfile()
+        assert f'gem "{gem_name}", "~> {version}"' in content
+
+    def test_gemfile_excludes_rails_only_brakeman(self) -> None:
+        """Brakeman is Rails-specific and must not break the scaffold.
+
+        ``brakeman`` exits with an error when pointed at a non-Rails
+        project, so wiring it into a plain-Ruby scaffold would emit a
+        tool that can never pass; the Gemfile documents it as the
+        add-on for when Rails is adopted instead.
+        """
+        content = ruby.ruby_gemfile()
+        assert 'gem "brakeman"' not in content
+        assert "Brakeman" in content
+
+    def test_quality_gems_are_development_group_only(self) -> None:
+        """Quality tooling lives in the development/test group."""
+        content = ruby.ruby_gemfile()
+        group_index = content.index("group :development, :test do")
+        for gem_name in ("rspec", "rubocop", "simplecov", "bundler-audit"):
+            assert content.index(f'gem "{gem_name}"') > group_index


### PR DESCRIPTION
## Summary

Wires the Ruby quality toolchain across all four generators — the sixth language on the proven shape, with two findings worth note:

- **Foundation coherence glue** (the established uncompilable-scaffold class): the spec and lib disagreed on the module name (capitalize vs per-word) AND the method (`.main` vs `.hello`) — a guaranteed `NameError`; two diverging Gemfiles drifted between generators. New `utils/ruby.py` (`ruby_module_name`, shared `ruby_gemfile`, live-verified gem pins) is now the single source.
- **precommit.py** — rubocop/rubocop ships an **official pre-commit hooks manifest** (verified live; the first language in the matrix with one). The default hook args include `--autocorrect`, so the generated hook overrides to check-mode that actually fails (`--force-exclusion` only) — the #430 formatter lesson; `format.sh` owns the fixing path.
- **scripts.py** — SimpleCov ≥90% with the bound's single home in `spec_helper.rb` (`minimum_coverage 90`, COVERAGE-gated; no surface restates the number, no empty-report path). Complexity ≤10 via `Metrics/CyclomaticComplexity` in the `.rubocop.yml` companion. **Brakeman deliberately not wired** — it errors on non-Rails projects; documented on every surface as the Rails add-on, with bundler-audit as the real CVE gate (warn-and-skip offline). All scripts bash-n + shellcheck clean, test-pinned.
- **architecture.py** — **Packwerk** as parked templates (`packwerk.yml` + `package.yml`, the Konsist precedent), with accurate limits: static constant-reference analysis, the Zeitwerk assumption (vacuous pass on the flat scaffold, tighten-me included), and the correct Ruby claim — `require` does not reject circular requires at load time, so `packwerk validate` is the only early cycle signal.
- **Reference CI surgical fixes** (test-pinned): EOL ruby 3.1/3.2 → 3.3/3.4 (verified), the never-wired Reek step removed, the bogus `rspec --minimum-coverage` flag removed (no such flag exists), Brakeman → bundler-audit, Codecov → `@v6` best-effort (the #435 note applied), and the gemspec-build job removed (the scaffold ships no gemspec).
- **cli.py** — `_LANG_SETUP_STEPS["ruby"]` added (the #371 unknown-path lesson); unknown-language probes that used "ruby" switched intent-preserving to "php".

## Test plan

- TDD: **111 new/flipped tests** — a 36-test ruby init integration suite, 26 utils tests, per-generator classes including bash-n/shellcheck/companion-preservation pins, parse-validation throughout; generated config passes `pre-commit validate-config`.
- `./scripts/check-all.sh`: all 7 checks pass — **2,644 unit+integration tests, 26 e2e**, coverage **95.07%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

## Boundaries

#374 (tests/reference-script pins) and #375 (docs) remain.

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
