### PR TITLE
feat(cli): platform-aware setup instructions without exec-bit reliance (#384)

### DIFF
--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -96,6 +96,7 @@ from start_green_stay_green.utils.enhance_state import hash_inputs
 from start_green_stay_green.utils.enhance_state import load_state
 from start_green_stay_green.utils.enhance_state import save_state
 from start_green_stay_green.utils.file_writer import FileWriter
+from start_green_stay_green.utils.fs import is_windows
 from start_green_stay_green.utils.timing import TimingReport
 from start_green_stay_green.utils.timing import set_active_report
 from start_green_stay_green.utils.timing import step_timer
@@ -1702,28 +1703,87 @@ def _venv_activation_command(os_name: str, env: Mapping[str, str]) -> str:
     return "source .venv/bin/activate"
 
 
-def _get_setup_instructions(languages: Sequence[str], project_path: Path) -> list[str]:
+def _quote_path_for_shell(os_name: str, path: Path) -> str:
+    r"""Quote ``path`` for copy-paste into the platform's shell.
+
+    ``shlex.quote`` emits POSIX single-quote syntax, which cmd.exe does
+    not understand at all (``cd 'C:\my project'`` fails) and which is
+    unnecessary in PowerShell. Both Windows shells accept double
+    quotes, and ``"`` cannot appear in Windows file names, so on
+    Windows the path is wrapped verbatim with no escaping needed.
+
+    Args:
+        os_name: Platform identifier, typically ``os.name`` ("nt" on
+            Windows, "posix" elsewhere).
+        path: Filesystem path to quote.
+
+    Returns:
+        The path quoted for safe copy-paste into the platform's shell.
+    """
+    if os_name == "nt":
+        return f'"{path}"'
+    return shlex.quote(str(path))
+
+
+def _check_all_command(os_name: str) -> str:
+    """Return the command that runs a generated project's check-all gate.
+
+    On POSIX the generated ``scripts/check-all.sh`` carries the
+    executable bit (see ``utils.fs.make_executable``) and is invoked
+    directly. Windows has no executable bit, and generated projects
+    have no native Windows gate runner yet (#386) — the honest
+    instruction is to run the POSIX script through Git Bash, which
+    needs no executable bit because bash receives the script path as
+    an argument.
+
+    Args:
+        os_name: Platform identifier, typically ``os.name``.
+
+    Returns:
+        The shell command that runs all quality checks in the
+        generated project.
+    """
+    if os_name == "nt":
+        return "bash scripts/check-all.sh"
+    return "./scripts/check-all.sh"
+
+
+def _get_setup_instructions(
+    languages: Sequence[str],
+    project_path: Path,
+    *,
+    os_name: str,
+    env: Mapping[str, str],
+) -> list[str]:
     """Return language-specific setup commands for a generated project.
 
     For multi-language projects, language-specific steps are concatenated
     in the order the languages appear. Shared steps (cd, pre-commit
-    install, check-all) are not duplicated. The Python venv activation
-    line is shell-aware (see :func:`_venv_activation_command`); the
-    detection is a heuristic based on ``os.name`` and the ``SHELL`` /
-    ``PSModulePath`` environment variables, and defaults to the bash/zsh
-    form when the shell cannot be identified.
+    install, check-all) are not duplicated. Every shell-sensitive line
+    is platform-aware via one canonical helper each: cd quoting
+    (:func:`_quote_path_for_shell`), venv activation
+    (:func:`_venv_activation_command`), and the check-all invocation
+    (:func:`_check_all_command`). Shell detection is a heuristic based
+    on ``os_name`` and the ``SHELL`` / ``PSModulePath`` environment
+    variables, defaulting to the bash/zsh form when the shell cannot
+    be identified.
 
     Args:
         languages: Ordered sequence of programming languages (python,
             typescript, go, rust, etc.). May be empty for a sensible
             default.
         project_path: Path to the generated project directory.
+        os_name: Platform identifier, typically ``os.name``. Passed
+            explicitly so tests never patch the real ``os.name``,
+            which breaks ``pathlib.Path`` construction (#380).
+        env: Environment mapping for shell detection, typically
+            ``os.environ``.
 
     Returns:
         Ordered list of shell commands to set up and verify the project.
     """
-    cd = f"cd {shlex.quote(str(project_path))}"
-    common_tail = ["pre-commit install", "./scripts/check-all.sh"]
+    cd = f"cd {_quote_path_for_shell(os_name, project_path)}"
+    common_tail = ["pre-commit install", _check_all_command(os_name)]
 
     middle: list[str] = []
     for lang in dict.fromkeys(languages):
@@ -1731,7 +1791,7 @@ def _get_setup_instructions(languages: Sequence[str], project_path: Path) -> lis
             middle.extend(
                 [
                     "python -m venv .venv",
-                    _venv_activation_command(os.name, os.environ),
+                    _venv_activation_command(os_name, env),
                     "pip install -r requirements.txt -r requirements-dev.txt",
                 ]
             )
@@ -1739,6 +1799,34 @@ def _get_setup_instructions(languages: Sequence[str], project_path: Path) -> lis
             middle.extend(_LANG_SETUP_STEPS.get(lang, []))
 
     return [cd, *middle, *common_tail]
+
+
+def _print_setup_instructions(languages: Sequence[str], project_path: Path) -> None:
+    """Print platform-appropriate setup commands for a generated project.
+
+    The command list comes from :func:`_get_setup_instructions` for the
+    live platform. On Windows (via the patchable ``is_windows`` seam,
+    #380) a note explains that the generated POSIX scripts run through
+    Git Bash, since no native Windows gate scripts exist yet (#386).
+
+    Args:
+        languages: Ordered sequence of programming languages for the
+            project.
+        project_path: Path to the generated project directory.
+    """
+    console.print("\nTo get started, run:")
+    for cmd in _get_setup_instructions(
+        languages, project_path, os_name=os.name, env=os.environ
+    ):
+        console.print(f"  {cmd}")
+    if is_windows():
+        console.print(
+            "\nNote: 'bash scripts/check-all.sh' runs the quality gate "
+            "through Git Bash (included with Git for Windows). The "
+            "generated scripts are POSIX shell; native Windows "
+            "equivalents are not generated yet."
+        )
+    console.print()
 
 
 def _finalize_init(
@@ -1765,10 +1853,7 @@ def _finalize_init(
     console.print(
         f"\n[green]✓[/green] Project generated successfully at: {project_path}"
     )
-    console.print("\nTo get started, run:")
-    for cmd in _get_setup_instructions(languages, project_path):
-        console.print(f"  {cmd}")
-    console.print()
+    _print_setup_instructions(languages, project_path)
     if enable_live_dashboard:
         console.print(
             "[green]✓[/green] Live metrics dashboard enabled "

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -76,6 +76,16 @@ ALL_LANGUAGES = (
 )
 
 
+def _always_posix() -> bool:
+    """Pin the POSIX branch of the is_windows seam."""
+    return False
+
+
+def _always_windows() -> bool:
+    """Pin the Windows branch of the is_windows seam."""
+    return True
+
+
 class TestVenvActivationCommand:
     """Tests for _venv_activation_command shell detection."""
 
@@ -633,7 +643,7 @@ class TestFinalizeInitWindowsNote:
         tmp_path: Path,
     ) -> None:
         """On Windows the success message explains the Git Bash gate."""
-        monkeypatch.setattr("start_green_stay_green.cli.is_windows", lambda: True)
+        monkeypatch.setattr("start_green_stay_green.cli.is_windows", _always_windows)
 
         _finalize_init(tmp_path, "proj", ("python",))
 
@@ -649,7 +659,7 @@ class TestFinalizeInitWindowsNote:
     ) -> None:
         """On POSIX no Windows-specific note clutters the output."""
         # bool() returns False — refurb's FURB111-preferred lambda: False.
-        monkeypatch.setattr("start_green_stay_green.cli.is_windows", bool)
+        monkeypatch.setattr("start_green_stay_green.cli.is_windows", _always_posix)
 
         _finalize_init(tmp_path, "proj", ("python",))
 

--- a/tests/unit/test_cli_setup_instructions.py
+++ b/tests/unit/test_cli_setup_instructions.py
@@ -1,17 +1,49 @@
-"""Tests for language-specific setup instructions in CLI init output."""
+"""Tests for language-specific setup instructions in CLI init output.
 
-import os
+The shell-sensitive helpers (``_venv_activation_command``,
+``_quote_path_for_shell``, ``_check_all_command``) and
+``_get_setup_instructions`` all take ``os_name``/``env`` explicitly, so
+every test here is hermetic: the real ``os.name`` is never patched —
+``pathlib.Path`` dispatches on it at construction time, so patching it
+crashes ``Path()`` on Windows runners (#380).
+
+Cross-platform literal goldens: POSIX-flavored test paths use a single
+path component (e.g. ``Path("my-project")``) because multi-component
+POSIX paths stringify with backslashes on Windows runners. Windows
+test paths like ``Path("C:\\Users\\dev\\proj")`` stringify identically
+on every platform (on POSIX the backslashes are literal name
+characters), so their goldens are safe everywhere.
+"""
+
 from pathlib import Path
 import shlex
+from typing import TypedDict
 
 import pytest
 
+from start_green_stay_green.cli import _check_all_command
+from start_green_stay_green.cli import _finalize_init
 from start_green_stay_green.cli import _get_setup_instructions
+from start_green_stay_green.cli import _quote_path_for_shell
 from start_green_stay_green.cli import _venv_activation_command
+
+# A PSModulePath value marks the environment as PowerShell (#284/#409).
+POWERSHELL_ENV = {"PSModulePath": "C:\\Program Files\\PowerShell\\Modules"}
+
+
+class _PlatformArgs(TypedDict):
+    """Keyword arguments selecting a platform for the instruction helpers."""
+
+    os_name: str
+    env: dict[str, str]
+
+
+# Default hermetic platform args for tests that don't care about shell.
+POSIX_BASH: _PlatformArgs = {"os_name": "posix", "env": {"SHELL": "/bin/bash"}}
 
 
 def _assert_cd_command(command: str, path: Path) -> None:
-    """Assert that ``command`` is a cd to exactly ``path``.
+    """Assert that ``command`` is a POSIX cd to exactly ``path``.
 
     The shlex round-trip keeps the assertion platform-agnostic: on
     Windows ``str(Path(...))`` uses backslashes, which ``shlex.quote``
@@ -85,8 +117,7 @@ class TestVenvActivationCommand:
 
     def test_windows_powershell_uses_activate_ps1(self) -> None:
         """Windows with PSModulePath set should emit the PowerShell script."""
-        env = {"PSModulePath": "C:\\Users\\dev\\Documents\\PowerShell\\Modules"}
-        command = _venv_activation_command("nt", env)
+        command = _venv_activation_command("nt", POWERSHELL_ENV)
         assert command == ".venv\\Scripts\\Activate.ps1"
 
     def test_windows_ignores_posix_shell_var(self) -> None:
@@ -95,77 +126,210 @@ class TestVenvActivationCommand:
         assert command == ".venv\\Scripts\\activate"
 
 
+class TestQuotePathForShell:
+    """Tests for _quote_path_for_shell platform-aware quoting."""
+
+    def test_posix_simple_path_is_unquoted(self) -> None:
+        """A safe POSIX path should pass through without quoting."""
+        assert _quote_path_for_shell("posix", Path("my-project")) == "my-project"
+
+    def test_posix_path_with_spaces_uses_posix_quoting(self) -> None:
+        """POSIX quoting must match shlex semantics exactly."""
+        quoted = _quote_path_for_shell("posix", Path("my project"))
+        assert quoted == "'my project'"
+
+    def test_posix_quoting_matches_shlex_for_absolute_paths(self) -> None:
+        """The POSIX branch must be exactly shlex.quote of the path."""
+        path = Path("/home/user/my project")
+        assert _quote_path_for_shell("posix", path) == shlex.quote(str(path))
+
+    def test_windows_path_is_double_quoted(self) -> None:
+        """Windows paths get double quotes — valid in both cmd and PowerShell.
+
+        ``shlex.quote`` would emit ``'C:\\Users\\dev\\proj'``, which
+        cmd.exe does not understand at all; double quotes work in both
+        Windows shells (#409 deferred UX issue).
+        """
+        path = Path("C:\\Users\\dev\\proj")
+        assert _quote_path_for_shell("nt", path) == '"C:\\Users\\dev\\proj"'
+
+    def test_windows_path_with_spaces_is_double_quoted(self) -> None:
+        """Windows paths with spaces survive copy-paste via double quotes."""
+        path = Path("C:\\Users\\dev\\my project")
+        quoted = _quote_path_for_shell("nt", path)
+        assert quoted == '"C:\\Users\\dev\\my project"'
+
+    def test_windows_never_uses_posix_single_quotes(self) -> None:
+        """The nt branch must not fall back to POSIX single-quoting."""
+        quoted = _quote_path_for_shell("nt", Path("my project"))
+        assert quoted == '"my project"'
+        assert "'" not in quoted
+
+
+class TestCheckAllCommand:
+    """Tests for _check_all_command platform-aware gate invocation."""
+
+    def test_posix_invokes_script_directly(self) -> None:
+        """POSIX runs the generated script directly via its exec bit."""
+        assert _check_all_command("posix") == "./scripts/check-all.sh"
+
+    def test_windows_invokes_via_git_bash(self) -> None:
+        """Windows runs the POSIX script through bash (Git Bash).
+
+        Generated projects have no native Windows gate runner yet, and
+        NTFS has no executable bit — passing the script as an argument
+        to bash needs neither ``./`` invocation nor the exec bit.
+        """
+        assert _check_all_command("nt") == "bash scripts/check-all.sh"
+
+    def test_windows_does_not_reference_dot_slash(self) -> None:
+        """The Windows form must not rely on ./ exec-bit invocation."""
+        assert not _check_all_command("nt").startswith("./")
+
+
+class TestPerShellGoldenInstructions:
+    """Golden full-instruction-list assertions per supported shell.
+
+    Each case pins the complete, copy-pasteable instruction list for a
+    Python project so any drift in ordering, quoting, activation, or
+    gate invocation fails loudly. Paths are chosen to stringify
+    identically on POSIX and Windows runners (see module docstring).
+    """
+
+    PIP_INSTALL = "pip install -r requirements.txt -r requirements-dev.txt"
+
+    def test_posix_bash_golden(self) -> None:
+        """bash/zsh: source activate + direct ./scripts invocation."""
+        instructions = _get_setup_instructions(
+            ("python",),
+            Path("my-project"),
+            os_name="posix",
+            env={"SHELL": "/bin/bash"},
+        )
+        assert instructions == [
+            "cd my-project",
+            "python -m venv .venv",
+            "source .venv/bin/activate",
+            self.PIP_INSTALL,
+            "pre-commit install",
+            "./scripts/check-all.sh",
+        ]
+
+    def test_fish_golden(self) -> None:
+        """fish: activate.fish + direct ./scripts invocation."""
+        instructions = _get_setup_instructions(
+            ("python",),
+            Path("my-project"),
+            os_name="posix",
+            env={"SHELL": "/usr/bin/fish"},
+        )
+        assert instructions == [
+            "cd my-project",
+            "python -m venv .venv",
+            "source .venv/bin/activate.fish",
+            self.PIP_INSTALL,
+            "pre-commit install",
+            "./scripts/check-all.sh",
+        ]
+
+    def test_csh_golden(self) -> None:
+        """csh/tcsh: activate.csh + direct ./scripts invocation."""
+        instructions = _get_setup_instructions(
+            ("python",),
+            Path("my-project"),
+            os_name="posix",
+            env={"SHELL": "/bin/csh"},
+        )
+        assert instructions == [
+            "cd my-project",
+            "python -m venv .venv",
+            "source .venv/bin/activate.csh",
+            self.PIP_INSTALL,
+            "pre-commit install",
+            "./scripts/check-all.sh",
+        ]
+
+    def test_windows_cmd_golden(self) -> None:
+        """cmd.exe: double-quoted cd, Scripts activate, Git Bash gate."""
+        instructions = _get_setup_instructions(
+            ("python",),
+            Path("C:\\Users\\dev\\my project"),
+            os_name="nt",
+            env={},
+        )
+        assert instructions == [
+            'cd "C:\\Users\\dev\\my project"',
+            "python -m venv .venv",
+            ".venv\\Scripts\\activate",
+            self.PIP_INSTALL,
+            "pre-commit install",
+            "bash scripts/check-all.sh",
+        ]
+
+    def test_windows_powershell_golden(self) -> None:
+        """PowerShell: double-quoted cd, Activate.ps1, Git Bash gate."""
+        instructions = _get_setup_instructions(
+            ("python",),
+            Path("C:\\Users\\dev\\my project"),
+            os_name="nt",
+            env=POWERSHELL_ENV,
+        )
+        assert instructions == [
+            'cd "C:\\Users\\dev\\my project"',
+            "python -m venv .venv",
+            ".venv\\Scripts\\Activate.ps1",
+            self.PIP_INSTALL,
+            "pre-commit install",
+            "bash scripts/check-all.sh",
+        ]
+
+    def test_windows_non_python_golden(self) -> None:
+        """Non-Python languages on Windows still get the Git Bash gate."""
+        instructions = _get_setup_instructions(
+            ("typescript",),
+            Path("C:\\Users\\dev\\ts-proj"),
+            os_name="nt",
+            env={},
+        )
+        assert instructions == [
+            'cd "C:\\Users\\dev\\ts-proj"',
+            "npm install",
+            "pre-commit install",
+            "bash scripts/check-all.sh",
+        ]
+
+
 class TestGetSetupInstructions:
     """Tests for _get_setup_instructions."""
 
     def test_python_includes_venv_creation(self) -> None:
         """Python setup should create a virtualenv."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
+            ("python",), Path("/home/user/my-project"), **POSIX_BASH
         )
         assert "python -m venv .venv" in instructions
 
-    def test_python_includes_venv_activation(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Python setup embeds the canonical activation command.
-
-        Platform-agnostic by construction: the expected string is
-        computed through the same helper the production code calls, for
-        the live platform plus a controlled environment. The exact
-        POSIX/Windows command strings are pinned hermetically in
-        TestVenvActivationCommand; the real os.name is never patched —
-        pathlib.Path dispatches on it at construction time, so patching
-        it crashes Path() on Windows runners (#380).
-        """
-        monkeypatch.delenv("SHELL", raising=False)
-        # Production passes os.environ; computing the expectation with
-        # the same mapping keeps this true on Windows runners, where
-        # PSModulePath selects the PowerShell activation form.
-        expected = _venv_activation_command(os.name, os.environ)
-
+    def test_python_activation_respects_shell_env(self) -> None:
+        """The fish activation form appears when SHELL points at fish."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
+            ("python",),
+            Path("/home/user/my-project"),
+            os_name="posix",
+            env={"SHELL": "/usr/bin/fish"},
         )
+        assert "source .venv/bin/activate.fish" in instructions
 
-        assert expected in instructions
-
-    def test_python_activation_respects_shell_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Setup instructions follow the helper's SHELL-sensitive output.
-
-        Under fish on POSIX this is the activate.fish form; on Windows
-        SHELL is ignored and the Scripts form appears — either way the
-        instructions must embed exactly what the canonical helper
-        produces for the same inputs.
-        """
-        monkeypatch.setenv("SHELL", "/usr/bin/fish")
-        expected = _venv_activation_command(os.name, os.environ)
-
+    def test_python_activation_defaults_without_shell_var(self) -> None:
+        """Unset SHELL yields the bash/zsh activation default."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
+            ("python",), Path("/home/user/my-project"), os_name="posix", env={}
         )
-
-        assert expected in instructions
-
-    def test_python_activation_defaults_without_shell_var(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Unset SHELL yields the helper's platform default."""
-        monkeypatch.delenv("SHELL", raising=False)
-        expected = _venv_activation_command(os.name, os.environ)
-
-        instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
-        )
-
-        assert expected in instructions
+        assert "source .venv/bin/activate" in instructions
 
     def test_python_includes_pip_install(self) -> None:
         """Python setup should install requirements."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
+            ("python",), Path("/home/user/my-project"), **POSIX_BASH
         )
         pip_cmds = [c for c in instructions if "pip install" in c]
         assert len(pip_cmds) == 1
@@ -175,7 +339,7 @@ class TestGetSetupInstructions:
     def test_python_includes_precommit_and_check_all(self) -> None:
         """Python setup should end with pre-commit install and check-all."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my-project")
