### PR TITLE
feat(ci): opt-in windows-latest leg in generated workflows (#388)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1782
+        "line_number": 1789
       }
     ]
   },
-  "generated_at": "2026-06-11T05:59:49Z"
+  "generated_at": "2026-06-11T13:33:16Z"
 }

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ start-green-stay-green init [OPTIONS]
 - `--dry-run`: Preview what would be generated without creating files
 - `--no-interactive`: Run in non-interactive mode (requires all options)
 - `--config, --config-file PATH`: Path to configuration file (YAML or TOML)
+- `--windows-ci`: Add an opt-in `windows-latest` job to the generated CI workflow (default off; see below)
 
 **Examples:**
 
@@ -147,6 +148,9 @@ start-green-stay-green init -n my-app -l python --no-interactive
 # Multi-language project
 start-green-stay-green init -n fullstack-app -l python -l typescript
 
+# Opt into a Windows CI leg for the generated project
+start-green-stay-green init -n my-app -l python --windows-ci
+
 # Re-run safely in existing project (skips existing files)
 start-green-stay-green init -n my-app -l python
 
@@ -159,6 +163,40 @@ start-green-stay-green init -n my-app -l python --interactive
 # Dry run to preview
 start-green-stay-green init -n my-app -l typescript --dry-run
 ```
+
+#### `--windows-ci`: opt-in Windows CI leg for generated projects
+
+By default the generated `.github/workflows/ci.yml` runs on Linux only.
+Passing `--windows-ci` appends a `quality-windows` job that runs the
+project's quality gates on `windows-latest` through Git Bash — the same
+`bash scripts/<gate>.sh` invocation documented in the generated
+`scripts/README.md` — gated behind the Linux quality job so a red Linux
+run never burns Windows minutes. Default off: without the flag the
+generated CI is byte-for-byte unchanged and uses no Windows runner
+minutes.
+
+Supported languages: python, typescript, go, rust, java, csharp, ruby.
+Not supported (the flag fails fast with an explanation): swift and cpp
+(their gate toolchains are not available on `windows-latest`) and
+kotlin (the gate scripts need a Gradle wrapper jar that `init` cannot
+write). For a multi-language project the leg follows the primary
+language (the first `-l` value), matching how the CI workflow itself is
+generated. The go leg runs only its test gate — golangci-lint is
+provisioned by a Linux-only action in the quality job.
+
+To add the leg to an **existing** scaffolded repo, re-run init with the
+flag plus a conflict-resolution mode, since init never overwrites your
+files by default:
+
+```bash
+green init -n my-app -l python --windows-ci --interactive  # choose
+# "overwrite" for .github/workflows/ci.yml when prompted
+```
+
+(There is no YAML-aware merge for workflow files yet — unlike
+`.pre-commit-config.yaml`, which init merges — so overwriting the
+generated `ci.yml` is the supported path; copy your own edits back in
+afterwards.)
 
 ### `version` - Display Version Information
 

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -63,6 +63,7 @@ from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.base import validate_language
 from start_green_stay_green.generators.ci import CIGenerator
 from start_green_stay_green.generators.ci import LANGUAGE_CONFIGS as CI_LANGUAGE_CONFIGS
+from start_green_stay_green.generators.ci_windows import WINDOWS_CI_LANGUAGES
 from start_green_stay_green.generators.claude_md import ClaudeMdGenerationResult
 from start_green_stay_green.generators.claude_md import ClaudeMdGenerator
 from start_green_stay_green.generators.dependencies import DependenciesGenerator
@@ -1138,20 +1139,24 @@ def _generate_ci_step(
     project_path: Path,
     project_name: str,
     language: str,
-    orchestrator: AIOrchestrator | None,
+    pass2: _Pass2Options | None,
     file_writer: FileWriter | None = None,
 ) -> None:
     """Generate the CI pipeline.
 
     Always runs the deterministic template path so a project is never
-    missing CI just because the user has no API key. ``orchestrator`` is
-    only used to opt into the legacy AI-tuned path for backward
-    compatibility. ``project_name`` is forwarded to the template
-    renderer so any ``<<% project_name %>>`` placeholder lands with
-    the real value rather than the empty string. Languages without a
-    CIGenerator config are skipped with an informational message instead
-    of aborting init — with kotlin wired in (#358) every CLI language
-    has one, so this guard is defensive for future additions.
+    missing CI just because the user has no API key.
+    ``pass2.orchestrator`` is only used to opt into the legacy AI-tuned
+    path for backward compatibility; ``pass2`` as a whole may be
+    ``None``, selecting the deterministic defaults. ``project_name`` is
+    forwarded to the template renderer so any ``<<% project_name %>>``
+    placeholder lands with the real value rather than the empty string.
+    ``pass2.windows_ci`` opts into the ``quality-windows`` leg (#388);
+    default off leaves the generated workflow unchanged. Languages
+    without a CIGenerator config are skipped with an informational
+    message instead of aborting init — with kotlin wired in (#358)
+    every CLI language has one, so this guard is defensive for future
+    additions.
     """
     if language not in CI_LANGUAGE_CONFIGS:
         console.print(
@@ -1160,13 +1165,16 @@ def _generate_ci_step(
         )
         return
 
+    if pass2 is None:
+        pass2 = _Pass2Options(orchestrator=None)
+
     with step_timer("ci"), console.status("Generating CI pipeline..."):
         ci_generator = CIGenerator(
-            orchestrator,
+            pass2.orchestrator,
             language,
             project_name=project_name,
         )
-        workflow = ci_generator.generate_workflow()
+        workflow = ci_generator.generate_workflow(windows_ci=pass2.windows_ci)
         workflows_dir = project_path / ".github" / "workflows"
         workflows_dir.mkdir(parents=True, exist_ok=True)
         ci_file = workflows_dir / "ci.yml"
@@ -1623,10 +1631,14 @@ class _Pass2Options:
         agent_targets: Resolved agent-context targets in canonical
             order. Defaults to Claude only (the backward-compatible
             default).
+        windows_ci: Opt-in ``--windows-ci`` flag (#388): append the
+            ``quality-windows`` leg to the generated CI workflow.
+            Default off keeps the generated CI unchanged.
     """
 
     orchestrator: AIOrchestrator | None
     agent_targets: tuple[str, ...] = (TARGET_CLAUDE,)
+    windows_ci: bool = False
 
 
 def _generate_pass2_polish(
@@ -1659,7 +1671,7 @@ def _generate_pass2_polish(
     """
     orchestrator = pass2.orchestrator
     emit_claude = TARGET_CLAUDE in pass2.agent_targets
-    _generate_ci_step(project_path, project_name, language, orchestrator, file_writer)
+    _generate_ci_step(project_path, project_name, language, pass2, file_writer)
     _generate_review_step(project_path, file_writer)
     if emit_claude:
         _generate_claude_md_step(
@@ -2275,6 +2287,41 @@ def _validate_pass2_flags(
         raise typer.Exit(code=1)
 
 
+def _validate_windows_ci_language(
+    *,
+    windows_ci: bool,
+    primary_language: str,
+) -> None:
+    """Fail fast when ``--windows-ci`` targets an unsupported language.
+
+    The generated CI workflow follows the project's primary language
+    (the first ``-l`` value), so the Windows leg is validated against
+    that language. Validation runs before any file is generated — and
+    before the ``--dry-run`` preview — so the user learns about the
+    unsupported combination immediately.
+
+    Args:
+        windows_ci: ``True`` if ``--windows-ci`` was passed.
+        primary_language: The resolved primary project language.
+
+    Raises:
+        typer.Exit: If the flag was passed for a language without a
+            supported Windows CI leg (see
+            :data:`~start_green_stay_green.generators.ci_windows.WINDOWS_CI_LANGUAGES`).
+    """
+    if not windows_ci or primary_language in WINDOWS_CI_LANGUAGES:
+        return
+    supported = ", ".join(WINDOWS_CI_LANGUAGES)
+    console.print(
+        f"[red]Error:[/red] --windows-ci is not supported for "
+        f"{primary_language!r} (supported: {supported}). The gates for "
+        "this language cannot run on a windows-latest runner — see "
+        "generators/ci_windows.py for the per-language rationale.",
+        style="bold",
+    )
+    raise typer.Exit(code=1)
+
+
 @app.command()
 def init(  # noqa: PLR0913
     project_name: Annotated[
@@ -2392,6 +2439,20 @@ def init(  # noqa: PLR0913
             help="Generate live metrics dashboard with auto-updating workflow.",
         ),
     ] = False,
+    windows_ci: Annotated[
+        bool,
+        typer.Option(
+            "--windows-ci",
+            help=(
+                "Add an opt-in windows-latest job to the generated CI "
+                "workflow that runs the quality gates through Git Bash "
+                "(bash scripts/<gate>.sh). Default off: without this "
+                "flag the generated CI is unchanged and uses no Windows "
+                "runner minutes. Applies to the primary language's "
+                "workflow; not supported for swift, cpp, or kotlin."
+            ),
+        ),
+    ] = False,
     timing_json: Annotated[
         Path | None,
         typer.Option(
@@ -2431,6 +2492,10 @@ def init(  # noqa: PLR0913
         no_enhance: Skip Pass 2 (AI tuning) but still resolve the API
             key for a future ``green enhance`` invocation.
         enable_live_dashboard: Generate live metrics dashboard with workflow.
+        windows_ci: Opt into a ``quality-windows`` CI job that runs the
+            generated project's quality gates on ``windows-latest``
+            through Git Bash (#388). Default off leaves the generated
+            workflow unchanged.
         timing_json: Optional path to write a timing/telemetry JSON report.
         config: Configuration file path.
         provider: Optional LLM provider override (``--provider``).
@@ -2457,6 +2522,10 @@ def init(  # noqa: PLR0913
         language, config_data, no_interactive=no_interactive
     )
     resolved_agents = _resolve_agent_targets(agent)
+    _validate_windows_ci_language(
+        windows_ci=windows_ci,
+        primary_language=resolved_languages[0],
+    )
 
     # Validate project name and paths
     try:
@@ -2506,7 +2575,11 @@ def init(  # noqa: PLR0913
             project_path,
             resolved_project_name,
             resolved_languages,
-            _Pass2Options(orchestrator=orchestrator, agent_targets=resolved_agents),
+            _Pass2Options(
+                orchestrator=orchestrator,
+                agent_targets=resolved_agents,
+                windows_ci=windows_ci,
+            ),
             file_writer,
         )
         _finalize_init(

--- a/start_green_stay_green/generators/ci.py
+++ b/start_green_stay_green/generators/ci.py
@@ -24,6 +24,7 @@ import yaml
 
 from start_green_stay_green.ai.prompts.manager import get_default_manager
 from start_green_stay_green.generators.base import BaseGenerator
+from start_green_stay_green.generators.ci_windows import append_windows_job
 from start_green_stay_green.utils.yaml_utils import strip_markdown_fences
 
 if TYPE_CHECKING:
@@ -252,7 +253,7 @@ class CIGenerator(BaseGenerator):
         self.supported_versions = config["supported_versions"]
         self.reference_dir = reference_dir or REFERENCE_CI_DIR
 
-    def generate_workflow(self) -> CIWorkflow:
+    def generate_workflow(self, *, windows_ci: bool = False) -> CIWorkflow:
         """Generate a customized CI workflow.
 
         By default this renders the deterministic ``reference/ci/<language>.yml``
@@ -261,16 +262,26 @@ class CIGenerator(BaseGenerator):
         Claude-generated path is used instead, preserving backward
         compatibility for callers that rely on AI tuning.
 
+        Args:
+            windows_ci: Opt-in flag (#388): append a ``quality-windows``
+                job that runs the generated project's quality gates on
+                ``windows-latest`` through Git Bash. Default ``False``
+                leaves the generated workflow byte-for-byte unchanged.
+
         Returns:
             CIWorkflow with generated YAML content and validation status.
 
         Raises:
             GenerationError: If AI generation fails (orchestrator path).
-            ValueError: If validation fails or template missing.
+            ValueError: If validation fails, the template is missing, or
+                ``windows_ci`` is requested for a language without a
+                supported Windows leg (see
+                :data:`~.ci_windows.WINDOWS_CI_LANGUAGES`).
         """
         if self.orchestrator is None:
             return self.generate_workflow_from_template(
                 project_name=self.project_name,
+                windows_ci=windows_ci,
             )
 
         # Build context for AI generation
@@ -281,12 +292,16 @@ class CIGenerator(BaseGenerator):
         result = self._generate_with_ai(context)
 
         # Validate generated workflow
-        return self._validate_and_parse(result.content)
+        return self._maybe_append_windows_leg(
+            self._validate_and_parse(result.content),
+            windows_ci=windows_ci,
+        )
 
     def generate_workflow_from_template(
         self,
         *,
         project_name: str | None = None,
+        windows_ci: bool = False,
     ) -> CIWorkflow:
         """Render the deterministic CI template for the configured language.
 
@@ -304,6 +319,10 @@ class CIGenerator(BaseGenerator):
                 ``<<% project_name %>>`` placeholders. ``None`` is
                 coerced to ``""`` so the literal string ``"None"`` is
                 never baked into the rendered YAML.
+            windows_ci: Opt-in flag (#388): append the
+                ``quality-windows`` job after rendering. Default
+                ``False`` leaves the rendered workflow byte-for-byte
+                unchanged.
 
         Returns:
             ``CIWorkflow`` with the rendered, validated YAML.
@@ -315,7 +334,9 @@ class CIGenerator(BaseGenerator):
                 placeholder that has not been wired through this
                 method's ``render(...)`` kwargs (raised eagerly thanks
                 to ``StrictUndefined``).
-            ValueError: If the rendered YAML fails structural validation.
+            ValueError: If the rendered YAML fails structural
+                validation, or ``windows_ci`` is requested for a
+                language without a supported Windows leg.
         """
         template_path = self.reference_dir / f"{self.language}.yml"
         if not template_path.exists():
@@ -354,7 +375,41 @@ class CIGenerator(BaseGenerator):
             language=self.language,
         )
 
-        return self._validate_and_parse(rendered)
+        return self._maybe_append_windows_leg(
+            self._validate_and_parse(rendered),
+            windows_ci=windows_ci,
+        )
+
+    def _maybe_append_windows_leg(
+        self,
+        workflow: CIWorkflow,
+        *,
+        windows_ci: bool,
+    ) -> CIWorkflow:
+        """Append the opt-in Windows leg when ``windows_ci`` is set (#388).
+
+        Default off: when the flag is unset the workflow is returned
+        untouched, keeping the generated CI byte-for-byte identical to
+        the pre-flag output. When set, the ``quality-windows`` job is
+        appended under the workflow's ``jobs`` mapping and the combined
+        document is re-validated.
+
+        Args:
+            workflow: The validated baseline workflow.
+            windows_ci: ``True`` to append the Windows leg.
+
+        Returns:
+            The workflow, extended with the Windows leg when opted in.
+
+        Raises:
+            ValueError: If the language has no supported Windows leg,
+                the leg cannot attach under ``jobs``, or the combined
+                workflow fails validation.
+        """
+        if not windows_ci:
+            return workflow
+        content = append_windows_job(workflow.content, self.language)
+        return self._validate_and_parse(content)
 
     def _build_generation_context(
         self,

--- a/start_green_stay_green/generators/ci_windows.py
+++ b/start_green_stay_green/generators/ci_windows.py
@@ -1,0 +1,313 @@
+"""Opt-in Windows CI leg for generated workflows (#388, windows-compat #378).
+
+The single source of truth for the ``quality-windows`` job that
+``green init --windows-ci`` appends to the generated
+``.github/workflows/ci.yml``. The job mirrors the pattern Start Green
+Stay Green's own Windows CI leg (#380) established and invokes the
+quality gates the way ``scripts/README.md`` documents for Windows
+(#386): ``bash scripts/<gate>.sh`` through Git Bash, which ships with
+Git for Windows and is preinstalled on the ``windows-latest`` runner
+image.
+
+Design notes:
+
+* **Default off.** Nothing here runs unless the user opts in, so the
+  default generated CI is byte-for-byte unchanged and no one pays for
+  Windows runner minutes by surprise.
+* **One job shape, parameterized per language (DRY).** Every language
+  shares the same scaffold — LF-safe checkout, toolchain setup,
+  dependency install, then gate invocations through Git Bash — and only
+  the toolchain setup fragment and gate list vary, exactly where the
+  per-language Linux templates already vary.
+* **No invented versions.** Every action the leg references reuses a
+  pin that already appears in the language's ``reference/ci/*.yml``
+  template, so version bumps stay single-sourced in the templates.
+* **A smoke leg, not a second matrix.** The leg runs once on the newest
+  toolchain version from the Linux quality matrix; languages keep their
+  multi-version coverage on Linux.
+
+Supported languages and the honest reasons for each exclusion:
+
+* ``swift`` is excluded: the scaffolded gates run SwiftLint and
+  swift-format, which have no Windows distribution, and the reference
+  workflow targets macOS/Linux toolchains.
+* ``cpp`` is excluded: the reference workflow provisions the toolchain
+  with ``apt-get`` (Linux-only); no equivalent Windows provisioning is
+  scaffolded.
+* ``kotlin`` is excluded: the gate scripts call ``./gradlew``, but the
+  Gradle wrapper jar is a binary ``green init`` never writes — the
+  language's own CI deliberately runs ``gradle`` directly for the same
+  reason — so the Git Bash gate path cannot run on a fresh checkout.
+* ``go`` runs only its test gate: the lint gate needs golangci-lint,
+  which the Linux quality job provisions through a Linux-specific
+  action; ``go test`` needs nothing beyond the Go toolchain.
+"""
+
+from __future__ import annotations
+
+import io
+
+import yaml
+
+#: Job id of the opt-in Windows leg inside the generated workflow.
+WINDOWS_JOB_ID = "quality-windows"
+
+#: Languages whose generated projects support the opt-in Windows leg.
+#: Kept in the CLI's canonical language order. See the module docstring
+#: for why swift, cpp, and kotlin are excluded.
+WINDOWS_CI_LANGUAGES: tuple[str, ...] = (
+    "python",
+    "typescript",
+    "go",
+    "rust",
+    "java",
+    "csharp",
+    "ruby",
+)
+
+#: Gate scripts the Windows leg invokes per language, in execution
+#: order. Each entry is a script the scripts generator emits for that
+#: language; the leg runs them as ``bash scripts/<gate>`` (the #386
+#: Windows invocation). lint + test mirrors the smoke-leg scope of this
+#: repository's own Windows CI job; go drops lint (module docstring).
+WINDOWS_GATES: dict[str, tuple[str, ...]] = {
+    "python": ("lint.sh", "test.sh"),
+    "typescript": ("lint.sh", "test.sh"),
+    "go": ("test.sh",),
+    "rust": ("lint.sh", "test.sh"),
+    "java": ("lint.sh", "test.sh"),
+    "csharp": ("lint.sh", "test.sh"),
+    "ruby": ("lint.sh", "test.sh"),
+}
+
+#: Job-level env blocks (4-space indented YAML lines), per language.
+#: Only python needs one: Windows Python defaults text I/O to the
+#: legacy ANSI code page (cp1252) while the gates and generated content
+#: are UTF-8, so the leg enables Python's UTF-8 mode (PEP 540) for the
+#: gate processes it spawns — the same fix this repository's own
+#: Windows CI leg applies.
+_JOB_ENV: dict[str, str] = {
+    "python": """\
+    env:
+      # Windows Python defaults text I/O to the legacy ANSI code page
+      # (cp1252); the gates and project content are UTF-8, so enable
+      # Python's UTF-8 mode (PEP 540) for every gate process.
+      PYTHONUTF8: "1"
+""",
+}
+
+#: Toolchain setup + dependency install steps per language (6-space
+#: indented YAML list items). Single-version: the newest entry from the
+#: language's Linux quality matrix — this is a smoke leg, not a second
+#: matrix. Action pins are reused from ``reference/ci/<language>.yml``.
+_SETUP_STEPS: dict[str, str] = {
+    "python": """\
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+""",
+    "typescript": """\
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: 'npm'
+
+      # Like the Linux quality job, `npm ci` expects the lockfile the
+      # first local `npm install` commits.
+      - name: Install dependencies
+        run: npm ci
+""",
+    "go": """\
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+""",
+    "rust": """\
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+""",
+    "java": """\
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: 'temurin'
+          cache: 'maven'
+""",
+    "csharp": """\
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0"
+
+      - name: Restore dependencies
+        run: dotnet restore
+""",
+    "ruby": """\
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          # bundler-cache runs `bundle install` and caches the gems.
+          bundler-cache: true
+""",
+}
+
+#: Shared job preamble. ``needs: quality`` gates the leg behind the
+#: Linux quality job (present in every reference template and enforced
+#: by the CI generator's validation) so a red Linux run never burns
+#: Windows minutes.
+_JOB_HEADER = f"""\
+  # Opt-in Windows leg (`green init --windows-ci`). Runs the quality
+  # gates on windows-latest through Git Bash — the documented Windows
+  # invocation (`bash scripts/<gate>.sh`, see scripts/README.md) —
+  # mirroring the Windows CI pattern of the generator's own pipeline.
+  {WINDOWS_JOB_ID}:
+    name: Quality Gates (Windows)
+    runs-on: windows-latest
+    needs: quality
+    # Cap a hung Windows runner well above a healthy gate runtime.
+    timeout-minutes: 30
+"""
+
+#: Shared first steps: force-LF checkout. Windows git defaults to
+#: ``core.autocrlf=true``, which would check the repo out with CRLF
+#: endings — bash cannot execute CRLF scripts. The generated
+#: ``.gitattributes`` already pins ``*.sh`` to LF; configuring git
+#: before checkout keeps the leg green even where that file has been
+#: customised (belt and suspenders, same as the reference pattern).
+_CHECKOUT_STEPS = """\
+    steps:
+      - name: Force LF line endings on checkout
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+"""
+
+
+def _unsupported_language_message(language: str) -> str:
+    """Build the fail-fast message for an unsupported language.
+
+    Args:
+        language: The rejected language identifier.
+
+    Returns:
+        An actionable message naming every supported language.
+    """
+    supported = ", ".join(WINDOWS_CI_LANGUAGES)
+    return (
+        f"the opt-in windows-latest CI leg does not support {language!r} "
+        f"(supported: {supported}); see generators/ci_windows.py for the "
+        "per-language rationale"
+    )
+
+
+def _gate_steps(language: str) -> str:
+    """Render the gate-invocation steps for ``language``.
+
+    Each gate runs as ``bash scripts/<gate>`` with ``shell: bash`` so
+    the step uses Git Bash regardless of the runner's default shell
+    (PowerShell on windows-latest).
+
+    Args:
+        language: A key of :data:`WINDOWS_GATES`.
+
+    Returns:
+        YAML list items (6-space indented), one step per gate.
+    """
+    steps = []
+    for gate in WINDOWS_GATES[language]:
+        stem = gate.removesuffix(".sh")
+        steps.append(f"""\
+      - name: Run {stem} gate (Git Bash)
+        shell: bash
+        run: bash scripts/{gate}
+""")
+    return "\n".join(steps)
+
+
+def render_windows_job(language: str) -> str:
+    """Render the ``quality-windows`` job block for ``language``.
+
+    The block is indented two spaces so it nests directly under a
+    workflow's top-level ``jobs:`` mapping. Rendering is pure string
+    assembly from module constants — deterministic and LF-only.
+
+    Args:
+        language: Generated project's language; must be in
+            :data:`WINDOWS_CI_LANGUAGES`.
+
+    Returns:
+        The YAML job block, ending with a single trailing newline.
+
+    Raises:
+        ValueError: If the language has no supported Windows leg.
+    """
+    if language not in WINDOWS_CI_LANGUAGES:
+        raise ValueError(_unsupported_language_message(language))
+
+    parts = [_JOB_HEADER]
+    env_block = _JOB_ENV.get(language)
+    if env_block is not None:
+        parts.append(env_block)
+    parts.extend((_CHECKOUT_STEPS, _SETUP_STEPS[language], "\n", _gate_steps(language)))
+    return "".join(parts)
+
+
+def append_windows_job(workflow_yaml: str, language: str) -> str:
+    """Append the Windows leg to a rendered workflow's jobs mapping.
+
+    Relies on ``jobs`` being the final top-level key of the workflow —
+    true for every reference template — and verifies the result by
+    re-parsing, so a workflow with a different layout fails loudly
+    instead of silently emitting a job outside ``jobs``.
+
+    Args:
+        workflow_yaml: Complete rendered workflow YAML.
+        language: Generated project's language; must be in
+            :data:`WINDOWS_CI_LANGUAGES`.
+
+    Returns:
+        The workflow YAML with the ``quality-windows`` job appended.
+
+    Raises:
+        ValueError: If the language is unsupported, or the appended job
+            did not attach under the ``jobs`` mapping.
+    """
+    job_block = render_windows_job(language)
+    merged = workflow_yaml.rstrip("\n") + "\n\n" + job_block
+
+    try:
+        with io.StringIO(merged) as stream:
+            parsed = yaml.safe_load(stream)
+    except yaml.YAMLError as e:
+        msg = f"appending the Windows CI leg produced invalid YAML: {e}"
+        raise ValueError(msg) from e
+    jobs = parsed.get("jobs") if isinstance(parsed, dict) else None
+    if not isinstance(jobs, dict) or WINDOWS_JOB_ID not in jobs:
+        msg = (
+            "could not attach the Windows CI leg under the workflow's "
+            "'jobs' mapping; 'jobs' must be the final top-level key"
+        )
+        raise ValueError(msg)
+    return merged

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -43,7 +43,7 @@ def _stub_ci_step(
     project_path: Path,
     _project_name: str,
     _language: str,
-    _orchestrator: object,
+    _pass2: object,
     _file_writer: object = None,
 ) -> None:
     """Stub CI generation step that writes minimal valid workflow files.
@@ -52,7 +52,8 @@ def _stub_ci_step(
         project_path: Target project directory.
         _project_name: Project name (unused in stub).
         _language: Programming language (unused in stub).
-        _orchestrator: Mock orchestrator (unused in stub).
+        _pass2: Pass 2 options bundle — orchestrator plus the
+            ``--windows-ci`` flag (#388) — unused in stub.
         _file_writer: File writer (unused in stub).
     """
     workflows_dir = project_path / ".github" / "workflows"

--- a/tests/integration/test_windows_ci_leg.py
+++ b/tests/integration/test_windows_ci_leg.py
@@ -1,0 +1,107 @@
+"""Integration tests for the opt-in Windows CI leg (#388).
+
+Generates a real sample project with ``green init --windows-ci`` and
+then executes, on the current machine, the exact gate invocations the
+generated ``quality-windows`` job declares (``bash scripts/<gate>.sh``).
+
+What this proves — and what it does not:
+
+* On this repository's own Windows CI leg (#380), these tests run on a
+  real ``windows-latest`` runner under real Git Bash with the python
+  toolchain (ruff, pytest) installed — so a passing run demonstrates
+  that a freshly generated python sample passes the same gate commands
+  its generated Windows CI job would run, on the same runner image and
+  shell that job targets.
+* It does NOT execute GitHub Actions itself: runner provisioning steps
+  (checkout, setup-python, dependency install) are exercised only by
+  this repository's own workflow, not the generated one. Structural
+  validity of the generated job is covered by the unit suite
+  (``tests/unit/generators/test_ci_windows.py``).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green.cli import app
+from start_green_stay_green.generators.ci_windows import WINDOWS_GATES
+from start_green_stay_green.generators.ci_windows import WINDOWS_JOB_ID
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _init_python_project(tmp_path: Path) -> Path:
+    """Scaffold a python sample with the Windows leg opted in."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--project-name",
+            "sample-windows",
+            "-l",
+            "python",
+            "-o",
+            str(tmp_path),
+            "--offline",
+            "--no-interactive",
+            "--windows-ci",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return tmp_path / "sample-windows"
+
+
+def _windows_gate_commands(project: Path) -> list[str]:
+    """Extract the Windows job's gate commands from the generated ci.yml."""
+    ci_file = project / ".github" / "workflows" / "ci.yml"
+    parsed = yaml.safe_load(ci_file.read_text(encoding="utf-8"))
+    job = parsed["jobs"][WINDOWS_JOB_ID]
+    return [
+        step["run"]
+        for step in job["steps"]
+        if str(step.get("run", "")).startswith("bash scripts/")
+    ]
+
+
+class TestGeneratedSamplePassesWindowsGates:
+    """Run the generated sample's Windows gate commands for real."""
+
+    def test_windows_leg_gates_pass_on_fresh_python_sample(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every gate the generated Windows job invokes exits 0.
+
+        The commands executed here are read out of the generated
+        workflow itself (not re-stated), so the test cannot drift from
+        what the Windows leg actually runs. Requires ruff and pytest on
+        PATH — both ship in this repository's requirements-dev.txt, on
+        every CI leg including windows-latest.
+        """
+        project = _init_python_project(tmp_path)
+        commands = _windows_gate_commands(project)
+        assert commands == [f"bash scripts/{gate}" for gate in WINDOWS_GATES["python"]]
+
+        bash = shutil.which("bash")
+        assert bash is not None, "bash not found on PATH"
+        # The generated job runs from the project root; mirror that.
+        monkeypatch.chdir(project)
+        for command in commands:
+            script = command.removeprefix("bash ")
+            result = subprocess.run(  # noqa: S603  # Issue #388: bash on generated content, no untrusted input
+                [bash, script],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (
+                result.returncode == 0
+            ), f"{command} failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/unit/generators/test_ci_windows.py
+++ b/tests/unit/generators/test_ci_windows.py
@@ -1,0 +1,323 @@
+"""Tests for the opt-in Windows CI leg in generated workflows (#388).
+
+Covers the final tracer of the windows-compat epic (#378):
+
+- ``render_windows_job`` / ``append_windows_job`` building blocks
+- ``CIGenerator(windows_ci=True)`` emitting a parse-valid
+  ``quality-windows`` job that runs gates the #386 way
+  (``bash scripts/<gate>.sh`` through Git Bash)
+- the default-off contract: no Windows content unless opted in, and
+  the existing jobs are untouched when opting in
+- drift protection: every gate the Windows leg invokes is a script the
+  scripts generator actually emits, and every action version the leg
+  references is already pinned by the language's base template
+- execution: the exact gate scripts the Windows leg invokes run under
+  ``bash <path>`` — on this repo's own Windows CI leg (#380) that is
+  real Git Bash on windows-latest
+
+Honest scope note: these tests prove the generated Windows leg is
+structurally valid and that its gate invocations execute under (Git)
+Bash against a freshly generated scaffold. They cannot run GitHub
+Actions itself, so "the leg passes on a real windows-latest runner with
+the full language toolchain" is demonstrated only to the extent this
+repository's own Windows CI executes these tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+import pytest
+import yaml
+
+from start_green_stay_green.generators import ci_windows
+from start_green_stay_green.generators.ci import CIGenerator
+from start_green_stay_green.generators.ci import LANGUAGE_CONFIGS
+from start_green_stay_green.generators.ci_windows import WINDOWS_CI_LANGUAGES
+from start_green_stay_green.generators.ci_windows import WINDOWS_GATES
+from start_green_stay_green.generators.ci_windows import WINDOWS_JOB_ID
+from start_green_stay_green.generators.ci_windows import append_windows_job
+from start_green_stay_green.generators.ci_windows import render_windows_job
+from start_green_stay_green.generators.scripts import ScriptConfig
+from start_green_stay_green.generators.scripts import ScriptsGenerator
+
+#: Languages CIGenerator supports but the Windows leg deliberately
+#: excludes (toolchain not viable on windows-latest — see module docs).
+UNSUPPORTED_WINDOWS_LANGUAGES = ("swift", "cpp", "kotlin")
+
+
+def _generate_content(language: str, *, windows_ci: bool) -> str:
+    """Render the deterministic workflow for ``language``."""
+    generator = CIGenerator(language=language, project_name="sample-project")
+    return generator.generate_workflow(windows_ci=windows_ci).content
+
+
+def _windows_job(language: str) -> dict[str, Any]:
+    """Parse the opt-in workflow and return the Windows job mapping."""
+    parsed = yaml.safe_load(_generate_content(language, windows_ci=True))
+    job = parsed["jobs"][WINDOWS_JOB_ID]
+    assert isinstance(job, dict)
+    return job
+
+
+class TestWindowsLegRegistry:
+    """Test the supported-language registry and its gate table."""
+
+    def test_supported_languages_are_a_strict_subset_of_ci_languages(self) -> None:
+        """Every Windows-leg language has a CI generator config."""
+        assert set(WINDOWS_CI_LANGUAGES) < set(LANGUAGE_CONFIGS)
+
+    def test_excluded_languages_are_not_in_registry(self) -> None:
+        """swift/cpp/kotlin are deliberately excluded (see module docs)."""
+        for language in UNSUPPORTED_WINDOWS_LANGUAGES:
+            assert language not in WINDOWS_CI_LANGUAGES
+
+    def test_every_supported_language_has_gates(self) -> None:
+        """The gate table covers exactly the supported languages."""
+        assert set(WINDOWS_GATES) == set(WINDOWS_CI_LANGUAGES)
+        for gates in WINDOWS_GATES.values():
+            assert gates, "every Windows leg must run at least one gate"
+
+    def test_gates_are_shell_scripts(self) -> None:
+        """Each configured gate is a ``.sh`` script name."""
+        for gates in WINDOWS_GATES.values():
+            for gate in gates:
+                assert gate.endswith(".sh")
+
+
+class TestRenderWindowsJob:
+    """Test the standalone Windows job renderer."""
+
+    @pytest.mark.parametrize("language", UNSUPPORTED_WINDOWS_LANGUAGES)
+    def test_unsupported_language_raises_value_error(self, language: str) -> None:
+        """Unsupported languages fail fast with the supported list."""
+        with pytest.raises(ValueError, match="python"):
+            render_windows_job(language)
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_rendering_is_deterministic(self, language: str) -> None:
+        """Two renders produce identical bytes (reproducible generation)."""
+        assert render_windows_job(language) == render_windows_job(language)
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_rendered_job_uses_lf_only(self, language: str) -> None:
+        """No CR bytes — CRLF would break bash and YAML round-trips."""
+        assert "\r" not in render_windows_job(language)
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_rendered_job_never_writes_github_env(self, language: str) -> None:
+        """No GITHUB_ENV/GITHUB_PATH writes (env-injection guardrail)."""
+        block = render_windows_job(language)
+        assert "GITHUB_ENV" not in block
+        assert "GITHUB_PATH" not in block
+
+    def test_append_attaches_job_under_jobs(self) -> None:
+        """append_windows_job lands the job inside the jobs mapping."""
+        base = (
+            "name: CI\n"
+            "on:\n"
+            "  push:\n"
+            "jobs:\n"
+            "  quality:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+        )
+        merged = yaml.safe_load(append_windows_job(base, "python"))
+        assert WINDOWS_JOB_ID in merged["jobs"]
+        assert "quality" in merged["jobs"]
+
+    def test_append_wraps_yaml_parse_errors_as_value_error(self) -> None:
+        """A workflow the job cannot syntactically extend fails loudly.
+
+        Flow-style ``jobs`` mappings cannot take an appended block key,
+        so the merged document does not parse; the YAML error surfaces
+        as a ValueError naming the operation.
+        """
+        base = "name: CI\njobs: {quality: {steps: [{uses: x}]}}\n"
+        with pytest.raises(ValueError, match="invalid YAML"):
+            append_windows_job(base, "python")
+
+    def test_append_rejects_yaml_where_jobs_is_not_last(self) -> None:
+        """If the job cannot attach under jobs, fail loudly, not silently."""
+        base = (
+            "name: CI\n"
+            "jobs:\n"
+            "  quality:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "permissions:\n"
+            "  contents: read\n"
+        )
+        with pytest.raises(ValueError, match="jobs"):
+            append_windows_job(base, "python")
+
+
+class TestDefaultOffContract:
+    """Test that default output carries no Windows leg at all."""
+
+    @pytest.mark.parametrize("language", sorted(LANGUAGE_CONFIGS))
+    def test_default_output_has_no_windows_content(self, language: str) -> None:
+        """Without the flag, no Windows job or runner appears."""
+        content = _generate_content(language, windows_ci=False)
+        assert WINDOWS_JOB_ID not in content
+        assert "windows-latest" not in content
+
+    @pytest.mark.parametrize("language", sorted(LANGUAGE_CONFIGS))
+    def test_explicit_false_matches_default_byte_for_byte(self, language: str) -> None:
+        """``windows_ci=False`` is byte-identical to omitting the flag."""
+        default = CIGenerator(
+            language=language, project_name="sample-project"
+        ).generate_workflow()
+        assert _generate_content(language, windows_ci=False) == default.content
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_opt_in_only_adds_the_windows_job(self, language: str) -> None:
+        """Opting in leaves every existing job byte-equal (minimal diff)."""
+        off = yaml.safe_load(_generate_content(language, windows_ci=False))
+        on = yaml.safe_load(_generate_content(language, windows_ci=True))
+        on_jobs = dict(on["jobs"])
+        on_jobs.pop(WINDOWS_JOB_ID)
+        assert on_jobs == off["jobs"]
+        for key in off:
+            if key == "jobs":
+                continue
+            assert on[key] == off[key]
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_opt_in_content_is_prefix_extended(self, language: str) -> None:
+        """The opt-in output starts with the unmodified default output."""
+        off = _generate_content(language, windows_ci=False)
+        on = _generate_content(language, windows_ci=True)
+        assert on.startswith(off.rstrip("\n"))
+
+
+class TestOptInWindowsJobStructure:
+    """Parse-validate the emitted Windows job for every language."""
+
+    @pytest.mark.parametrize("language", UNSUPPORTED_WINDOWS_LANGUAGES)
+    def test_generator_rejects_unsupported_language(self, language: str) -> None:
+        """generate_workflow fails fast for legs without Windows support."""
+        generator = CIGenerator(language=language, project_name="sample-project")
+        with pytest.raises(ValueError, match="windows"):
+            generator.generate_workflow(windows_ci=True)
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_workflow_parses_and_validates(self, language: str) -> None:
+        """The opt-in workflow is valid per the generator's own checks."""
+        generator = CIGenerator(language=language, project_name="sample-project")
+        workflow = generator.generate_workflow(windows_ci=True)
+        assert workflow.is_valid
+        assert workflow.error_message is None
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_job_runs_on_windows_latest(self, language: str) -> None:
+        """The leg targets windows-latest."""
+        assert _windows_job(language)["runs-on"] == "windows-latest"
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_job_needs_quality_and_is_time_capped(self, language: str) -> None:
+        """The leg is gated behind the Linux quality job and time-capped."""
+        job = _windows_job(language)
+        assert job["needs"] == "quality"
+        assert job["timeout-minutes"] == 30
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_first_step_forces_lf_before_checkout(self, language: str) -> None:
+        """autocrlf=false is configured before the checkout step runs."""
+        steps = _windows_job(language)["steps"]
+        assert "core.autocrlf false" in steps[0]["run"]
+        assert "core.eol lf" in steps[0]["run"]
+        assert steps[1]["uses"].startswith("actions/checkout@")
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_gate_steps_invoke_scripts_through_git_bash(self, language: str) -> None:
+        """Every configured gate runs as ``bash scripts/<gate>`` with
+        ``shell: bash`` (the #386-documented Windows invocation)."""
+        steps = _windows_job(language)["steps"]
+        gate_runs = [
+            step
+            for step in steps
+            if str(step.get("run", "")).startswith("bash scripts/")
+        ]
+        assert [s["run"] for s in gate_runs] == [
+            f"bash scripts/{gate}" for gate in WINDOWS_GATES[language]
+        ]
+        for step in gate_runs:
+            assert step["shell"] == "bash"
+
+    def test_python_leg_enables_utf8_mode(self) -> None:
+        """The python leg sets PYTHONUTF8=1 (cp1252 vs UTF-8 content)."""
+        assert _windows_job("python")["env"]["PYTHONUTF8"] == "1"
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_action_versions_reuse_base_template_pins(self, language: str) -> None:
+        """Every action the leg uses is already pinned by the language's
+        base template — the leg never invents a new version."""
+        base = _generate_content(language, windows_ci=False)
+        for step in _windows_job(language)["steps"]:
+            uses = step.get("uses")
+            if uses is not None:
+                assert uses in base, uses
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_gates_match_scripts_the_generator_emits(self, language: str) -> None:
+        """Drift protection: each invoked gate is an emitted script."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(language=language, package_name="my_package")
+            scripts = ScriptsGenerator(
+                Path(tmpdir) / "scripts", config, project_root=Path(tmpdir)
+            ).generate()
+        for gate in WINDOWS_GATES[language]:
+            assert gate in scripts
+
+
+class TestWindowsGateExecution:
+    """Execute the exact gate scripts the Windows leg invokes.
+
+    Mirrors the #386 execution tests: on this repository's own Windows
+    CI leg these run under real Git Bash on windows-latest, proving the
+    ``bash scripts/<gate>.sh`` invocation the generated workflow emits
+    executes against a fresh scaffold. ``--help`` keeps the run
+    toolchain-independent; it does not prove a full gate pass with the
+    language toolchain installed.
+    """
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_windows_leg_gate_invocations_execute_under_bash(
+        self, language: str
+    ) -> None:
+        """``bash <gate> --help`` exits 0 for every invoked gate."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ScriptConfig(language=language, package_name="my_package")
+            scripts = ScriptsGenerator(
+                Path(tmpdir) / "scripts", config, project_root=Path(tmpdir)
+            ).generate()
+
+            bash = shutil.which("bash")
+            assert bash is not None, "bash not found on PATH"
+            for gate in WINDOWS_GATES[language]:
+                result = subprocess.run(  # noqa: S603  # Issue #388: bash on generated content, no untrusted input
+                    [bash, str(scripts[gate]), "--help"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert result.returncode == 0, result.stderr
+                assert "Usage" in result.stdout
+
+
+class TestModuleDocumentation:
+    """Test the honesty notes the module must carry."""
+
+    def test_module_documents_excluded_languages(self) -> None:
+        """The module docstring explains every exclusion."""
+        doc = ci_windows.__doc__
+        assert doc is not None
+        for language in UNSUPPORTED_WINDOWS_LANGUAGES:
+            assert language in doc

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -1265,13 +1265,20 @@ class TestGenerateSteps:
         mock_path.__truediv__.return_value = MagicMock(spec=Path)
 
         with patch("start_green_stay_green.cli.console"):
-            cli._generate_ci_step(mock_path, "my-project", "python", mock_orchestrator)
+            cli._generate_ci_step(
+                mock_path,
+                "my-project",
+                "python",
+                cli._Pass2Options(orchestrator=mock_orchestrator),
+            )
 
         # ``project_name`` is now threaded through so ``<<% project_name %>>``
         # placeholders in the reference templates render with the real value.
         mock_ci_generator_class.assert_called_with(
             mock_orchestrator, "python", project_name="my-project"
         )
+        # ``windows_ci`` defaults off (#388) so generated CI is unchanged.
+        mock_generator.generate_workflow.assert_called_once_with(windows_ci=False)
 
     @patch("start_green_stay_green.cli.CIGenerator")
     def test_generate_ci_step_uses_template_without_orchestrator(

--- a/tests/unit/test_cli_windows_ci.py
+++ b/tests/unit/test_cli_windows_ci.py
@@ -1,0 +1,137 @@
+"""Tests for the ``green init --windows-ci`` opt-in flag (#388).
+
+Covers:
+
+- flag validation: unsupported languages fail fast with an actionable
+  message before any file is generated
+- plumbing: the flag reaches ``_generate_ci_step`` and flips the
+  ``CIGenerator`` Windows leg on
+- the default-off contract at the CLI layer: omitting the flag emits a
+  ci.yml with no Windows content
+- help text discoverability
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import typer
+from typer.testing import CliRunner
+import yaml
+
+from start_green_stay_green import cli
+from start_green_stay_green.generators.ci_windows import WINDOWS_CI_LANGUAGES
+from start_green_stay_green.generators.ci_windows import WINDOWS_JOB_ID
+from start_green_stay_green.utils.file_writer import FileWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestValidateWindowsCiLanguage:
+    """Test the _validate_windows_ci_language helper."""
+
+    def test_flag_off_accepts_every_language(self) -> None:
+        """Without the flag no language is rejected."""
+        for language in ("python", "swift", "cpp", "kotlin"):
+            cli._validate_windows_ci_language(
+                windows_ci=False, primary_language=language
+            )
+
+    @pytest.mark.parametrize("language", WINDOWS_CI_LANGUAGES)
+    def test_flag_on_accepts_supported_languages(self, language: str) -> None:
+        """Supported languages pass validation with the flag on."""
+        cli._validate_windows_ci_language(windows_ci=True, primary_language=language)
+
+    @pytest.mark.parametrize("language", ["swift", "cpp", "kotlin"])
+    def test_flag_on_rejects_unsupported_language(self, language: str) -> None:
+        """Unsupported languages exit with an actionable message."""
+        with pytest.raises(typer.Exit):
+            cli._validate_windows_ci_language(
+                windows_ci=True, primary_language=language
+            )
+
+
+class TestGenerateCiStepWindowsFlag:
+    """Test that the CI step forwards the flag to the generator."""
+
+    def test_windows_ci_emits_quality_windows_job(self, tmp_path: Path) -> None:
+        """The step writes a ci.yml containing the Windows job."""
+        writer = FileWriter(project_root=tmp_path)
+        pass2 = cli._Pass2Options(orchestrator=None, windows_ci=True)
+        cli._generate_ci_step(tmp_path, "my-project", "python", pass2, writer)
+        content = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        parsed = yaml.safe_load(content)
+        assert WINDOWS_JOB_ID in parsed["jobs"]
+
+    def test_default_emits_no_windows_content(self, tmp_path: Path) -> None:
+        """Without the flag the emitted ci.yml has no Windows leg."""
+        writer = FileWriter(project_root=tmp_path)
+        cli._generate_ci_step(tmp_path, "my-project", "python", None, writer)
+        content = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        assert WINDOWS_JOB_ID not in content
+        assert "windows-latest" not in content
+
+
+class TestInitWindowsCiFlag:
+    """Test the end-to-end ``green init --windows-ci`` behaviour."""
+
+    def test_init_rejects_windows_ci_for_unsupported_language(
+        self, tmp_path: Path
+    ) -> None:
+        """swift + --windows-ci fails fast, before generating files."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "sample-swift",
+                "-l",
+                "swift",
+                "-o",
+                str(tmp_path),
+                "--offline",
+                "--no-interactive",
+                "--windows-ci",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--windows-ci" in result.output
+        assert not (tmp_path / "sample-swift").exists()
+
+    def test_init_windows_ci_writes_windows_leg(self, tmp_path: Path) -> None:
+        """Opting in lands the Windows job in the generated ci.yml."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.app,
+            [
+                "init",
+                "--project-name",
+                "sample-python",
+                "-l",
+                "python",
+                "-o",
+                str(tmp_path),
+                "--offline",
+                "--no-interactive",
+                "--windows-ci",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        ci_file = tmp_path / "sample-python" / ".github" / "workflows" / "ci.yml"
+        parsed = yaml.safe_load(ci_file.read_text(encoding="utf-8"))
+        job = parsed["jobs"][WINDOWS_JOB_ID]
+        assert job["runs-on"] == "windows-latest"
+
+    def test_init_help_documents_windows_ci(self) -> None:
+        """--help mentions the flag so users can discover it."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["init", "--help"])
+        assert result.exit_code == 0
+        assert "--windows-ci" in result.output

--- a/tests/unit/test_cli_windows_ci.py
+++ b/tests/unit/test_cli_windows_ci.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -27,6 +28,18 @@ from start_green_stay_green.utils.file_writer import FileWriter
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    """Normalize rich-rendered CLI output for substring assertions.
+
+    Rich styles, pads, borders, and may hyphen-wrap long option names
+    depending on the environment it detects, so strip ANSI sequences and
+    collapse box-drawing characters and whitespace before matching.
+    """
+    return re.sub(r"[│╭╮╰╯─\s]+", "", _ANSI_RE.sub("", output))
 
 
 class TestValidateWindowsCiLanguage:
@@ -102,7 +115,7 @@ class TestInitWindowsCiFlag:
             ],
         )
         assert result.exit_code != 0
-        assert "--windows-ci" in result.output
+        assert "--windows-ci" in _plain(result.output)
         assert not (tmp_path / "sample-swift").exists()
 
     def test_init_windows_ci_writes_windows_leg(self, tmp_path: Path) -> None:
@@ -134,4 +147,4 @@ class TestInitWindowsCiFlag:
         runner = CliRunner()
         result = runner.invoke(cli.app, ["init", "--help"])
         assert result.exit_code == 0
-        assert "--windows-ci" in result.output
+        assert "--windows-ci" in _plain(result.output)


### PR DESCRIPTION
## Summary

Implements windows-compat tracer **T5** (final tracer of epic #378): `green init --windows-ci` adds an opt-in `windows-latest` job to generated CI workflows, mirroring this repo's own `test-windows` pattern (#380/#382) and invoking gates the #386-documented way.

- **New `generators/ci_windows.py`** — single source of truth for the appended `quality-windows` job: windows-latest, `needs: quality`, 30-minute cap, force-LF checkout (`core.autocrlf=false`), gates through Git Bash (`shell: bash` + `bash scripts/<gate>.sh`). One shared scaffold, parameterized per language only where the Linux templates already vary (toolchain setup + gate list) — no bespoke per-language Windows jobs. Every `action@version` pin is reused from the language's own reference template (test-enforced); python sets `PYTHONUTF8: "1"`. No new matrix, no `GITHUB_ENV` writes (tested).
- **Supported: 7 languages** (python, typescript, go, rust, java, csharp, ruby). **Excluded with documented rationale**: swift (no Windows SwiftLint/swift-format), cpp (apt-provisioned toolchain), kotlin (gates require a gradle wrapper jar init never writes). go runs the test gate only (golangci-lint provisioned by a Linux-only action); others run lint + test — the same smoke-leg scope as this repo's own Windows job. `--windows-ci` fails fast with a clear message for unsupported primary languages.
- **Plumbing**: typer flag → `_Pass2Options.windows_ci` → `CIGenerator.generate_workflow(windows_ci=...)` → `append_windows_job()` + structural re-validation (works on both template and AI generation paths). Multi-language projects: CI is generated for the primary language today, so the Windows leg follows it (documented).
- **Default-off byte-identical**: all 10 languages regenerated pre-change vs post-change, `diff -r` — identical; unit tests pin "no windows content by default", "explicit False == default", and "opt-in leaves pre-existing jobs byte-equal".
- **Docs**: README `--windows-ci` subsection (enablement, supported/excluded languages and why, multi-language behavior, and the honest note that adding the leg to an existing repo requires `--interactive`/`--force` since no YAML-aware workflow merge exists).

## Test plan

- 143 new tests (TDD red-first): `test_ci_windows.py` (126 — YAML parse-validation per language, gate↔emitted-script drift protection, action-pin reuse enforcement, no-GITHUB_ENV, default-off pins), `test_cli_windows_ci.py` (16), `test_windows_ci_leg.py` (1 integration test that generates a real sample with `--windows-ci`, reads the gate commands out of the generated workflow, and executes them for real — actual ruff + pytest runs, exit 0).
- **What's proven on Windows**: these tests run on this repo's `test-windows` leg under real Git Bash on windows-latest, so the python sample's workflow-specified gate commands are demonstrated on the actual runner image and shell; all 7 languages' gates execute `--help` through Git Bash. **Not proven**: GitHub Actions execution of the generated job's checkout/setup steps, and full toolchain gate runs for the 6 non-python languages — stated in test docstrings and docs. actionlint: zero new findings across all 7 opt-in outputs.
- Coverage 96.14% (`ci_windows.py` 100%); `./scripts/check-all.sh` ✅ 7/7; `pre-commit run --all-files` ✅ all 30 hooks.

Closes #388
Refs #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)