### PR TITLE
feat(ai): OpenAI-compatible provider behind an optional extra (#385)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,18 @@ dependencies = [
 anthropic = [
     "anthropic>=0.18.0",
 ]
+# OpenAI-compatible provider SDK (#385). Also covers local/OSS servers
+# (Ollama, vLLM, LM Studio, …) via the OPENAI_BASE_URL override.
+# Install with ``pip install 'start-green-stay-green[openai]'``.
+# Floor live-verified against PyPI (latest 2.41.1, 2026-06-11).
+openai = [
+    "openai>=2.0.0",
+]
 dev = [
-    # AI provider SDK — optional runtime extra (#383), but required for the
-    # test suite, so installed in dev.
+    # AI provider SDKs — optional runtime extras (#383, #385), but required
+    # for the test suite's mypy run, so installed in dev.
     "anthropic>=0.18.0",
+    "openai>=2.0.0",
 
     # Linting and formatting
     "ruff>=0.2.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,10 @@
 # Include runtime dependencies
 -r requirements.txt
 
-# AI provider SDK — an optional runtime extra (#383), but required for
-# the test suite and local AI features, so it is always installed in dev.
+# AI provider SDKs — optional runtime extras (#383, #385), but required
+# for the test suite and local AI features, so always installed in dev.
 anthropic>=0.18.0,<1.0.0
+openai>=2.0.0,<3.0.0
 
 # Linting and formatting
 ruff>=0.2.0,<1.0.0

--- a/start_green_stay_green/ai/provider_selection.py
+++ b/start_green_stay_green/ai/provider_selection.py
@@ -103,22 +103,38 @@ class ProviderSpec:
         class_name: Name of the provider class within ``module``.
         api_key_env_var: Environment variable the provider's API key
             is read from (kept stable for backward compatibility).
+        default_model: Model id used when no flag/env/config supplies
+            one. Per-provider because model ids are vendor-specific —
+            the Anthropic default would be rejected by an OpenAI
+            endpoint and vice versa.
     """
 
     module: str
     class_name: str
     api_key_env_var: str
+    default_model: str
 
 
-# Registry of every selectable provider. Tracer T2 ships only the
-# Anthropic entry (T3, #385, adds the second concrete provider). Keying
-# by the normalized provider name keeps lookup, validation, and the
-# "supported set" error message all driven by one source of truth.
+# Registry of every selectable provider: Anthropic from tracer T2
+# (#383) and the OpenAI-compatible provider from tracer T3 (#385).
+# Keying by the normalized provider name keeps lookup, validation, and
+# the "supported set" error message all driven by one source of truth.
 _PROVIDERS: Final[dict[str, ProviderSpec]] = {
     "anthropic": ProviderSpec(
         module="start_green_stay_green.ai.providers.anthropic_provider",
         class_name="AnthropicProvider",
         api_key_env_var="ANTHROPIC_API_KEY",  # pragma: allowlist secret
+        default_model=DEFAULT_MODEL,
+    ),
+    "openai": ProviderSpec(
+        module="start_green_stay_green.ai.providers.openai_provider",
+        class_name="OpenAIProvider",
+        api_key_env_var="OPENAI_API_KEY",  # pragma: allowlist secret
+        # Current flagship chat model; live-verified against
+        # developers.openai.com on 2026-06-11. Local/OSS servers ignore
+        # this default — pass --model (or GREEN_LLM_MODEL) with the
+        # hosted model's name instead.
+        default_model="gpt-5.5",
     ),
 }
 
@@ -259,7 +275,9 @@ def resolve_provider_selection(
     1. CLI flag (``provider_flag`` / ``model_flag``)
     2. Environment (``GREEN_LLM_PROVIDER`` / ``GREEN_LLM_MODEL``)
     3. Config-file keys (``llm_provider`` / ``llm_model``)
-    4. Built-in default (:data:`DEFAULT_PROVIDER` / :data:`DEFAULT_MODEL`)
+    4. Built-in default (:data:`DEFAULT_PROVIDER`; the model default
+       is the *selected provider's* default — :data:`DEFAULT_MODEL`
+       for Anthropic — because model ids are vendor-specific)
 
     Blank / whitespace-only values at any tier are treated as unset, so
     they fall through to the next tier rather than erroring.
@@ -283,23 +301,28 @@ def resolve_provider_selection(
     Raises:
         ValueError: If the resolved provider is not registered.
     """
-    # Provider names are case-insensitive registry keys → fold.
-    provider = _coalesce_with_default(
-        DEFAULT_PROVIDER,
-        provider_flag,
-        env.get(ENV_PROVIDER),
-        config.get(_CONFIG_PROVIDER_KEY),
+    # Provider names are case-insensitive registry keys → fold. The
+    # provider resolves first so the model's tier-4 default can follow
+    # it (an Anthropic model id would be rejected by an OpenAI
+    # endpoint and vice versa).
+    provider = _require_known(
+        _coalesce_with_default(
+            DEFAULT_PROVIDER,
+            provider_flag,
+            env.get(ENV_PROVIDER),
+            config.get(_CONFIG_PROVIDER_KEY),
+        )
     )
     # Model ids are case-sensitive API identifiers → preserve case
     # (trim only). ``--model GPT-4o`` must reach the API as ``GPT-4o``.
     model = _coalesce_with_default(
-        DEFAULT_MODEL,
+        _PROVIDERS[provider].default_model,
         model_flag,
         env.get(ENV_MODEL),
         config.get(_CONFIG_MODEL_KEY),
         fold=False,
     )
-    return ProviderSelection(provider=_require_known(provider), model=model)
+    return ProviderSelection(provider=provider, model=model)
 
 
 def resolve_api_key_env_var(provider: str) -> str:

--- a/start_green_stay_green/ai/providers/__init__.py
+++ b/start_green_stay_green/ai/providers/__init__.py
@@ -4,23 +4,33 @@ Introduced in tracer T1 of the multi-agent epic (#381). The
 :class:`~start_green_stay_green.ai.providers.base.LLMProvider`
 interface is the seam every later tracer depends on: it decouples
 :class:`~start_green_stay_green.ai.orchestrator.AIOrchestrator` from
-any single SDK. :class:`AnthropicProvider` is the only concrete
-implementation today and contains *all* Anthropic-specific code
-(client construction, retry/backoff, token accounting, the Message
-Batches API).
+any single SDK. Two concrete implementations exist:
 
-The orchestrator depends on the interface, not on the ``anthropic``
-package, so a future provider (a second vendor, a local model, a
-fake for tests) can be slotted in without touching orchestration
-logic.
+* :class:`AnthropicProvider` (tracer T1, #381) — contains *all*
+  Anthropic-specific code (client construction, retry/backoff, token
+  accounting, the Message Batches API).
+* :class:`OpenAIProvider` (tracer T3, #385) — maps the same neutral
+  types onto the OpenAI Chat Completions API, and via its base-URL
+  override onto any local/OSS OpenAI-compatible server. Batch is
+  declined with :class:`UnsupportedCapabilityError` (negotiation is
+  tracer T5, #389).
+
+The orchestrator depends on the interface, not on any vendor package
+— each SDK is an optional install extra imported lazily inside its
+provider module — so further providers (another vendor, a fake for
+tests) can be slotted in without touching orchestration logic.
 """
 
 from __future__ import annotations
 
 from start_green_stay_green.ai.providers.anthropic_provider import AnthropicProvider
 from start_green_stay_green.ai.providers.base import LLMProvider
+from start_green_stay_green.ai.providers.base import UnsupportedCapabilityError
+from start_green_stay_green.ai.providers.openai_provider import OpenAIProvider
 
 __all__ = [
     "AnthropicProvider",
     "LLMProvider",
+    "OpenAIProvider",
+    "UnsupportedCapabilityError",
 ]

--- a/start_green_stay_green/ai/providers/base.py
+++ b/start_green_stay_green/ai/providers/base.py
@@ -36,9 +36,48 @@ if TYPE_CHECKING:
     from start_green_stay_green.ai.types import GenerationResult
     from start_green_stay_green.ai.types import ToolUseResult
 
-__all__ = ["LLMProvider"]
+__all__ = ["LLMProvider", "UnsupportedCapabilityError"]
 
 OutputFormat = Literal["yaml", "toml", "markdown", "bash"]
+
+
+class UnsupportedCapabilityError(NotImplementedError):
+    """A provider does not implement one of the optional capability groups.
+
+    Some capability groups are vendor-specific — the batch group maps
+    onto Anthropic's Message Batches API and has no equivalent on
+    OpenAI-compatible endpoints. A provider that cannot honestly
+    implement a group raises this typed error instead of emulating it
+    badly, so callers can catch it and fall back to a per-request
+    path. Full capability advertisement/negotiation arrives with
+    tracer T5 (#389); this minimal convention is what it will build
+    on.
+
+    Subclasses :class:`NotImplementedError` so generic handlers keep
+    working, while ``provider`` and ``capability`` stay machine-readable.
+
+    Attributes:
+        provider: Registry name of the provider lacking the capability.
+        capability: Human-readable name of the missing capability.
+    """
+
+    def __init__(self, *, provider: str, capability: str) -> None:
+        """Build the error message from the provider/capability pair.
+
+        Args:
+            provider: Registry name of the provider (e.g. ``"openai"``).
+            capability: Capability group being declined (e.g.
+                ``"batch tool-use"``).
+        """
+        msg = (
+            f"The {provider!r} provider does not support {capability}. "
+            f"Use a provider that implements this capability (for "
+            f"batch tool-use: 'anthropic'), or run the requests "
+            f"individually."
+        )
+        super().__init__(msg)
+        self.provider = provider
+        self.capability = capability
 
 
 class LLMProvider(ABC):

--- a/start_green_stay_green/ai/providers/openai_provider.py
+++ b/start_green_stay_green/ai/providers/openai_provider.py
@@ -1,0 +1,954 @@
+"""OpenAI-compatible :class:`LLMProvider` implementation (tracer T3, #385).
+
+Second concrete provider behind the seam tracer T1 (#381) introduced,
+mapping the provider-neutral request/response types onto the OpenAI
+Chat Completions API (``chat.completions.create`` with function
+tools). Because the request shape is the de-facto standard for
+local/OSS inference servers (Ollama, vLLM, LM Studio, llama.cpp,
+…), one **base URL override** makes this provider cover all of them:
+
+* Pass ``base_url=...`` to the constructor, or set the
+  ``OPENAI_BASE_URL`` environment variable (the constructor argument
+  wins). Unset, the SDK's default ``https://api.openai.com/v1`` is
+  used.
+* The API key is resolved by the selection layer from
+  ``OPENAI_API_KEY``. Local servers usually ignore it, so any
+  non-empty dummy value (e.g. ``OPENAI_API_KEY=local``) is fine.
+
+Like the Anthropic provider, the ``openai`` SDK is an *optional*
+install extra (``pip install 'start-green-stay-green[openai]'``).
+Every SDK reference is imported lazily through the module
+:func:`__getattr__` seam — never at module import time — so
+``import start_green_stay_green`` and ``green --help`` work without
+the extra installed; a missing extra surfaces as an actionable
+:class:`~start_green_stay_green.ai.provider_selection.ProviderUnavailableError`
+when a generation method first runs.
+
+Capability notes:
+
+* **Batch** is Anthropic-specific (Message Batches API); the three
+  batch methods honestly decline with a typed
+  :class:`~start_green_stay_green.ai.providers.base.UnsupportedCapabilityError`
+  (capability negotiation/fallback is tracer T5, #389).
+* **Caching telemetry**: OpenAI prompt caching is automatic and only
+  reports *read* hits (``usage.prompt_tokens_details.cached_tokens``);
+  there is no cache-write count, so ``cache_creation_tokens`` is
+  always ``0``. The Anthropic-specific ``cache_control`` markers on
+  system blocks are dropped during translation.
+* **Stop reasons** are not part of the neutral result types (the
+  orchestrator consumes content/tool-input, token usage, model, and
+  message id only); the forced ``tool_choice`` guarantees a tool call
+  on the structured path, mirroring the Anthropic contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from typing import Final
+from typing import Never
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import cast
+
+from start_green_stay_green.ai.providers.base import LLMProvider
+from start_green_stay_green.ai.providers.base import OutputFormat
+from start_green_stay_green.ai.providers.base import UnsupportedCapabilityError
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import GenerationResult
+from start_green_stay_green.ai.types import TokenUsage
+from start_green_stay_green.ai.types import ToolUseResult
+from start_green_stay_green.utils.timing import APICallRecord
+from start_green_stay_green.utils.timing import get_active_report
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+    from collections.abc import Callable
+    from collections.abc import Iterator
+    from collections.abc import Sequence
+
+    from openai import AsyncOpenAI
+    from openai import OpenAI
+
+    from start_green_stay_green.ai.batch import BatchPoll
+    from start_green_stay_green.ai.batch import BatchResultsBundle
+    from start_green_stay_green.ai.batch import BatchSubmission
+    from start_green_stay_green.ai.batch import ToolUseBatchRequest
+    from start_green_stay_green.utils.timing import TimingReport
+
+__all__ = ["OpenAIProvider"]
+
+# ``pip`` extra that installs the SDK; named in the missing-dependency
+# hint so users can copy/paste the fix.
+_INSTALL_EXTRA: Final[str] = "openai"
+
+# Registry name of this provider, echoed in capability errors.
+_PROVIDER_NAME: Final[str] = "openai"
+
+# Environment variable supplying the endpoint override for local/OSS
+# OpenAI-compatible servers (e.g. ``http://localhost:11434/v1`` for
+# Ollama). A constructor ``base_url`` argument takes precedence.
+ENV_BASE_URL: Final[str] = "OPENAI_BASE_URL"
+
+# Per-call max_tokens for every request this provider issues — same
+# value the Anthropic provider uses, so swapping providers does not
+# silently change output budgets. ``max_tokens`` (not the newer
+# ``max_completion_tokens``) is used deliberately: it is the field
+# local/OSS OpenAI-compatible servers universally accept.
+_MAX_TOKENS: Final[int] = 4096
+
+# Names this module exposes lazily from the ``openai`` SDK via
+# :func:`__getattr__`. Resolved on first *attribute* access
+# (``openai_provider.OpenAI``) rather than at import time, so the
+# module imports without the optional extra. ``unittest.mock.patch``
+# targets these exact attribute paths, so the lazy seam is also the
+# test seam.
+_SDK_EXPORTS: Final[dict[str, tuple[str, str]]] = {
+    "OpenAI": ("openai", "OpenAI"),
+    "AsyncOpenAI": ("openai", "AsyncOpenAI"),
+}
+
+# Retry loops are generic over the two neutral result types so the
+# free-form and tool-use paths share one driver instead of three
+# near-identical copies.
+_ResultT = TypeVar("_ResultT", GenerationResult, ToolUseResult)
+
+
+def _raise_missing_sdk(exc: ImportError) -> Never:
+    """Re-raise an SDK ``ImportError`` as an actionable error.
+
+    The ``openai`` SDK is an optional install extra. When a provider
+    method needs it but it is absent, surface a
+    :class:`~start_green_stay_green.ai.provider_selection.ProviderUnavailableError`
+    carrying a ``pip install`` hint instead of a bare "No module named
+    'openai'". The triggering :class:`ImportError` is chained.
+
+    Args:
+        exc: The original import failure.
+
+    Raises:
+        ProviderUnavailableError: Always.
+    """
+    from start_green_stay_green.ai.provider_selection import (  # noqa: PLC0415 — lazy to avoid an import cycle
+        ProviderUnavailableError,
+    )
+
+    msg = (
+        f"The {_INSTALL_EXTRA!r} provider requires an optional dependency "
+        f"that is not installed. Install it with: "
+        f"pip install 'start-green-stay-green[{_INSTALL_EXTRA}]'"
+    )
+    raise ProviderUnavailableError(msg) from exc
+
+
+def __getattr__(name: str) -> object:
+    """Lazily resolve SDK names off the optional ``openai`` extra.
+
+    Implements PEP 562 module-level attribute access so
+    ``openai_provider.OpenAI`` (and the other entries in
+    :data:`_SDK_EXPORTS`) import the SDK on first use rather than at
+    module import time. A missing extra is reported as an actionable
+    :class:`ProviderUnavailableError`, never a raw :class:`ImportError`.
+
+    Args:
+        name: The attribute being accessed on the module.
+
+    Returns:
+        The requested SDK object.
+
+    Raises:
+        AttributeError: If ``name`` is not a known SDK export.
+        ProviderUnavailableError: If the SDK extra is not installed.
+    """
+    target = _SDK_EXPORTS.get(name)
+    if target is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr = target
+    from importlib import (  # noqa: PLC0415 — lazy, keeps import cost off hot path
+        import_module,
+    )
+
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        _raise_missing_sdk(exc)
+    return getattr(module, attr)
+
+
+def _sdk_attr(name: str) -> object:
+    """Fetch an SDK export off *this module*, honoring any test patch.
+
+    Reading through ``sys.modules[__name__]`` means a
+    ``unittest.mock.patch("...openai_provider.OpenAI")`` (which sets
+    the attribute in the module ``__dict__``) is found first, and
+    otherwise :func:`__getattr__` resolves the real SDK lazily. This
+    keeps the lazy-import seam and the test seam one and the same.
+    """
+    return getattr(sys.modules[__name__], name)
+
+
+def _usage_tokens(usage: object) -> TokenUsage:
+    """Map the Chat Completions ``usage`` object to :class:`TokenUsage`.
+
+    ``usage`` can be ``None`` (some compatible servers omit it) and
+    its counts can be ``None``; coerce to ``int`` so downstream
+    telemetry never has to defend against missing fields.
+    """
+    return TokenUsage(
+        input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+        output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+    )
+
+
+def _cached_tokens(usage: object) -> int:
+    """Extract the prompt-cache *read* count from ``usage``.
+
+    OpenAI reports automatic cache hits as
+    ``usage.prompt_tokens_details.cached_tokens``; both levels can be
+    ``None``/absent (older SDKs, local servers). There is no
+    cache-*write* counterpart on this API.
+    """
+    details = getattr(usage, "prompt_tokens_details", None)
+    return int(getattr(details, "cached_tokens", 0) or 0)
+
+
+def _first_message(response: object) -> object:
+    """Return ``response.choices[0].message`` or raise on an empty list.
+
+    Args:
+        response: A Chat Completions response (or test double).
+
+    Returns:
+        The first choice's message object.
+
+    Raises:
+        GenerationError: If the response carries no choices.
+    """
+    choices = list(getattr(response, "choices", None) or [])
+    if not choices:
+        msg = "Response contained no choices"
+        raise GenerationError(msg)
+    return choices[0].message
+
+
+class OpenAIProvider(LLMProvider):
+    """OpenAI-compatible SDK implementation of :class:`LLMProvider`.
+
+    Construction is cheap and performs no I/O: the sync client is
+    created per-call inside a context manager, and the async client is
+    allocated lazily and cached for reuse across concurrent calls —
+    the same lifecycle contract as the Anthropic provider.
+
+    Attributes:
+        model: Model identifier used for every request (an OpenAI id
+            such as ``gpt-5.5``, or whatever the local server hosts).
+        max_retries: Maximum number of retry attempts for failed
+            requests.
+        retry_delay: Initial delay in seconds between retry attempts
+            (doubled each retry).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        base_url: str | None = None,
+    ) -> None:
+        """Initialize the provider with credentials and retry policy.
+
+        Args:
+            api_key: API key for authentication (read from
+                ``OPENAI_API_KEY`` by the selection layer). Local
+                OpenAI-compatible servers usually ignore it, so a
+                dummy non-empty value works there.
+            model: Model identifier to generate with.
+            max_retries: Maximum retry attempts. Defaults to 3.
+            retry_delay: Initial retry delay in seconds. Defaults to
+                1.0.
+            base_url: Optional endpoint override for local/OSS
+                OpenAI-compatible servers. Falls back to the
+                ``OPENAI_BASE_URL`` environment variable, then to the
+                SDK default endpoint.
+        """
+        self._api_key = api_key
+        self._model = model
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._base_url = base_url
+        # Lazily-created long-lived async client; one shared httpx pool
+        # across all async calls, mirroring AnthropicProvider.
+        self._async_client: AsyncOpenAI | None = None
+
+    @property
+    def model(self) -> str:
+        """Return the model identifier this provider generates with."""
+        return self._model
+
+    def _resolve_base_url(self) -> str | None:
+        """Resolve the endpoint override: constructor arg, then env, then SDK.
+
+        Returns:
+            The base URL to pass to the SDK client, or ``None`` to use
+            the SDK's default OpenAI endpoint. A blank environment
+            value is treated as unset.
+        """
+        return self._base_url or os.environ.get(ENV_BASE_URL) or None
+
+    # ------------------------------ retry core ------------------------------
+    def _retry_schedule(self) -> Iterator[tuple[int, float | None]]:
+        """Yield ``(attempt_index, sleep_before_next_or_None)`` pairs.
+
+        Same exponential schedule as the Anthropic provider so swapping
+        providers does not change retry behavior.
+        """
+        for attempt in range(self.max_retries + 1):
+            is_last = attempt == self.max_retries
+            yield attempt, None if is_last else self.retry_delay * (2**attempt)
+
+    @staticmethod
+    def _capture(
+        attempt: Callable[[], _ResultT],
+    ) -> tuple[_ResultT | None, Exception | None]:
+        """Run one sync attempt; return the result or capture the error.
+
+        :class:`GenerationError` (a malformed response) propagates
+        immediately — only transport-level failures are retryable,
+        matching the Anthropic provider's semantics.
+        """
+        try:
+            return attempt(), None
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return None, e
+
+    @staticmethod
+    async def _capture_async(
+        attempt: Callable[[], Awaitable[_ResultT]],
+    ) -> tuple[_ResultT | None, Exception | None]:
+        """Async counterpart of :meth:`_capture`."""
+        try:
+            return await attempt(), None
+        except GenerationError:
+            raise
+        except Exception as e:  # noqa: BLE001 — preserved for retry semantics
+            return None, e
+
+    def _retry_sync(self, attempt: Callable[[], _ResultT]) -> _ResultT:
+        """Drive ``attempt`` through the retry schedule (sync).
+
+        Telemetry is recorded exactly once per logical call — on the
+        successful attempt or on exhaustion — never per retry.
+
+        Args:
+            attempt: Zero-argument callable performing one API call.
+
+        Returns:
+            The first successful result.
+
+        Raises:
+            GenerationError: When every attempt failed; the last
+                transport error is chained as ``cause``.
+        """
+        report = get_active_report()
+        call_started = time.perf_counter()
+
+        for attempt_index, sleep_s in self._retry_schedule():
+            result, error = self._capture(attempt)
+            if result is not None:
+                self._record_call(report, call_started, attempt_index, result)
+                return result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt_index, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=error) from error
+            time.sleep(sleep_s)
+
+        # ``_retry_schedule`` always yields at least one entry, so this
+        # is unreachable; keep mypy happy with an explicit terminal.
+        msg = "Failed to generate content"
+        raise GenerationError(msg)
+
+    async def _retry_async(
+        self,
+        attempt: Callable[[], Awaitable[_ResultT]],
+    ) -> _ResultT:
+        """Async counterpart of :meth:`_retry_sync`.
+
+        Args:
+            attempt: Zero-argument coroutine factory performing one
+                API call.
+
+        Returns:
+            The first successful result.
+
+        Raises:
+            GenerationError: When every attempt failed; the last
+                transport error is chained as ``cause``.
+        """
+        report = get_active_report()
+        call_started = time.perf_counter()
+
+        for attempt_index, sleep_s in self._retry_schedule():
+            result, error = await self._capture_async(attempt)
+            if result is not None:
+                self._record_call(report, call_started, attempt_index, result)
+                return result
+            if sleep_s is None:
+                self._record_call(report, call_started, attempt_index, None)
+                msg = "Failed to generate content"
+                raise GenerationError(msg, cause=error) from error
+            await asyncio.sleep(sleep_s)
+
+        msg = "Failed to generate content"
+        raise GenerationError(msg)
+
+    @staticmethod
+    def _build_api_call_record(
+        latency_s: float,
+        attempt: int,
+        result: GenerationResult | ToolUseResult | None,
+    ) -> APICallRecord:
+        """Build an ``APICallRecord`` from a result, or zeros for failures."""
+        if result is None:
+            return APICallRecord(latency_s=latency_s, retries=attempt)
+        return APICallRecord(
+            latency_s=latency_s,
+            retries=attempt,
+            input_tokens=result.token_usage.input_tokens,
+            output_tokens=result.token_usage.output_tokens,
+            cache_read_tokens=result.cache_read_tokens,
+            cache_creation_tokens=result.cache_creation_tokens,
+        )
+
+    @classmethod
+    def _record_call(
+        cls,
+        report: TimingReport | None,
+        start: float,
+        attempt: int,
+        result: GenerationResult | ToolUseResult | None,
+    ) -> None:
+        """Record a completed call (success or failure) on the active report.
+
+        Args:
+            report: Active timing collector, or ``None`` when telemetry
+                is off.
+            start: ``perf_counter`` value captured before the first
+                attempt.
+            attempt: Zero-indexed attempt number (stored as
+                ``retries`` on the record).
+            result: Successful result, or ``None`` when the call failed
+                (token counts default to 0).
+        """
+        if report is None:
+            return
+        latency_s = time.perf_counter() - start
+        report.record_api_call(cls._build_api_call_record(latency_s, attempt, result))
+
+    # --------------------------- request building ---------------------------
+    def _completion_params(self, prompt: str, output_format: str) -> dict[str, object]:
+        """Build the ``chat.completions.create`` body for free-form output.
+
+        Same system instruction the Anthropic provider sends, expressed
+        as the OpenAI ``system`` role message.
+        """
+        return {
+            "model": self._model,
+            "max_tokens": _MAX_TOKENS,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        f"Generate {output_format} output. "
+                        "Follow the instructions precisely."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+        }
+
+    @staticmethod
+    def _system_text(system_blocks: list[dict[str, object]]) -> str:
+        """Collapse Anthropic-shaped system blocks into one system string.
+
+        Callers pass system prompts in the neutral (Anthropic-shaped)
+        block list: ``{"type": "text", "text": ..., "cache_control":
+        {...}}``. OpenAI has a single ``system`` message and caches
+        prompts automatically, so the block *texts* are joined with
+        blank lines and the ``cache_control`` markers are dropped.
+        """
+        texts = [
+            text
+            for block in system_blocks
+            if isinstance(text := block.get("text"), str) and text
+        ]
+        return "\n\n".join(texts)
+
+    def _tool_request_params(
+        self,
+        prompt: str,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> dict[str, object]:
+        """Build the forced-tool ``chat.completions.create`` body.
+
+        Translates the neutral (Anthropic-shaped) tool definition —
+        ``name`` / ``description`` / ``input_schema`` — into an OpenAI
+        function tool, and forces its invocation via ``tool_choice``
+        so the response is guaranteed to contain a tool call
+        (mirroring the Anthropic ``tool_choice`` contract).
+
+        Args:
+            prompt: User-message body (per-call delta).
+            system_blocks: Neutral system-prompt blocks; collapsed via
+                :meth:`_system_text`.
+            tool_schema: Neutral tool definition with at least a
+                non-empty ``name``.
+
+        Returns:
+            Keyword arguments for ``chat.completions.create``.
+
+        Raises:
+            GenerationError: If ``tool_schema`` lacks a non-empty
+                ``name`` (failing locally beats an opaque HTTP 400).
+        """
+        raw_name = self._validate_tool_name(tool_schema)
+        return {
+            "model": self._model,
+            "max_tokens": _MAX_TOKENS,
+            "messages": self._chat_messages(prompt, system_blocks),
+            "tools": [
+                {
+                    "type": "function",
+                    "function": self._function_definition(raw_name, tool_schema),
+                },
+            ],
+            "tool_choice": {"type": "function", "function": {"name": raw_name}},
+        }
+
+    @staticmethod
+    def _validate_tool_name(tool_schema: dict[str, object]) -> str:
+        """Return the schema's tool name, rejecting missing/blank names.
+
+        Args:
+            tool_schema: Neutral tool definition.
+
+        Returns:
+            The non-empty ``name`` string.
+
+        Raises:
+            GenerationError: If the name is missing, blank, or not a
+                string.
+        """
+        raw_name = tool_schema.get("name")
+        if not isinstance(raw_name, str) or not raw_name:
+            msg = "tool_schema must include a non-empty 'name' string"
+            raise GenerationError(msg)
+        return raw_name
+
+    @staticmethod
+    def _function_definition(
+        name: str,
+        tool_schema: dict[str, object],
+    ) -> dict[str, object]:
+        """Translate the neutral tool schema into an OpenAI function body.
+
+        ``description`` and ``input_schema`` (→ ``parameters``) are
+        carried over when present; absent optional keys are simply
+        omitted rather than sent as ``None``.
+        """
+        function: dict[str, object] = {"name": name}
+        description = tool_schema.get("description")
+        if isinstance(description, str) and description:
+            function["description"] = description
+        parameters = tool_schema.get("input_schema")
+        if parameters is not None:
+            function["parameters"] = parameters
+        return function
+
+    def _chat_messages(
+        self,
+        prompt: str,
+        system_blocks: list[dict[str, object]],
+    ) -> list[dict[str, object]]:
+        """Build the chat message list: optional system text, then the user turn."""
+        messages: list[dict[str, object]] = []
+        system_text = self._system_text(system_blocks)
+        if system_text:
+            messages.append({"role": "system", "content": system_text})
+        messages.append({"role": "user", "content": prompt})
+        return messages
+
+    # --------------------------- response mapping ---------------------------
+    def _result_from_completion(
+        self,
+        response: object,
+        output_format: str,
+    ) -> GenerationResult:
+        """Map a Chat Completions response to :class:`GenerationResult`.
+
+        Args:
+            response: The SDK response object (or test double).
+            output_format: Format echoed onto the result.
+
+        Returns:
+            A populated :class:`GenerationResult`.
+
+        Raises:
+            GenerationError: If the response has no choices or no text
+                content.
+        """
+        message = _first_message(response)
+        content = getattr(message, "content", None)
+        if not isinstance(content, str) or not content:
+            msg = "Expected text content in response"
+            raise GenerationError(msg)
+        usage = getattr(response, "usage", None)
+        return GenerationResult(
+            content=content,
+            format=output_format,
+            token_usage=_usage_tokens(usage),
+            model=str(getattr(response, "model", "") or ""),
+            message_id=str(getattr(response, "id", "") or ""),
+            cache_read_tokens=_cached_tokens(usage),
+            # OpenAI prompt caching is automatic and reports reads only;
+            # there is no cache-write count on this API.
+            cache_creation_tokens=0,
+        )
+
+    def _tool_result_from_completion(self, response: object) -> ToolUseResult:
+        """Map a forced-tool Chat Completions response to :class:`ToolUseResult`.
+
+        Args:
+            response: The SDK response object (or test double).
+
+        Returns:
+            A populated :class:`ToolUseResult` with the parsed
+            ``tool_input`` dict.
+
+        Raises:
+            GenerationError: If the response carries no tool call or
+                its arguments are not a JSON object.
+        """
+        call = self._first_tool_call(_first_message(response))
+        function = getattr(call, "function", None)
+        usage = getattr(response, "usage", None)
+        return ToolUseResult(
+            tool_name=str(getattr(function, "name", "") or ""),
+            tool_input=self._parse_tool_arguments(
+                getattr(function, "arguments", None),
+            ),
+            token_usage=_usage_tokens(usage),
+            model=str(getattr(response, "model", "") or ""),
+            message_id=str(getattr(response, "id", "") or ""),
+            cache_read_tokens=_cached_tokens(usage),
+            cache_creation_tokens=0,
+        )
+
+    @staticmethod
+    def _first_tool_call(message: object) -> object:
+        """Return the message's first tool call, or raise if there is none.
+
+        The forced ``tool_choice`` makes a missing tool call a
+        provider/protocol error, mirroring Anthropic's "Expected
+        ToolUseBlock" check.
+
+        Args:
+            message: The first choice's message object.
+
+        Returns:
+            The first entry of ``message.tool_calls``.
+
+        Raises:
+            GenerationError: If the message carries no tool calls.
+        """
+        tool_calls = list(getattr(message, "tool_calls", None) or [])
+        if not tool_calls:
+            msg = "Expected a tool call in response"
+            raise GenerationError(msg)
+        return tool_calls[0]
+
+    @staticmethod
+    def _parse_tool_arguments(raw: object) -> dict[str, object]:
+        """Parse the tool call's JSON ``arguments`` string into a dict.
+
+        Unlike Anthropic (which returns ``input`` pre-parsed), OpenAI
+        delivers tool arguments as a JSON *string* that may be
+        malformed; every failure mode maps to :class:`GenerationError`
+        so callers see one error surface across providers.
+
+        Args:
+            raw: The ``function.arguments`` payload.
+
+        Returns:
+            The parsed JSON object.
+
+        Raises:
+            GenerationError: If ``raw`` is not a string, not valid
+                JSON, or not a JSON object.
+        """
+        if not isinstance(raw, str):
+            msg = "Tool arguments were not a JSON string"
+            raise GenerationError(msg)
+        try:
+            parsed: object = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            msg = "Tool arguments were not valid JSON"
+            raise GenerationError(msg, cause=exc) from exc
+        if not isinstance(parsed, dict):
+            msg = "Tool input was not a JSON object"
+            raise GenerationError(msg)
+        return cast("dict[str, object]", parsed)
+
+    # ------------------------------ sync complete ----------------------------
+    def generate(self, prompt: str, output_format: OutputFormat) -> GenerationResult:
+        """Generate content via the Chat Completions API (synchronous).
+
+        Args:
+            prompt: Prompt describing what to generate.
+            output_format: Desired output format (yaml, toml, markdown,
+                bash).
+
+        Returns:
+            GenerationResult containing generated content and metadata.
+
+        Raises:
+            GenerationError: If the API call fails after retries or
+                the response is malformed.
+            ProviderUnavailableError: If the ``openai`` extra is not
+                installed.
+        """
+        # Resolve the SDK client lazily through the module __getattr__
+        # seam so the module imports without the optional extra; a
+        # missing extra becomes an actionable ProviderUnavailableError.
+        client_cls = cast("type[OpenAI]", _sdk_attr("OpenAI"))
+
+        with client_cls(
+            api_key=self._api_key,
+            base_url=self._resolve_base_url(),
+        ) as client:
+            return self._retry_sync(
+                lambda: self._call_api(client, prompt, output_format),
+            )
+
+    def _call_api(
+        self,
+        client: OpenAI,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Make one sync Chat Completions call and map the response.
+
+        The SDK method is typed against deeply-nested TypedDict unions;
+        the request body is built as plain dicts (pinned by tests), so
+        a single documented ``cast`` at the SDK boundary asserts the
+        contract instead of a ``type: ignore`` suppressing it.
+        """
+        create = cast(
+            "Callable[..., object]",
+            client.chat.completions.create,
+        )
+        response = create(**self._completion_params(prompt, output_format))
+        return self._result_from_completion(response, output_format)
+
+    # ----------------------------- async complete ----------------------------
+    def _get_async_client(self) -> AsyncOpenAI:
+        """Return the cached ``AsyncOpenAI`` client, creating it once.
+
+        Safe under asyncio for the same reason as the Anthropic
+        provider: no ``await`` between the check and the assignment.
+        Do *not* call this from a thread pool.
+        """
+        if self._async_client is None:
+            async_cls = cast("type[AsyncOpenAI]", _sdk_attr("AsyncOpenAI"))
+            self._async_client = async_cls(
+                api_key=self._api_key,
+                base_url=self._resolve_base_url(),
+            )
+        return self._async_client
+
+    async def generate_async(
+        self,
+        prompt: str,
+        output_format: OutputFormat,
+    ) -> GenerationResult:
+        """Async equivalent of :meth:`generate`.
+
+        Reuses a single long-lived ``AsyncOpenAI`` client per provider
+        instance so concurrent calls share the httpx connection pool.
+        Callers should ``await`` :meth:`aclose` when finished.
+
+        Args:
+            prompt: Prompt describing what to generate.
+            output_format: Desired output format.
+
+        Returns:
+            A populated :class:`GenerationResult`.
+
+        Raises:
+            GenerationError: If the API call fails after retries or
+                the response is malformed.
+        """
+        client = self._get_async_client()
+        return await self._retry_async(
+            lambda: self._call_api_async(client, prompt, output_format),
+        )
+
+    async def _call_api_async(
+        self,
+        client: AsyncOpenAI,
+        prompt: str,
+        output_format: str,
+    ) -> GenerationResult:
+        """Async counterpart of :meth:`_call_api`."""
+        create = cast(
+            "Callable[..., Awaitable[object]]",
+            client.chat.completions.create,
+        )
+        response = await create(**self._completion_params(prompt, output_format))
+        return self._result_from_completion(response, output_format)
+
+    # -------------------------------- tool use -------------------------------
+    async def generate_tool_use_async(
+        self,
+        prompt: str,
+        *,
+        system_blocks: list[dict[str, object]],
+        tool_schema: dict[str, object],
+    ) -> ToolUseResult:
+        """Run a structured (forced tool-use) generation.
+
+        The neutral tool definition is translated to an OpenAI function
+        tool, its invocation is forced via ``tool_choice``, and the
+        returned JSON ``arguments`` are parsed into the neutral
+        :class:`ToolUseResult` — so callers see exactly the contract
+        the Anthropic provider honors.
+
+        Args:
+            prompt: User-message body (per-call delta).
+            system_blocks: Neutral system-prompt blocks. Anthropic
+                ``cache_control`` markers are accepted and dropped
+                (OpenAI caches prompts automatically).
+            tool_schema: Neutral tool definition with ``name``,
+                ``description``, and ``input_schema`` keys.
+
+        Returns:
+            :class:`ToolUseResult` with the parsed ``tool_input`` dict
+            and token telemetry.
+
+        Raises:
+            GenerationError: If the call fails after retries, the
+                schema lacks a name, or the response carries no
+                parseable tool call.
+        """
+        client = self._get_async_client()
+        params = self._tool_request_params(prompt, system_blocks, tool_schema)
+        return await self._retry_async(
+            lambda: self._call_tool_api_async(client, params),
+        )
+
+    async def _call_tool_api_async(
+        self,
+        client: AsyncOpenAI,
+        params: dict[str, object],
+    ) -> ToolUseResult:
+        """Make one forced-tool call and map the response.
+
+        Args:
+            client: The cached async client.
+            params: Pre-built request body from
+                :meth:`_tool_request_params`.
+
+        Returns:
+            The mapped :class:`ToolUseResult`.
+        """
+        create = cast(
+            "Callable[..., Awaitable[object]]",
+            client.chat.completions.create,
+        )
+        response = await create(**params)
+        return self._tool_result_from_completion(response)
+
+    # -------------------------------- lifecycle ------------------------------
+    async def aclose(self) -> None:
+        """Release the cached async client, if any.
+
+        Idempotent. Safe to call from a finally block even when no
+        async calls were made.
+        """
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None
+
+    # ---------------------------------- batch --------------------------------
+    async def submit_tool_use_batch(
+        self,
+        requests: Sequence[ToolUseBatchRequest],
+    ) -> BatchSubmission:
+        """Decline batch submission: there is no OpenAI-compatible batch seam.
+
+        The batch capability group maps onto Anthropic's Message
+        Batches API; emulating it with fan-out requests would silently
+        change cost and durability semantics, so this provider
+        declines honestly (capability negotiation/fallback is tracer
+        T5, #389). The interface's input contract is still honored
+        first so callers get the most specific error.
+
+        Args:
+            requests: Validated for emptiness, then declined.
+
+        Raises:
+            ValueError: If ``requests`` is empty (per the interface).
+            UnsupportedCapabilityError: For every non-empty submission.
+        """
+        if not requests:
+            msg = "submit_tool_use_batch requires at least one request"
+            raise ValueError(msg)
+        raise UnsupportedCapabilityError(
+            provider=_PROVIDER_NAME,
+            capability="batch tool-use",
+        )
+
+    async def poll_batch(self, batch_id: str) -> BatchPoll:
+        """Decline batch polling; see :meth:`submit_tool_use_batch`.
+
+        Args:
+            batch_id: Validated for emptiness, then declined.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty (per the interface).
+            UnsupportedCapabilityError: For every non-empty id.
+        """
+        if not batch_id:
+            msg = "poll_batch requires a non-empty batch_id"
+            raise ValueError(msg)
+        raise UnsupportedCapabilityError(
+            provider=_PROVIDER_NAME,
+            capability="batch tool-use",
+        )
+
+    async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
+        """Decline batch fetching; see :meth:`submit_tool_use_batch`.
+
+        Args:
+            batch_id: Validated for emptiness, then declined.
+
+        Raises:
+            ValueError: If ``batch_id`` is empty (per the interface).
+            UnsupportedCapabilityError: For every non-empty id.
+        """
+        if not batch_id:
+            msg = "fetch_batch_results requires a non-empty batch_id"
+            raise ValueError(msg)
+        raise UnsupportedCapabilityError(
+            provider=_PROVIDER_NAME,
+            capability="batch tool-use",
+        )

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -162,7 +162,9 @@ provider_option = Annotated[
             "LLM provider for AI features. Precedence: this flag > "
             "GREEN_LLM_PROVIDER env > config file > default (anthropic). "
             "The provider's API key is read from its own env var "
-            "(ANTHROPIC_API_KEY for anthropic)."
+            "(ANTHROPIC_API_KEY for anthropic, OPENAI_API_KEY for openai). "
+            "For openai, OPENAI_BASE_URL points at any OpenAI-compatible "
+            "local server (a dummy key is fine there)."
         ),
     ),
 ]

--- a/tests/unit/ai/test_openai_provider.py
+++ b/tests/unit/ai/test_openai_provider.py
@@ -1,0 +1,840 @@
+"""Unit tests for the OpenAI-compatible provider (tracer T3, #385).
+
+Pins the second concrete :class:`LLMProvider` implementation:
+
+* ``OpenAIProvider`` satisfies the full interface with no I/O at
+  construction time.
+* Completion and tool-use round-trip through the provider-neutral
+  request/response types (Anthropic-shaped ``system_blocks`` /
+  ``tool_schema`` in, :class:`GenerationResult` /
+  :class:`ToolUseResult` out) against a mocked SDK — no live network.
+* The base URL for local/OSS OpenAI-compatible servers plumbs through
+  from the constructor or ``OPENAI_BASE_URL``.
+* Batch capabilities are honestly declared unsupported via the typed
+  :class:`UnsupportedCapabilityError`.
+* The module imports — and ``build_provider("openai")`` constructs —
+  without the optional ``openai`` extra installed; only *using* the
+  provider requires it, and then with an actionable install hint.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from start_green_stay_green.ai.batch import ToolUseBatchRequest
+from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
+from start_green_stay_green.ai.providers import LLMProvider
+from start_green_stay_green.ai.providers import OpenAIProvider
+from start_green_stay_green.ai.providers import UnsupportedCapabilityError
+from start_green_stay_green.ai.providers import openai_provider
+from start_green_stay_green.ai.types import GenerationError
+from start_green_stay_green.ai.types import GenerationResult
+from start_green_stay_green.ai.types import ToolUseResult
+from start_green_stay_green.utils.timing import TimingReport
+from start_green_stay_green.utils.timing import set_active_report
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterator
+
+_MODEL = "gpt-5.5"
+
+
+def _completion_response(
+    content: str | None = "hello",
+    *,
+    cached_tokens: int = 0,
+) -> MagicMock:
+    """Build a mock Chat Completions response carrying text content."""
+    response = MagicMock()
+    response.id = "chatcmpl-1"
+    response.model = _MODEL
+    response.usage.prompt_tokens = 11
+    response.usage.completion_tokens = 4
+    response.usage.prompt_tokens_details.cached_tokens = cached_tokens
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = None
+    choice = MagicMock()
+    choice.message = message
+    response.choices = [choice]
+    return response
+
+
+def _tool_call_response(
+    name: str = "report_tuning",
+    arguments: object = '{"k": "v"}',
+) -> MagicMock:
+    """Build a mock Chat Completions response carrying one tool call."""
+    response = _completion_response(content=None)
+    call = MagicMock()
+    call.function.name = name
+    call.function.arguments = arguments
+    response.choices[0].message.tool_calls = [call]
+    return response
+
+
+def _sync_client_cls(create: MagicMock) -> tuple[MagicMock, MagicMock]:
+    """Build a mock ``OpenAI`` class whose context manager yields a client.
+
+    Returns:
+        ``(client_cls, client)`` so tests can assert on both the
+        constructor kwargs and the ``create`` call.
+    """
+    client = MagicMock()
+    client.chat.completions.create = create
+    client_cls = MagicMock()
+    client_cls.return_value.__enter__.return_value = client
+    client_cls.return_value.__exit__.return_value = False
+    return client_cls, client
+
+
+def _async_client(create: AsyncMock) -> MagicMock:
+    """Build a mock ``AsyncOpenAI`` client with awaitable create/close."""
+    client = MagicMock()
+    client.chat.completions.create = create
+    client.close = AsyncMock()
+    return client
+
+
+def _block_openai_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make resolving the ``openai`` SDK raise ``ModuleNotFoundError``.
+
+    Simulates the optional extra being absent without uninstalling it
+    from the test environment, mirroring the Anthropic-extra tests:
+    the provider's lazy seam resolves the SDK through
+    :func:`importlib.import_module`, so patching that to reject
+    ``openai`` faithfully reproduces a missing extra.
+    """
+    real_import_module: Callable[..., object] = importlib.import_module
+
+    def _fake_import_module(name: str, *args: object, **kwargs: object) -> object:
+        if name == "openai" or name.startswith("openai."):
+            msg = "No module named 'openai'"
+            raise ModuleNotFoundError(msg)
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+
+@pytest.fixture
+def active_report() -> Iterator[TimingReport]:
+    """Install a fresh ``TimingReport`` for the test, then clear it."""
+    report = TimingReport()
+    set_active_report(report)
+    try:
+        yield report
+    finally:
+        set_active_report(None)
+
+
+@pytest.fixture
+def no_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``OPENAI_BASE_URL`` is unset so tests are hermetic."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+class TestOpenAIProviderSatisfiesInterface:
+    """``OpenAIProvider`` must be a concrete, no-I/O ``LLMProvider``."""
+
+    def test_is_subclass_of_llm_provider(self) -> None:
+        """The provider subclasses the abstract interface."""
+        assert issubclass(OpenAIProvider, LLMProvider)
+
+    def test_instance_is_an_llm_provider(self) -> None:
+        """A constructed provider satisfies isinstance checks."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        assert isinstance(provider, LLMProvider)
+
+    def test_implements_every_abstract_method(self) -> None:
+        """No abstract methods remain unimplemented."""
+        assert not OpenAIProvider.__abstractmethods__
+
+    def test_model_property_returns_configured_id(self) -> None:
+        """``model`` echoes the constructor argument verbatim."""
+        provider = OpenAIProvider("sk-test", model="local-llama")
+        assert provider.model == "local-llama"
+
+    def test_construction_performs_no_io(self) -> None:
+        """Constructing the provider allocates no network client."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        assert provider._async_client is None
+
+    def test_default_retry_policy_matches_anthropic_provider(self) -> None:
+        """Retry defaults stay consistent across providers."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        assert provider.max_retries == 3
+        assert provider.retry_delay == 1.0
+
+    def test_retry_schedule_is_exponential_and_last_has_no_sleep(self) -> None:
+        """The schedule doubles the delay and ends with ``None``."""
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=2, retry_delay=1.5
+        )
+        schedule = list(provider._retry_schedule())
+        assert schedule == [(0, 1.5), (1, 3.0), (2, None)]
+
+
+class TestSyncGenerate:
+    """Sync completion maps the Chat Completions response faithfully."""
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_returns_mapped_generation_result(self) -> None:
+        """Content, token usage, model, and id all round-trip."""
+        create = MagicMock(return_value=_completion_response("hi", cached_tokens=3))
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            result = provider.generate("p", "yaml")
+
+        assert isinstance(result, GenerationResult)
+        assert result.content == "hi"
+        assert result.format == "yaml"
+        assert result.token_usage.input_tokens == 11
+        assert result.token_usage.output_tokens == 4
+        assert result.token_usage.total_tokens == 15
+        assert result.cache_read_tokens == 3
+        assert result.cache_creation_tokens == 0
+        assert result.model == _MODEL
+        assert result.message_id == "chatcmpl-1"
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_sends_system_and_user_messages(self) -> None:
+        """The request carries the format system prompt and the user prompt."""
+        create = MagicMock(return_value=_completion_response())
+        client_cls, client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("write it", "toml")
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == _MODEL
+        assert kwargs["max_tokens"] == 4096
+        assert kwargs["messages"] == [
+            {
+                "role": "system",
+                "content": ("Generate toml output. Follow the instructions precisely."),
+            },
+            {"role": "user", "content": "write it"},
+        ]
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_client_receives_api_key(self) -> None:
+        """The sync client is constructed with the configured key."""
+        create = MagicMock(return_value=_completion_response())
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-local", model=_MODEL)
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("p", "yaml")
+
+        assert (
+            client_cls.call_args.kwargs["api_key"]
+            == "sk-local"  # pragma: allowlist secret
+        )
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_missing_text_content_raises(self) -> None:
+        """A ``None`` message content is a hard error, not a retry."""
+        create = MagicMock(return_value=_completion_response(content=None))
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with (
+            patch.object(openai_provider, "OpenAI", client_cls, create=True),
+            pytest.raises(GenerationError, match="Expected text content"),
+        ):
+            provider.generate("p", "yaml")
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_empty_choices_raises(self) -> None:
+        """A response with no choices is rejected."""
+        response = _completion_response()
+        response.choices = []
+        create = MagicMock(return_value=response)
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with (
+            patch.object(openai_provider, "OpenAI", client_cls, create=True),
+            pytest.raises(GenerationError, match="no choices"),
+        ):
+            provider.generate("p", "yaml")
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_retries_then_succeeds(self) -> None:
+        """A transient failure is retried, then the success returned."""
+        create = MagicMock(
+            side_effect=[RuntimeError("boom"), _completion_response("ok")],
+        )
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=2, retry_delay=0.0
+        )
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            result = provider.generate("p", "yaml")
+
+        assert result.content == "ok"
+        assert create.call_count == 2
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_exhausted_retries_raise_with_cause(
+        self, active_report: TimingReport
+    ) -> None:
+        """Persistent failure raises and records a zero-token call."""
+        boom = RuntimeError("always down")
+        create = MagicMock(side_effect=boom)
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=0, retry_delay=0.001
+        )
+
+        with (
+            patch.object(openai_provider, "OpenAI", client_cls, create=True),
+            pytest.raises(GenerationError, match="Failed to generate content") as exc,
+        ):
+            provider.generate("p", "yaml")
+
+        assert exc.value.cause is boom
+        assert len(active_report.api_calls) == 1
+        assert active_report.api_calls[0].input_tokens == 0
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_success_records_token_telemetry(self, active_report: TimingReport) -> None:
+        """A successful call records its token counts on the report."""
+        create = MagicMock(return_value=_completion_response(cached_tokens=2))
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("p", "yaml")
+
+        assert len(active_report.api_calls) == 1
+        record = active_report.api_calls[0]
+        assert record.input_tokens == 11
+        assert record.output_tokens == 4
+        assert record.cache_read_tokens == 2
+
+
+class TestAsyncGenerate:
+    """Async completion mirrors the sync mapping over a cached client."""
+
+    @pytest.mark.asyncio
+    async def test_returns_mapped_generation_result(self) -> None:
+        """A successful async call yields a populated result."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(
+            AsyncMock(return_value=_completion_response("hello"))
+        )
+        try:
+            result = await provider.generate_async("p", "markdown")
+        finally:
+            await provider.aclose()
+
+        assert isinstance(result, GenerationResult)
+        assert result.content == "hello"
+        assert result.format == "markdown"
+        assert result.token_usage.input_tokens == 11
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self) -> None:
+        """The async retry loop recovers from a transient failure."""
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=2, retry_delay=0.0
+        )
+        provider._async_client = _async_client(
+            AsyncMock(side_effect=[RuntimeError("boom"), _completion_response("ok")]),
+        )
+        try:
+            result = await provider.generate_async("p", "yaml")
+        finally:
+            await provider.aclose()
+
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_raise(self, active_report: TimingReport) -> None:
+        """Persistent async failure raises and records a failure call."""
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=0, retry_delay=0.001
+        )
+        provider._async_client = _async_client(
+            AsyncMock(side_effect=RuntimeError("down"))
+        )
+
+        try:
+            with pytest.raises(GenerationError, match="Failed to generate content"):
+                await provider.generate_async("p", "yaml")
+        finally:
+            await provider.aclose()
+
+        assert len(active_report.api_calls) == 1
+        assert active_report.api_calls[0].input_tokens == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("no_base_url_env")
+    async def test_async_client_is_created_once_and_reused(self) -> None:
+        """The async client is cached across calls (shared pool)."""
+        create = AsyncMock(return_value=_completion_response())
+        client = _async_client(create)
+        client_cls = MagicMock(return_value=client)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with patch.object(openai_provider, "AsyncOpenAI", client_cls, create=True):
+            try:
+                await provider.generate_async("p", "yaml")
+                await provider.generate_async("p", "yaml")
+            finally:
+                await provider.aclose()
+
+        assert client_cls.call_count == 1
+        assert (
+            client_cls.call_args.kwargs["api_key"]
+            == "sk-test"  # pragma: allowlist secret
+        )
+
+
+class TestToolUse:
+    """Tool-use round-trips through the provider-neutral types."""
+
+    @pytest.mark.asyncio
+    async def test_tool_use_round_trip(self) -> None:
+        """The neutral tool schema and result translate both ways."""
+        create = AsyncMock(
+            return_value=_tool_call_response(
+                "report_tuning", json.dumps({"tuned_content": "x", "changes": []})
+            )
+        )
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            result = await provider.generate_tool_use_async(
+                "tune this",
+                system_blocks=[
+                    {
+                        "type": "text",
+                        "text": "You are a tuner.",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+                tool_schema={
+                    "name": "report_tuning",
+                    "description": "Report the tuned content.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"tuned_content": {"type": "string"}},
+                        "required": ["tuned_content"],
+                    },
+                },
+            )
+        finally:
+            await provider.aclose()
+
+        assert isinstance(result, ToolUseResult)
+        assert result.tool_name == "report_tuning"
+        assert result.tool_input == {"tuned_content": "x", "changes": []}
+        assert result.token_usage.input_tokens == 11
+        assert result.model == _MODEL
+        assert result.message_id == "chatcmpl-1"
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["tools"] == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "report_tuning",
+                    "description": "Report the tuned content.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"tuned_content": {"type": "string"}},
+                        "required": ["tuned_content"],
+                    },
+                },
+            },
+        ]
+        assert kwargs["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "report_tuning"},
+        }
+        # ``cache_control`` is Anthropic-specific and must not leak into
+        # the OpenAI request; the block text becomes the system message.
+        assert kwargs["messages"][0] == {
+            "role": "system",
+            "content": "You are a tuner.",
+        }
+        assert kwargs["messages"][1] == {"role": "user", "content": "tune this"}
+
+    @pytest.mark.asyncio
+    async def test_multiple_system_blocks_are_joined(self) -> None:
+        """Several system blocks collapse into one system message."""
+        create = AsyncMock(return_value=_tool_call_response())
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            await provider.generate_tool_use_async(
+                "p",
+                system_blocks=[
+                    {"type": "text", "text": "First."},
+                    {"type": "text", "text": "Second."},
+                ],
+                tool_schema={"name": "report_tuning"},
+            )
+        finally:
+            await provider.aclose()
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["messages"][0] == {
+            "role": "system",
+            "content": "First.\n\nSecond.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_system_blocks_send_no_system_message(self) -> None:
+        """No system message is sent when there is nothing to say."""
+        create = AsyncMock(return_value=_tool_call_response())
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            await provider.generate_tool_use_async(
+                "p",
+                system_blocks=[],
+                tool_schema={"name": "report_tuning"},
+            )
+        finally:
+            await provider.aclose()
+
+        kwargs = create.call_args.kwargs
+        assert kwargs["messages"] == [{"role": "user", "content": "p"}]
+
+    @pytest.mark.asyncio
+    async def test_missing_tool_name_raises(self) -> None:
+        """A schema without a non-empty name fails before any request."""
+        create = AsyncMock(return_value=_tool_call_response())
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            with pytest.raises(GenerationError, match="non-empty 'name'"):
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": ""}
+                )
+        finally:
+            await provider.aclose()
+        create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_response_without_tool_call_raises(self) -> None:
+        """A response lacking tool calls is a hard error."""
+        create = AsyncMock(return_value=_completion_response("just text"))
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            with pytest.raises(GenerationError, match="Expected a tool call"):
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": "report_tuning"}
+                )
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_arguments_raise_with_cause(self) -> None:
+        """Malformed JSON arguments surface as a chained GenerationError."""
+        create = AsyncMock(
+            return_value=_tool_call_response(arguments="{not json"),
+        )
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            with pytest.raises(GenerationError, match="not valid JSON") as exc:
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": "report_tuning"}
+                )
+        finally:
+            await provider.aclose()
+        assert isinstance(exc.value.cause, json.JSONDecodeError)
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_arguments_raise(self) -> None:
+        """A JSON array payload is rejected like Anthropic's non-dict input."""
+        create = AsyncMock(
+            return_value=_tool_call_response(arguments='["not", "a", "dict"]'),
+        )
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            with pytest.raises(GenerationError, match="not a JSON object"):
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": "report_tuning"}
+                )
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_non_string_arguments_raise(self) -> None:
+        """Arguments that are not a JSON string are rejected."""
+        create = AsyncMock(return_value=_tool_call_response(arguments=None))
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        provider._async_client = _async_client(create)
+
+        try:
+            with pytest.raises(GenerationError, match="not a JSON string"):
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": "report_tuning"}
+                )
+        finally:
+            await provider.aclose()
+
+    @pytest.mark.asyncio
+    async def test_tool_use_retries_then_raises_on_exhaustion(self) -> None:
+        """The tool-use retry loop raises when retries run out."""
+        provider = OpenAIProvider(
+            "sk-test", model=_MODEL, max_retries=1, retry_delay=0.0
+        )
+        provider._async_client = _async_client(
+            AsyncMock(side_effect=RuntimeError("down"))
+        )
+
+        try:
+            with pytest.raises(GenerationError, match="Failed to generate content"):
+                await provider.generate_tool_use_async(
+                    "p", system_blocks=[], tool_schema={"name": "report_tuning"}
+                )
+        finally:
+            await provider.aclose()
+
+
+class TestBaseURL:
+    """The endpoint override plumbs through for local/OSS servers."""
+
+    def test_constructor_base_url_reaches_sync_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit ``base_url`` wins over the environment."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env.example/v1")
+        create = MagicMock(return_value=_completion_response())
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider(
+            "sk-local", model="llama3", base_url="http://localhost:11434/v1"
+        )
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("p", "yaml")
+
+        assert client_cls.call_args.kwargs["base_url"] == "http://localhost:11434/v1"
+
+    def test_env_base_url_used_when_constructor_omits_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``OPENAI_BASE_URL`` applies when no explicit override is given."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+        create = MagicMock(return_value=_completion_response())
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-local", model="llama3")
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("p", "yaml")
+
+        assert client_cls.call_args.kwargs["base_url"] == "http://localhost:8000/v1"
+
+    @pytest.mark.usefixtures("no_base_url_env")
+    def test_default_base_url_is_none(self) -> None:
+        """Without any override the SDK default endpoint is used."""
+        create = MagicMock(return_value=_completion_response())
+        client_cls, _client = _sync_client_cls(create)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with patch.object(openai_provider, "OpenAI", client_cls, create=True):
+            provider.generate("p", "yaml")
+
+        assert client_cls.call_args.kwargs["base_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_base_url_reaches_async_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cached async client honors the same override."""
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        create = AsyncMock(return_value=_completion_response())
+        client = _async_client(create)
+        client_cls = MagicMock(return_value=client)
+        provider = OpenAIProvider(
+            "sk-local", model="llama3", base_url="http://localhost:1234/v1"
+        )
+
+        with patch.object(openai_provider, "AsyncOpenAI", client_cls, create=True):
+            try:
+                await provider.generate_async("p", "yaml")
+            finally:
+                await provider.aclose()
+
+        assert client_cls.call_args.kwargs["base_url"] == "http://localhost:1234/v1"
+
+
+class TestBatchUnsupported:
+    """Batch is Anthropic-specific; this provider declines it honestly."""
+
+    @pytest.mark.asyncio
+    async def test_submit_tool_use_batch_raises_typed_error(self) -> None:
+        """Submitting a batch raises the typed capability error."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        request = ToolUseBatchRequest(
+            custom_id="a",
+            prompt="p",
+            system_blocks=[],
+            tool_schema={"name": "report_tuning"},
+        )
+        with pytest.raises(UnsupportedCapabilityError, match="batch"):
+            await provider.submit_tool_use_batch([request])
+
+    @pytest.mark.asyncio
+    async def test_poll_batch_raises_typed_error(self) -> None:
+        """Polling a batch raises the typed capability error."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        with pytest.raises(UnsupportedCapabilityError, match="batch"):
+            await provider.poll_batch("b1")
+
+    @pytest.mark.asyncio
+    async def test_fetch_batch_results_raises_typed_error(self) -> None:
+        """Fetching batch results raises the typed capability error."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        with pytest.raises(UnsupportedCapabilityError, match="batch"):
+            await provider.fetch_batch_results("b1")
+
+    @pytest.mark.asyncio
+    async def test_error_names_provider_and_capability(self) -> None:
+        """The error is introspectable for T5 capability negotiation."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        with pytest.raises(UnsupportedCapabilityError) as exc:
+            await provider.poll_batch("b1")
+        assert exc.value.provider == "openai"
+        assert exc.value.capability == "batch tool-use"
+        assert "openai" in str(exc.value)
+
+    def test_error_is_a_not_implemented_error(self) -> None:
+        """Callers catching ``NotImplementedError`` still catch it."""
+        assert issubclass(UnsupportedCapabilityError, NotImplementedError)
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_submission_raises_value_error(self) -> None:
+        """The interface's input contract is honored before declining."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        with pytest.raises(ValueError, match="at least one request"):
+            await provider.submit_tool_use_batch([])
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_id_raises_value_error(self) -> None:
+        """Empty ids fail with the interface's ValueError, not the decline."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        with pytest.raises(ValueError, match="poll_batch requires"):
+            await provider.poll_batch("")
+        with pytest.raises(ValueError, match="fetch_batch_results requires"):
+            await provider.fetch_batch_results("")
+
+
+class TestMissingExtra:
+    """The ``openai`` package is optional; absence is reported actionably."""
+
+    def test_generate_without_extra_raises_install_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Using the provider without the SDK yields a pip install hint."""
+        _block_openai_import(monkeypatch)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with pytest.raises(ProviderUnavailableError) as exc:
+            provider.generate("hello", "yaml")
+
+        message = str(exc.value)
+        assert "pip install" in message
+        assert "openai" in message
+        assert isinstance(exc.value.__cause__, ImportError)
+
+    @pytest.mark.asyncio
+    async def test_generate_async_without_extra_raises_install_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The async path reports the missing extra the same way."""
+        _block_openai_import(monkeypatch)
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+
+        with pytest.raises(ProviderUnavailableError, match="pip install"):
+            await provider.generate_async("hello", "yaml")
+
+    def test_unknown_module_attribute_raises_attribute_error(self) -> None:
+        """The lazy seam only resolves known SDK exports."""
+        with pytest.raises(AttributeError, match="has no attribute"):
+            _ = openai_provider.NotAnExport
+
+    def test_core_imports_cleanly_with_openai_absent(self) -> None:
+        """Importing the package and building the provider needs no SDK.
+
+        Runs in a subprocess with a meta-path finder that blocks the
+        ``openai`` package entirely, proving the module performs no
+        top-level SDK import (hermetic — no network involved).
+        """
+        code = (
+            "import sys\n"
+            "import importlib.abc\n"
+            "class _Block(importlib.abc.MetaPathFinder):\n"
+            "    def find_spec(self, name, path=None, target=None):\n"
+            "        if name == 'openai' or name.startswith('openai.'):\n"
+            "            raise ModuleNotFoundError(name)\n"
+            "        return None\n"
+            "sys.meta_path.insert(0, _Block())\n"
+            "import start_green_stay_green\n"
+            "from start_green_stay_green.ai.provider_selection import "
+            "build_provider\n"
+            "provider = build_provider('openai', api_key='dummy', model='m')\n"
+            "print(provider.model)\n"
+        )
+        completed = subprocess.run(  # noqa: S603 — fixed argv, our interpreter
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert completed.stdout.strip() == "m"
+
+
+class TestAclose:
+    """Lifecycle: the cached async client is released idempotently."""
+
+    @pytest.mark.asyncio
+    async def test_aclose_without_client_is_safe(self) -> None:
+        """``aclose`` is a no-op when no async work happened."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        await provider.aclose()
+        assert provider._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_and_clears_cached_client(self) -> None:
+        """``aclose`` closes the cached client and forgets it."""
+        provider = OpenAIProvider("sk-test", model=_MODEL)
+        client = _async_client(AsyncMock())
+        provider._async_client = client
+
+        await provider.aclose()
+        await provider.aclose()  # idempotent
+
+        client.close.assert_awaited_once()
+        assert provider._async_client is None

--- a/tests/unit/ai/test_provider_selection.py
+++ b/tests/unit/ai/test_provider_selection.py
@@ -33,6 +33,7 @@ from start_green_stay_green.ai.provider_selection import _coalesce
 from start_green_stay_green.ai.provider_selection import build_provider
 from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
 from start_green_stay_green.ai.provider_selection import resolve_provider_selection
+from start_green_stay_green.ai.provider_selection import supported_providers
 from start_green_stay_green.ai.providers.base import LLMProvider
 
 if TYPE_CHECKING:
@@ -125,12 +126,13 @@ def test_unknown_provider_raises_with_supported_set() -> None:
     """An unknown provider fails loudly and names the supported set."""
     with pytest.raises(ValueError, match="Unknown LLM provider") as exc:
         resolve_provider_selection(
-            provider_flag="openai",
+            provider_flag="does-not-exist",
             model_flag=None,
             config={},
             env={},
         )
     assert "anthropic" in str(exc.value)
+    assert "openai" in str(exc.value)
 
 
 def test_blank_provider_falls_through_to_next_tier() -> None:
@@ -262,7 +264,7 @@ def test_build_provider_returns_anthropic_instance() -> None:
 def test_build_provider_unknown_raises() -> None:
     """Building an unknown provider raises a clear ValueError."""
     with pytest.raises(ValueError, match="Unknown LLM provider"):
-        build_provider("openai", api_key="x", model="m")
+        build_provider("does-not-exist", api_key="x", model="m")
 
 
 def _block_anthropic_import(
@@ -324,3 +326,97 @@ def test_missing_extra_raises_actionable_error_on_use(
 def test_provider_unavailable_is_importerror_subclass() -> None:
     """Callers catching ImportError still catch the friendlier error."""
     assert issubclass(ProviderUnavailableError, ImportError)
+
+
+# --------------------------- openai (T3, #385) -----------------------------
+def test_supported_providers_includes_openai() -> None:
+    """The registry exposes both providers in sorted order."""
+    assert supported_providers() == ("anthropic", "openai")
+
+
+def test_openai_api_key_env_var() -> None:
+    """The OpenAI key is read from ``OPENAI_API_KEY``."""
+    assert resolve_api_key_env_var("openai") == "OPENAI_API_KEY"
+
+
+def test_openai_selection_uses_provider_default_model() -> None:
+    """``--provider openai`` without a model uses the OpenAI default.
+
+    The Anthropic default model id would be rejected by an OpenAI
+    endpoint, so the tier-4 default must follow the selected provider.
+    """
+    selection = resolve_provider_selection(
+        provider_flag="openai",
+        model_flag=None,
+        config={},
+        env={},
+    )
+    assert selection.provider == "openai"
+    assert selection.model == "gpt-5.5"
+    assert selection.model != DEFAULT_MODEL
+
+
+def test_openai_selection_honors_explicit_model() -> None:
+    """An explicit model flag overrides the provider default verbatim."""
+    selection = resolve_provider_selection(
+        provider_flag="openai",
+        model_flag="llama3.1:8b",
+        config={},
+        env={},
+    )
+    assert selection.model == "llama3.1:8b"
+
+
+def test_build_provider_returns_openai_instance() -> None:
+    """``build_provider`` constructs the OpenAI provider when selected."""
+    provider = build_provider(
+        "openai",
+        api_key="sk-test",  # pragma: allowlist secret
+        model="gpt-5.5",
+        max_retries=2,
+        retry_delay=0.5,
+    )
+    assert isinstance(provider, LLMProvider)
+    assert type(provider).__name__ == "OpenAIProvider"
+    assert provider.model == "gpt-5.5"
+
+
+def _block_openai_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make resolving the ``openai`` SDK raise ``ModuleNotFoundError``.
+
+    Same seam as :func:`_block_anthropic_import`, for the second extra.
+    """
+    real_import_module: Callable[..., object] = importlib.import_module
+
+    def _fake_import_module(name: str, *args: object, **kwargs: object) -> object:
+        if name == "openai" or name.startswith("openai."):
+            msg = "No module named 'openai'"
+            raise ModuleNotFoundError(msg)
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+
+def test_build_openai_provider_succeeds_without_touching_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructing the OpenAI provider never imports its SDK."""
+    _block_openai_import(monkeypatch)
+    provider = build_provider("openai", api_key="x", model="m")
+    assert provider.model == "m"
+
+
+def test_missing_openai_extra_raises_actionable_error_on_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Using the OpenAI provider without its extra yields an install hint."""
+    _block_openai_import(monkeypatch)
+    provider = build_provider("openai", api_key="x", model="m")
+
+    with pytest.raises(ProviderUnavailableError) as exc:
+        provider.generate("hello", "yaml")
+
+    message = str(exc.value)
+    assert "pip install" in message
+    assert "[openai]" in message
+    assert isinstance(exc.value.__cause__, ImportError)


### PR DESCRIPTION
## Summary

Implements multi-agent tracer **T3**: a second `LLMProvider` — `OpenAIProvider` — validating the provider seam (#381) and selection machinery (#383) end-to-end with a non-Anthropic backend.

- **`OpenAIProvider`** (`start_green_stay_green/ai/providers/openai_provider.py`) implements every `LLMProvider` method, mapping sync/async completion and tool-use onto the `openai` SDK's `chat.completions` API. Neutral types translate both ways: system instructions → `system`-role message; neutral tool definitions → `{"type":"function",...}` with forced `tool_choice`; JSON-string `arguments` parsed back to `tool_input` with typed errors for malformed payloads; `usage.prompt_tokens_details.cached_tokens` → `cache_read_tokens` (OpenAI reports cache reads only — `cache_creation_tokens=0`, documented).
- **Batch declared unsupported** via a new `UnsupportedCapabilityError(NotImplementedError)` in `providers/base.py` carrying machine-readable `provider`/`capability` attributes — the minimal honest convention for T5 (#389) capability negotiation to build on. Batch methods validate the interface's documented input contracts first, then decline.
- **Base URL override** for local/OSS OpenAI-compatible endpoints: constructor arg > `OPENAI_BASE_URL` env > SDK default; `OPENAI_API_KEY` resolved through #383's per-provider registry (dummy keys for local servers documented).
- **Optional extra**: `pip install 'start-green-stay-green[openai]'` (`openai>=2.0.0`, floor live-verified against PyPI, latest 2.41.1). Lazy import via the same PEP 562 `__getattr__` seam as #383; a subprocess test with a meta-path finder blocking `openai` proves core import + `build_provider("openai")` work without the package and yield the install hint.
- **Selection wiring**: registry entry so `--provider openai` works; `ProviderSpec` gains per-provider `default_model` (Anthropic default byte-identical; openai defaults to `gpt-5.5`) so a non-Anthropic provider doesn't inherit a Claude model id.
- Anthropic behavior untouched; capability fallback (T5 #389) and config-file selection tier (#396) intentionally out of scope.

## Test plan

- 45 new tests in `tests/unit/ai/test_openai_provider.py`: sync/async completion round-trips, tool-use round-trips through neutral types (incl. malformed-arguments error paths), base-URL plumb-through, missing-extra subprocess test, unsupported-batch paths, retry behavior.
- +9 selection tests in `test_provider_selection.py` (registry entry, default-model resolution, key resolution).
- Full suite: 2986 passed; new module coverage 97.95%; total 95.95% (≥90% threshold untouched).
- `./scripts/check-all.sh` ✅ (7/7) and `pre-commit run --all-files` ✅ (29 hooks).

Closes #385
Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)