+            ("python",), Path("/home/user/my-project"), **POSIX_BASH
         )
         assert "pre-commit install" in instructions
         assert "./scripts/check-all.sh" in instructions
@@ -183,37 +347,41 @@ class TestGetSetupInstructions:
     def test_python_starts_with_cd(self) -> None:
         """Python setup should start with cd into project."""
         path = Path("/home/user/my-project")
-        instructions = _get_setup_instructions(("python",), path)
+        instructions = _get_setup_instructions(("python",), path, **POSIX_BASH)
         _assert_cd_command(instructions[0], path)
 
     def test_typescript_includes_npm_install(self) -> None:
         """TypeScript setup should run npm install."""
         instructions = _get_setup_instructions(
-            ("typescript",), Path("/home/user/ts-proj")
+            ("typescript",), Path("/home/user/ts-proj"), **POSIX_BASH
         )
         assert "npm install" in instructions
 
     def test_typescript_no_venv(self) -> None:
         """TypeScript should not include Python venv steps."""
         instructions = _get_setup_instructions(
-            ("typescript",), Path("/home/user/ts-proj")
+            ("typescript",), Path("/home/user/ts-proj"), **POSIX_BASH
         )
         assert "python -m venv .venv" not in instructions
 
     def test_go_includes_mod_download(self) -> None:
         """Go setup should download modules."""
