### PR TITLE
test(ruby): fill cross-language matrix gaps and pin the reference assets (#374)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1767
+        "line_number": 1782
       }
     ]
   },
-  "generated_at": "2026-06-11T00:25:17Z"
+  "generated_at": "2026-06-11T05:59:49Z"
 }

--- a/reference/scripts/ruby/lint.sh
+++ b/reference/scripts/ruby/lint.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "=== Running Ruby Linters ==="
+# RuboCop's full cop set IS the lint gate: Lint/Style departments, the
+# Metrics/CyclomaticComplexity <=10 ceiling, and the Security cops all
+# live in .rubocop.yml (the single home of the policy), so this
+# invocation restates none of it — parity with the generated
+# scripts/lint.sh and reference/ci/ruby.yml. Reek and Brakeman are
+# deliberately absent: neither gem is in the generated Gemfile, and
+# Brakeman is Rails-specific (it errors on plain-Ruby projects) — add
+# them to the Gemfile first if the project adopts them.
 echo "Running RuboCop..."
-bundle exec rubocop
-echo "Running Reek..."
-bundle exec reek
-echo "Running Brakeman..."
-bundle exec brakeman --no-pager
+bundle exec rubocop --force-exclusion
 echo "✓ All linters passed!"

--- a/reference/scripts/ruby/test.sh
+++ b/reference/scripts/ruby/test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "=== Running Ruby Tests ==="
-bundle exec rspec --format documentation --require simplecov --minimum-coverage 90
+# COVERAGE=true activates the SimpleCov gate; the >=90% line bound
+# lives in spec/spec_helper.rb (its single home), so this invocation
+# enforces it without restating the number — parity with the generated
+# scripts/test.sh and reference/ci/ruby.yml. SimpleCov's at_exit hook
+# fails the rspec run directly when the bound is missed.
+COVERAGE=true bundle exec rspec --format documentation
 echo "✓ Tests passed with required coverage!"

--- a/tests/integration/generators/test_precommit_integration.py
+++ b/tests/integration/generators/test_precommit_integration.py
@@ -102,6 +102,7 @@ class TestPreCommitGeneratorIntegration:
             "cpp",
             "java",
             "csharp",
+            "ruby",
         ]
 
         for language in languages:

--- a/tests/unit/generators/test_ci.py
+++ b/tests/unit/generators/test_ci.py
@@ -2434,3 +2434,175 @@ class TestCsharpReferenceTemplate:
         run_commands = _all_run_commands(parsed)
         assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
         assert not any("GITHUB_PATH" in cmd for cmd in run_commands)