-        instructions = _get_setup_instructions(("go",), Path("/home/user/go-proj"))
+        instructions = _get_setup_instructions(
+            ("go",), Path("/home/user/go-proj"), **POSIX_BASH
+        )
         assert "go mod download" in instructions
 
     def test_rust_includes_cargo_build(self) -> None:
         """Rust setup should run cargo build."""
-        instructions = _get_setup_instructions(("rust",), Path("/home/user/rust-proj"))
+        instructions = _get_setup_instructions(
+            ("rust",), Path("/home/user/rust-proj"), **POSIX_BASH
+        )
         assert "cargo build" in instructions
 
     def test_swift_includes_swift_build(self) -> None:
         """Swift setup should resolve dependencies and build the SPM package."""
         instructions = _get_setup_instructions(
-            ("swift",), Path("/home/user/swift-proj")
+            ("swift",), Path("/home/user/swift-proj"), **POSIX_BASH
         )
         assert "swift package resolve" in instructions
         assert "swift build" in instructions
@@ -225,7 +393,7 @@ class TestGetSetupInstructions:
         the first step materialises it from a local Gradle install.
         """
         instructions = _get_setup_instructions(
-            ("kotlin",), Path("/home/user/wear-proj")
+            ("kotlin",), Path("/home/user/wear-proj"), **POSIX_BASH
         )
         gradle_wrapper_cmds = [
             c for c in instructions if c.startswith("gradle wrapper")
@@ -243,7 +411,9 @@ class TestGetSetupInstructions:
         init), so the steps cover only the plain CMake + Conan build of
         the pure-logic library and its Catch2 tests.
         """
-        instructions = _get_setup_instructions(("cpp",), Path("/home/user/watch-proj"))
+        instructions = _get_setup_instructions(
+            ("cpp",), Path("/home/user/watch-proj"), **POSIX_BASH
+        )
 
         conan_idx = instructions.index(
             "conan install . --output-folder=build --build=missing"
@@ -264,7 +434,9 @@ class TestGetSetupInstructions:
         The watch APK build needs Android tooling (Android Studio /
         Gradle) that init cannot install, so no Gradle/APK step appears.
         """
-        instructions = _get_setup_instructions(("java",), Path("/home/user/wear-proj"))
+        instructions = _get_setup_instructions(
+            ("java",), Path("/home/user/wear-proj"), **POSIX_BASH
+        )
         assert "mvn test" in instructions
         assert not any("gradle" in c for c in instructions)
 
@@ -276,7 +448,7 @@ class TestGetSetupInstructions:
         appear — the csproj is the single home of the quality policy.
         """
         instructions = _get_setup_instructions(
-            ("csharp",), Path("/home/user/dotnet-proj")
+            ("csharp",), Path("/home/user/dotnet-proj"), **POSIX_BASH
         )
         assert "dotnet test" in instructions
         assert not any("dotnet restore" in c for c in instructions)
@@ -290,7 +462,9 @@ class TestGetSetupInstructions:
         lesson: a supported language must not sit on the
         unknown-language default path.
         """
-        instructions = _get_setup_instructions(("ruby",), Path("/home/user/ruby-proj"))
+        instructions = _get_setup_instructions(
+            ("ruby",), Path("/home/user/ruby-proj"), **POSIX_BASH
+        )
         assert "bundle install" in instructions
         assert "bundle exec rspec" in instructions
 
@@ -301,7 +475,7 @@ class TestGetSetupInstructions:
         php — a language with no setup-step entry.
         """
         path = Path("/home/user/php-proj")
-        instructions = _get_setup_instructions(("php",), path)
+        instructions = _get_setup_instructions(("php",), path, **POSIX_BASH)
         _assert_cd_command(instructions[0], path)
         assert "pre-commit install" in instructions
         assert "./scripts/check-all.sh" in instructions
@@ -309,31 +483,45 @@ class TestGetSetupInstructions:
     @pytest.mark.parametrize("lang", ALL_LANGUAGES)
     def test_language_ends_with_check_all(self, lang: str) -> None:
         """Every language's instructions should end with check-all."""
-        instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
+        instructions = _get_setup_instructions(
+            (lang,), Path("/home/user/proj"), **POSIX_BASH
+        )
         assert instructions[-1] == "./scripts/check-all.sh"
+
+    @pytest.mark.parametrize("lang", ALL_LANGUAGES)
+    def test_language_ends_with_git_bash_check_all_on_windows(self, lang: str) -> None:
+        """Every language's Windows instructions end with the bash gate."""
+        instructions = _get_setup_instructions(
+            (lang,), Path("C:\\Users\\dev\\proj"), os_name="nt", env={}
+        )
+        assert instructions[-1] == "bash scripts/check-all.sh"
 
     @pytest.mark.parametrize("lang", ALL_LANGUAGES)
     def test_language_includes_precommit(self, lang: str) -> None:
         """Every language's instructions should include pre-commit install."""
-        instructions = _get_setup_instructions((lang,), Path("/home/user/proj"))
+        instructions = _get_setup_instructions(
+            (lang,), Path("/home/user/proj"), **POSIX_BASH
+        )
         assert "pre-commit install" in instructions
 
     def test_returns_list_of_strings(self) -> None:
         """Instructions should be a list of strings."""
-        instructions = _get_setup_instructions(("python",), Path("/home/user/proj"))
+        instructions = _get_setup_instructions(
+            ("python",), Path("/home/user/proj"), **POSIX_BASH
+        )
         assert isinstance(instructions, list)
         assert all(isinstance(cmd, str) for cmd in instructions)
 
     def test_project_path_in_cd_command(self) -> None:
         """The cd command should use the exact project path."""
         path = Path("/home/user/my-awesome-project")
-        instructions = _get_setup_instructions(("python",), path)
+        instructions = _get_setup_instructions(("python",), path, **POSIX_BASH)
         _assert_cd_command(instructions[0], path)
 
     def test_multi_language_python_and_typescript(self) -> None:
         """Multi-language python+typescript should include steps for both."""
         instructions = _get_setup_instructions(
-            ("python", "typescript"), Path("/home/user/fullstack")
+            ("python", "typescript"), Path("/home/user/fullstack"), **POSIX_BASH
         )
         assert "python -m venv .venv" in instructions
         assert "npm install" in instructions
@@ -343,7 +531,7 @@ class TestGetSetupInstructions:
     def test_multi_language_preserves_order(self) -> None:
         """Language-specific steps should appear in the order of the languages tuple."""
         instructions = _get_setup_instructions(
-            ("python", "typescript"), Path("/home/user/proj")
+            ("python", "typescript"), Path("/home/user/proj"), **POSIX_BASH
         )
         # Python venv must come before npm install
         venv_idx = instructions.index("python -m venv .venv")
@@ -352,7 +540,9 @@ class TestGetSetupInstructions:
 
     def test_multi_language_rust_then_go(self) -> None:
         """Rust then Go should keep ordering."""
-        instructions = _get_setup_instructions(("rust", "go"), Path("/home/user/proj"))
+        instructions = _get_setup_instructions(
+            ("rust", "go"), Path("/home/user/proj"), **POSIX_BASH
+        )
         cargo_idx = instructions.index("cargo build")
         go_idx = instructions.index("go mod download")
         assert cargo_idx < go_idx
@@ -360,7 +550,7 @@ class TestGetSetupInstructions:
     def test_multi_language_common_tail_not_duplicated(self) -> None:
         """pre-commit install and check-all should appear only once."""
         instructions = _get_setup_instructions(
-            ("python", "typescript", "go"), Path("/home/user/proj")
+            ("python", "typescript", "go"), Path("/home/user/proj"), **POSIX_BASH
         )
         assert instructions.count("pre-commit install") == 1
         assert instructions.count("./scripts/check-all.sh") == 1
@@ -368,7 +558,7 @@ class TestGetSetupInstructions:
     def test_multi_language_cd_not_duplicated(self) -> None:
         """cd command should appear only once."""
         instructions = _get_setup_instructions(
-            ("python", "rust"), Path("/home/user/proj")
+            ("python", "rust"), Path("/home/user/proj"), **POSIX_BASH
         )
         cd_cmds = [c for c in instructions if c.startswith("cd ")]
         assert len(cd_cmds) == 1
@@ -376,7 +566,7 @@ class TestGetSetupInstructions:
     def test_path_with_spaces_is_quoted(self) -> None:
         """Paths containing spaces should be shell-quoted for safe copy-paste."""
         instructions = _get_setup_instructions(
-            ("python",), Path("/home/user/my project")
+            ("python",), Path("/home/user/my project"), **POSIX_BASH
         )
         # The cd command should quote the path so `cd /home/user/my project`
         # doesn't silently break when copy-pasted
@@ -389,14 +579,16 @@ class TestGetSetupInstructions:
     def test_duplicate_languages_not_doubled(self) -> None:
         """Duplicate languages in input should produce a single set of steps."""
         instructions = _get_setup_instructions(
-            ("python", "python"), Path("/home/user/proj")
+            ("python", "python"), Path("/home/user/proj"), **POSIX_BASH
         )
         assert instructions.count("python -m venv .venv") == 1
 
     def test_duplicate_languages_preserves_order(self) -> None:
         """Deduplication should preserve the order of first occurrence."""
         instructions = _get_setup_instructions(
-            ("typescript", "python", "typescript"), Path("/home/user/proj")
+            ("typescript", "python", "typescript"),
+            Path("/home/user/proj"),
+            **POSIX_BASH,
         )
         npm_idx = instructions.index("npm install")
         venv_idx = instructions.index("python -m venv .venv")
@@ -405,7 +597,61 @@ class TestGetSetupInstructions:
 
     def test_empty_languages_tuple_has_sensible_default(self) -> None:
         """Empty languages tuple should still produce valid instructions."""
-        instructions = _get_setup_instructions((), Path("/home/user/proj"))
+        instructions = _get_setup_instructions(
+            (), Path("/home/user/proj"), **POSIX_BASH
+        )
         assert instructions[0].startswith("cd ")
         assert "pre-commit install" in instructions
         assert instructions[-1] == "./scripts/check-all.sh"
+
+
+class TestFinalizeInitWindowsNote:
+    """The Git Bash note appears on Windows and only on Windows.
+
+    Platform selection goes through the patchable ``is_windows`` seam
+    from ``utils.fs`` (#380) — never by patching the real ``os.name``.
+    Rich wraps long lines at column width, so assertions normalize
+    whitespace before searching.
+    """
+
+    @staticmethod
+    def _printed_output(capsys: pytest.CaptureFixture[str]) -> str:
+        """Return captured stdout with all whitespace collapsed.
+
+        Args:
+            capsys: The pytest capture fixture for the test.
+
+        Returns:
+            The captured stdout joined on single spaces.
+        """
+        return " ".join(capsys.readouterr().out.split())
+
+    def test_windows_prints_git_bash_note(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """On Windows the success message explains the Git Bash gate."""
+        monkeypatch.setattr("start_green_stay_green.cli.is_windows", lambda: True)
+
+        _finalize_init(tmp_path, "proj", ("python",))
+
+        output = self._printed_output(capsys)
+        assert "Git Bash" in output
+        assert "bash scripts/check-all.sh" in output
+
+    def test_posix_omits_git_bash_note(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """On POSIX no Windows-specific note clutters the output."""
+        # bool() returns False — refurb's FURB111-preferred lambda: False.
+        monkeypatch.setattr("start_green_stay_green.cli.is_windows", bool)
+
+        _finalize_init(tmp_path, "proj", ("python",))
+
+        output = self._printed_output(capsys)
+        assert "Git Bash" not in output


### PR DESCRIPTION
## Summary

Windows-compat tracer T3 (epic #378; generalizes the already-shipped #284/#409 shell-aware activation):

- **The honest Windows check-all story**: the issue asked Windows instructions to invoke the #382 runner — but that runner exists only in this repo, not in generated projects (whose native Windows gates are T4 #386 scope). The shipped instruction is `bash scripts/check-all.sh`: Git Bash takes the script as an argument, needing neither `./` invocation nor the exec bit. A Windows-only note explains the Git Bash requirement and states plainly that generated scripts have no native Windows equivalents yet. No overclaiming; POSIX output is byte-identical.
- **Single source of truth per shell-sensitive line**: `_quote_path_for_shell` (fixes the #409-deferred cd-quoting bug — `shlex.quote`'s single quotes break cmd outright; Windows gets double quotes, illegal in filenames so no escaping needed), `_check_all_command`, and the pre-existing `_venv_activation_command`, all taking explicit `os_name`/`env` (the never-patch-real-`os.name` lesson); the Git Bash note gates on the patchable `is_windows` seam with the established named-helper test pattern.
- **Exec-bit verification**: all five script-emission chmod sites confirmed routing through `make_executable` (no-op on Windows); the only raw chmod in the package is `fs.py` itself. Nothing to redo from #380.

## Test plan

- Per-shell golden assertions for the full instruction list (posix-bash, fish, csh, windows-cmd, windows-powershell, non-Python Windows), quoting and check-all-command units, a 10-language Windows-tail parametrize, and the Windows-note seam tests — all hermetic by explicit args.
- `./scripts/check-all.sh`: all 7 checks pass — full suite **2,934 tests**, coverage **95.86%**.
- `.venv/bin/pre-commit run --all-files`: all hooks pass.

Closes #384
Refs #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