+
+
+class TestRubyReferenceTemplate:
+    """Tests for the Ruby reference CI workflow (#373/#374).
+
+    The ruby scaffold is a plain-Ruby (non-Rails, non-gem) project
+    whose quality policy lives in two single homes: .rubocop.yml
+    (format/lint/complexity/security cops) and spec/spec_helper.rb
+    (the SimpleCov >=90% line-coverage bound). Every assertion here
+    checks that the workflow runs thin bundle invocations against that
+    policy and restates none of it — the same manifest-owned shape the
+    Kotlin/Java/C# workflows follow.
+    """
+
+    @pytest.fixture
+    def ruby_workflow(self) -> CIWorkflow:
+        """Render the deterministic Ruby reference workflow."""
+        return CIGenerator(language="ruby").generate_workflow_from_template()
+
+    def test_workflow_is_valid_yaml(self, ruby_workflow: CIWorkflow) -> None:
+        """Rendered workflow parses with yaml.safe_load and validates."""
+        parsed = yaml.safe_load(ruby_workflow.content)
+        assert ruby_workflow.is_valid
+        assert isinstance(parsed, dict)
+        assert parsed["name"] == "Ruby Quality Checks"
+
+    def test_workflow_has_only_the_quality_job(self, ruby_workflow: CIWorkflow) -> None:
+        """Workflow declares exactly the quality job — no packaging.
+
+        The generated scaffold is a plain-Ruby project without a
+        .gemspec, so a `gem build` job would be red on every push;
+        packaging arrives together with the gemspec.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        assert set(parsed["jobs"]) == {"quality"}
+
+    def test_quality_job_runs_on_ubuntu(self, ruby_workflow: CIWorkflow) -> None:
+        """The quality job runs on ubuntu: MRI Ruby needs no macOS."""
+        parsed = yaml.safe_load(ruby_workflow.content)
+        assert parsed["jobs"]["quality"]["runs-on"] == "ubuntu-latest"
+
+    def test_ruby_matrix_runs_only_maintained_lines(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """The quality job matrixes over exactly the 3.3/3.4 lines.
+
+        These are the Ruby lines still receiving upstream maintenance
+        (3.1/3.2 reached EOL; verified against ruby-lang.org's branch
+        table, 2026-06); the matrix bumps together with
+        LANGUAGE_CONFIGS["ruby"]["supported_versions"] and the
+        generated .rubocop.yml's TargetRubyVersion.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        matrix = parsed["jobs"]["quality"]["strategy"]["matrix"]
+        assert matrix["ruby-version"] == ["3.3", "3.4"]
+
+    def test_setup_actions_are_pinned_to_majors(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """checkout and setup-ruby are pinned to major versions."""
+        content = ruby_workflow.content
+        assert "actions/checkout@v4" in content
+        assert "ruby/setup-ruby@v1" in content
+
+    def test_setup_ruby_installs_gems_via_bundler_cache(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """setup-ruby's bundler-cache owns the install — no extra step.
+
+        bundler-cache: true runs `bundle install` and caches the gems
+        inside the action, so a separate (and cache-blind) install run
+        command would only duplicate it.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        setup_steps = [
+            step
+            for step in parsed["jobs"]["quality"]["steps"]
+            if "ruby/setup-ruby" in step.get("uses", "")
+        ]
+        assert len(setup_steps) == 1
+        assert setup_steps[0]["with"]["bundler-cache"] is True
+        run_commands = _all_run_commands(parsed)
+        assert not any("bundle install" in cmd for cmd in run_commands)
+
+    def test_rubocop_run_defers_the_policy_to_rubocop_yml(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """CI runs RuboCop's full cop set against .rubocop.yml only.
+
+        Format (Layout), lint (Lint/Style), the
+        Metrics/CyclomaticComplexity <=10 ceiling, and the Security
+        department all live in .rubocop.yml — the same file the
+        pre-commit hook and scripts/lint.sh read — so the invocation
+        carries no --only/--except selection and no restated bound.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        rubocop_runs = [c for c in run_commands if "rubocop" in c]
+        assert rubocop_runs == ["bundle exec rubocop --force-exclusion"]
+
+    def test_security_gate_is_bundler_audit_not_brakeman(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """Dependency CVEs gate via an updated bundler-audit run.
+
+        The advisory-db update precedes the check (CI runners have
+        network access, so a stale-db pass is not acceptable there).
+        Brakeman is deliberately absent: it is Rails-specific and
+        errors on plain-Ruby projects — parity with the generated
+        Gemfile, which does not pin it.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        audit_runs = [c for c in run_commands if "bundler-audit" in c]
+        assert len(audit_runs) == 1
+        assert "bundler-audit update" in audit_runs[0]
+        assert "bundler-audit check" in audit_runs[0]
+        assert audit_runs[0].index("update") < audit_runs[0].index("check")
+        assert not any("brakeman" in c for c in run_commands)
+
+    def test_coverage_step_defers_the_bound_to_spec_helper(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """No run command restates the SimpleCov coverage threshold.
+
+        The >=90% bound lives in spec/spec_helper.rb (its single
+        home); COVERAGE=true activates the gate without duplicating
+        the number, and SimpleCov fails the rspec run directly when
+        the bound is missed — so the suite executes exactly once.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        rspec_runs = [c for c in run_commands if "rspec" in c]
+        assert len(rspec_runs) == 1
+        assert rspec_runs[0].startswith("COVERAGE=true bundle exec rspec")
+        assert not any("90" in cmd for cmd in run_commands)
+        assert not any("minimum" in cmd.lower() for cmd in run_commands)
+
+    def test_codecov_upload_cannot_fail_ci(self, ruby_workflow: CIWorkflow) -> None:
+        """The tokenless Codecov upload is best-effort, never a gate.
+
+        A fresh project has no CODECOV_TOKEN secret, so a failing
+        upload must not start the project red; the enforced coverage
+        gate is the spec_helper-backed SimpleCov run in the rspec
+        step.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        codecov_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job["steps"]
+            if "codecov" in step.get("uses", "")
+        ]
+        assert len(codecov_steps) == 1
+        assert codecov_steps[0]["uses"] == "codecov/codecov-action@v6"
+        assert codecov_steps[0]["with"]["fail_ci_if_error"] is False
+
+    def test_workflow_writes_nothing_to_github_env(
+        self, ruby_workflow: CIWorkflow
+    ) -> None:
+        """Nothing discovered at runtime is exported to GITHUB_ENV.
+
+        The Swift PR #414 review flagged unvalidated GITHUB_ENV writes
+        as the documented Actions env-injection vector; like the
+        Kotlin, cpp, java, and csharp workflows, every value here is a
+        static literal, so there is no dynamic discovery and no
+        GITHUB_ENV/GITHUB_PATH write to guard.
+        """
+        parsed = yaml.safe_load(ruby_workflow.content)
+        run_commands = _all_run_commands(parsed)
+        assert not any("GITHUB_ENV" in cmd for cmd in run_commands)
+        assert not any("GITHUB_PATH" in cmd for cmd in run_commands)

--- a/tests/unit/reference/test_reference_assets.py
+++ b/tests/unit/reference/test_reference_assets.py
@@ -154,6 +154,49 @@ class TestScriptsReferences:
             assert "/p:CollectCoverage=true" in command
             assert "Threshold" not in command
 
+    def test_ruby_lint_script_runs_only_gemfile_backed_tools(
+        self, scripts_dir: Path
+    ) -> None:
+        """The ruby reference lint script invokes no missing gems (#374).
+
+        The generated Gemfile pins RuboCop only for linting — Reek is
+        not in the toolchain and Brakeman is Rails-specific (it errors
+        on plain-Ruby projects), so invoking either would fail on every
+        generated project. RuboCop's full cop set is the lint gate,
+        run with --force-exclusion — parity with the generated
+        scripts/lint.sh and reference/ci/ruby.yml.
+        """
+        content = (scripts_dir / "ruby" / "lint.sh").read_text()
+        commands = [
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        ]
+        assert any("rubocop --force-exclusion" in c for c in commands)
+        assert not any("reek" in c for c in commands)
+        assert not any("brakeman" in c for c in commands)
+
+    def test_ruby_test_script_defers_the_coverage_bound_to_spec_helper(
+        self, scripts_dir: Path
+    ) -> None:
+        """The ruby reference test script never restates the threshold (#374).
+
+        The >=90% SimpleCov bound lives in spec/spec_helper.rb (its
+        single home); COVERAGE=true activates the gate without
+        duplicating the number, matching reference/ci/ruby.yml and the
+        generated scripts/test.sh. (rspec has no --minimum-coverage
+        flag — the pre-#374 invocation restated the threshold through
+        an option rspec would reject.)
+        """
+        content = (scripts_dir / "ruby" / "test.sh").read_text()
+        commands = [
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        ]
+        test_runs = [c for c in commands if "rspec" in c]
+        assert test_runs, "test.sh must run rspec"
+        for command in test_runs:
+            assert "COVERAGE=true" in command
+            assert "minimum-coverage" not in command
+            assert "90" not in command
+
 
 class TestSkillsReferences:
     """Test skills references exist and have proper structure."""

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1536,6 +1536,21 @@ class TestGenerateSteps:
         assert mock_generator.generate.call_args.kwargs["language"] == "csharp"
 
     @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
+    def test_generate_architecture_step_ruby(self, mock_generator_class: Mock) -> None:
+        """Test _generate_architecture_step generates rules for Ruby."""
+        mock_generator = MagicMock()
+        mock_generator_class.return_value = mock_generator
+        mock_path = MagicMock(spec=Path)
+        mock_path.__truediv__.return_value = MagicMock(spec=Path)
+
+        with patch("start_green_stay_green.cli.console"):
+            cli._generate_architecture_step(mock_path, "my-project", "ruby")
+
+        # ruby now has architecture parity (#373): the generator runs.
+        mock_generator.generate.assert_called_once()
+        assert mock_generator.generate.call_args.kwargs["language"] == "ruby"
+
+    @patch("start_green_stay_green.cli.ArchitectureEnforcementGenerator")
     def test_generate_architecture_step_skips_unsupported(
         self, mock_generator_class: Mock
     ) -> None:

--- a/tests/unit/test_multi_language.py
+++ b/tests/unit/test_multi_language.py
@@ -162,7 +162,7 @@ class TestMultiLanguageGeneration:
 
 class TestMultiLanguageArchitectureParity:
     """Go (#341), Rust (#342), Swift (#352), Kotlin (#357), cpp (#362),
-    java (#367), csharp (#370)."""
+    java (#367), csharp (#370), ruby (#373)."""
 
     def test_go_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
         """Go must emit an architecture-enforcement config like py/ts."""
@@ -213,6 +213,13 @@ class TestMultiLanguageArchitectureParity:
         config = tmp_path / "plans" / "architecture" / "ArchitectureTest.cs"
         assert config.exists(), "csharp init must emit the NetArchTest template"
 
+    def test_ruby_exercises_architecture_enforcement(self, tmp_path: Path) -> None:
+        """ruby must emit an architecture-enforcement config like py/ts/go."""
+        cli_mod._generate_architecture_step(tmp_path, "my-project", "ruby")
+
+        config = tmp_path / "plans" / "architecture" / "packwerk.yml"
+        assert config.exists(), "ruby init must emit a Packwerk config"
+
     @pytest.mark.parametrize(
         "language",
         [
@@ -225,6 +232,7 @@ class TestMultiLanguageArchitectureParity:
             "cpp",
             "java",
             "csharp",
+            "ruby",
         ],
     )
     def test_supported_languages_emit_architecture_config(
@@ -417,6 +425,14 @@ class TestGeneratorOnlyLanguagePipelineGates:
         ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
         assert ci_file.exists()
         assert "Kotlin Quality Checks" in ci_file.read_text()
+
+    def test_ci_step_writes_ruby_workflow(self, tmp_path: Path) -> None:
+        """The ruby CI workflow is generated (ci.py has a ruby config)."""
+        cli_mod._generate_ci_step(tmp_path, "my-project", "ruby", None)
+
+        ci_file = tmp_path / ".github" / "workflows" / "ci.yml"
+        assert ci_file.exists()
+        assert "Ruby Quality Checks" in ci_file.read_text()
 
     def test_metrics_step_writes_kotlin_dashboard(self, tmp_path: Path) -> None:
         """The metrics dashboard is now generated for kotlin (#357)."""


### PR DESCRIPTION
## Summary

Survey-first execution (sixth of its kind): #373 already delivered the integration suite, utils tests, e2e matrices, setup-instruction entries, and pipeline gates. The genuine gaps, all filled:

- **Matrices** — ruby added to the architecture-parity parametrize (+ dedicated parity test + `test_ci_step_writes_ruby_workflow`), the precommit multi-language workflow list, and the cli-mocked architecture-step pattern.
- **`TestRubyReferenceTemplate`** (11 tests, the established per-language CI-template suite): 3.3/3.4 matrix, quality-job-only (no gemspec packaging), spec_helper-owned coverage bound with no restated "90", bundler-audit (no Brakeman), codecov@v6 best-effort, zero GITHUB_ENV writes.
- **Reference-script corrections (test-pinned, the recurring class)**: `reference/scripts/ruby/lint.sh` invoked **Reek and Brakeman — neither is in the generated Gemfile** (and Brakeman errors on plain Ruby); now RuboCop only. `test.sh` passed `--minimum-coverage 90` — **an option rspec rejects**, and a threshold restatement besides; now the COVERAGE-gated invocation with the bound in spec_helper.

## Mutation testing (honest status)

Sixth verification: mutmut 3.6.0 still crashes on the repo's 2.x-style config. Tracked gap; no score claimed.

## Test plan

- `./scripts/check-all.sh`: all 7 checks pass — **2,661 tests**, coverage **95.07%** (≥90% gate).
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
