### PR TITLE
feat(ai): provider capability advertisement with graceful batch fallback (#389)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "tests/unit/ai/test_providers.py",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 274
       }
     ],
     "tests/unit/test_cli_mocked.py": [
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1789
+        "line_number": 1791
       }
     ]
   },
-  "generated_at": "2026-06-11T13:33:16Z"
+  "generated_at": "2026-06-11T14:47:11Z"
 }

--- a/start_green_stay_green/ai/orchestrator.py
+++ b/start_green_stay_green/ai/orchestrator.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from start_green_stay_green.ai.batch import BatchSubmission
     from start_green_stay_green.ai.batch import ToolUseBatchRequest
     from start_green_stay_green.ai.providers.base import LLMProvider
+    from start_green_stay_green.ai.providers.base import ProviderCapabilities
 
 # Re-export shared types from ``ai.types`` so existing
 # ``from start_green_stay_green.ai.orchestrator import ToolUseResult``
@@ -126,6 +127,21 @@ class AIOrchestrator:
             max_retries=max_retries,
             retry_delay=retry_delay,
         )
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        """Return the injected provider's capability advertisement.
+
+        Batch-aware call sites (the CLI's ``--batch`` path) consult
+        this before dispatching so a provider that lacks batch falls
+        back to sequential calls instead of crashing on the typed
+        decline. Reading it performs no I/O and needs no vendor SDK.
+
+        Returns:
+            The provider's frozen
+            :class:`~start_green_stay_green.ai.providers.base.ProviderCapabilities`.
+        """
+        return self._provider.capabilities()
 
     @staticmethod
     def _validate_api_key(api_key: str) -> None:

--- a/start_green_stay_green/ai/provider_selection.py
+++ b/start_green_stay_green/ai/provider_selection.py
@@ -59,7 +59,8 @@ class _ProviderFactory(Protocol):
         """Construct a provider; see ``AnthropicProvider.__init__``."""
         ...  # pragma: no cover - structural typing only
 
-    def capabilities(self) -> ProviderCapabilities:
+    @classmethod
+    def capabilities(cls) -> ProviderCapabilities:
         """Return the class-level capability advertisement."""
         ...  # pragma: no cover - structural typing only
 
@@ -69,6 +70,7 @@ __all__ = [
     "DEFAULT_PROVIDER",
     "ENV_MODEL",
     "ENV_PROVIDER",
+    "OPENAI_DEFAULT_MODEL",
     "ProviderListing",
     "ProviderSelection",
     "ProviderUnavailableError",
@@ -89,6 +91,12 @@ DEFAULT_MODEL: Final[str] = "claude-sonnet-4-5-20250929"
 
 # Built-in default provider. Anthropic remains the zero-config default.
 DEFAULT_PROVIDER: Final[str] = "anthropic"
+
+# Default model for the OpenAI-compatible provider. Current flagship
+# chat model; live-verified against developers.openai.com on
+# 2026-06-11. Local/OSS servers ignore this default — pass --model (or
+# GREEN_LLM_MODEL) with the hosted model's name instead.
+OPENAI_DEFAULT_MODEL: Final[str] = "gpt-5.5"
 
 # Environment variables for the selection layer. Documented precedence
 # tier 2 (below CLI flags, above config-file keys).
@@ -138,11 +146,7 @@ _PROVIDERS: Final[dict[str, ProviderSpec]] = {
         module="start_green_stay_green.ai.providers.openai_provider",
         class_name="OpenAIProvider",
         api_key_env_var="OPENAI_API_KEY",  # pragma: allowlist secret
-        # Current flagship chat model; live-verified against
-        # developers.openai.com on 2026-06-11. Local/OSS servers ignore
-        # this default — pass --model (or GREEN_LLM_MODEL) with the
-        # hosted model's name instead.
-        default_model="gpt-5.5",
+        default_model=OPENAI_DEFAULT_MODEL,
     ),
 }
 

--- a/start_green_stay_green/ai/provider_selection.py
+++ b/start_green_stay_green/ai/provider_selection.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from start_green_stay_green.ai.providers.base import LLMProvider
+    from start_green_stay_green.ai.providers.base import ProviderCapabilities
 
 
 class _ProviderFactory(Protocol):
@@ -58,15 +59,22 @@ class _ProviderFactory(Protocol):
         """Construct a provider; see ``AnthropicProvider.__init__``."""
         ...  # pragma: no cover - structural typing only
 
+    def capabilities(self) -> ProviderCapabilities:
+        """Return the class-level capability advertisement."""
+        ...  # pragma: no cover - structural typing only
+
 
 __all__ = [
     "DEFAULT_MODEL",
     "DEFAULT_PROVIDER",
     "ENV_MODEL",
     "ENV_PROVIDER",
+    "ProviderListing",
     "ProviderSelection",
     "ProviderUnavailableError",
     "build_provider",
+    "describe_providers",
+    "provider_capabilities",
     "resolve_api_key_env_var",
     "resolve_provider_selection",
     "supported_providers",
@@ -386,6 +394,76 @@ def build_provider(
         model=model,
         max_retries=max_retries,
         retry_delay=retry_delay,
+    )
+
+
+def provider_capabilities(provider: str) -> ProviderCapabilities:
+    """Return ``provider``'s capability advertisement, SDK-free.
+
+    Reads the frozen
+    :class:`~start_green_stay_green.ai.providers.base.ProviderCapabilities`
+    from the provider *class* — no provider instance is constructed,
+    no I/O is performed, and (because provider modules import their
+    vendor SDKs lazily) no optional extra needs to be installed. This
+    is what lets ``green providers`` list every provider's
+    capabilities on a minimal install.
+
+    Args:
+        provider: Provider name (normalized internally).
+
+    Returns:
+        The provider's capability advertisement.
+
+    Raises:
+        ValueError: If the provider is not registered.
+    """
+    normalized = _normalize(provider) or ""
+    spec = _PROVIDERS[_require_known(normalized)]
+    return _load_provider_class(spec).capabilities()
+
+
+@dataclass(frozen=True)
+class ProviderListing:
+    """One row of the user-facing provider listing (``green providers``).
+
+    Pairs the registry metadata a user needs to *select* a provider
+    with the capability advertisement that says what the selection can
+    do.
+
+    Attributes:
+        name: Registry name — the value accepted by ``--provider`` and
+            ``GREEN_LLM_PROVIDER``.
+        default_model: Model used when no flag/env/config supplies one.
+        api_key_env_var: Environment variable the provider's API key
+            is read from.
+        capabilities: The provider's capability advertisement.
+    """
+
+    name: str
+    default_model: str
+    api_key_env_var: str
+    capabilities: ProviderCapabilities
+
+
+def describe_providers() -> tuple[ProviderListing, ...]:
+    """Describe every registered provider for user-facing listings.
+
+    Combines each registry entry with its capability advertisement via
+    :func:`provider_capabilities`, so the listing works without any
+    optional vendor extra installed and performs no I/O.
+
+    Returns:
+        One :class:`ProviderListing` per registered provider, in
+        stable alphabetical name order.
+    """
+    return tuple(
+        ProviderListing(
+            name=name,
+            default_model=_PROVIDERS[name].default_model,
+            api_key_env_var=_PROVIDERS[name].api_key_env_var,
+            capabilities=provider_capabilities(name),
+        )
+        for name in supported_providers()
     )
 
 

--- a/start_green_stay_green/ai/providers/__init__.py
+++ b/start_green_stay_green/ai/providers/__init__.py
@@ -12,8 +12,13 @@ any single SDK. Two concrete implementations exist:
 * :class:`OpenAIProvider` (tracer T3, #385) — maps the same neutral
   types onto the OpenAI Chat Completions API, and via its base-URL
   override onto any local/OSS OpenAI-compatible server. Batch is
-  declined with :class:`UnsupportedCapabilityError` (negotiation is
-  tracer T5, #389).
+  declined with :class:`UnsupportedCapabilityError`.
+
+Each provider advertises which optional capability groups it
+implements via a frozen :class:`ProviderCapabilities` record (tracer
+T5, #389) readable from the class itself — no instance, no vendor SDK
+— so orchestration code negotiates features (e.g. falling back from
+batch to sequential calls) instead of crashing on a typed decline.
 
 The orchestrator depends on the interface, not on any vendor package
 — each SDK is an optional install extra imported lazily inside its
@@ -25,6 +30,7 @@ from __future__ import annotations
 
 from start_green_stay_green.ai.providers.anthropic_provider import AnthropicProvider
 from start_green_stay_green.ai.providers.base import LLMProvider
+from start_green_stay_green.ai.providers.base import ProviderCapabilities
 from start_green_stay_green.ai.providers.base import UnsupportedCapabilityError
 from start_green_stay_green.ai.providers.openai_provider import OpenAIProvider
 
@@ -32,5 +38,6 @@ __all__ = [
     "AnthropicProvider",
     "LLMProvider",
     "OpenAIProvider",
+    "ProviderCapabilities",
     "UnsupportedCapabilityError",
 ]

--- a/start_green_stay_green/ai/providers/anthropic_provider.py
+++ b/start_green_stay_green/ai/providers/anthropic_provider.py
@@ -44,6 +44,7 @@ from start_green_stay_green.ai.batch import BatchSubmission
 from start_green_stay_green.ai.batch import parse_batch_result_entry
 from start_green_stay_green.ai.providers.base import LLMProvider
 from start_green_stay_green.ai.providers.base import OutputFormat
+from start_green_stay_green.ai.providers.base import ProviderCapabilities
 from start_green_stay_green.ai.providers.outcomes import AttemptOutcome
 from start_green_stay_green.ai.providers.outcomes import ToolAttemptOutcome
 from start_green_stay_green.ai.types import GenerationError
@@ -75,6 +76,20 @@ __all__ = ["AnthropicProvider"]
 # ``pip`` extra that installs the SDK; named in the missing-dependency
 # hint so users can copy/paste the fix.
 _INSTALL_EXTRA: Final[str] = "anthropic"
+
+# Registry name of this provider, echoed in the capability advertisement.
+_PROVIDER_NAME: Final[str] = "anthropic"
+
+# Capability advertisement (tracer T5, #389). Anthropic implements
+# every optional capability group natively, including batch (the
+# Message Batches API). This frozen record is the single source of
+# truth negotiation code consults — see ``LLMProvider.capabilities``.
+_CAPABILITIES: Final[ProviderCapabilities] = ProviderCapabilities(
+    provider=_PROVIDER_NAME,
+    batch=True,
+    tool_use=True,
+    token_accounting=True,
+)
 
 # Names this module exposes lazily from the ``anthropic`` SDK via
 # :func:`__getattr__`. Resolved on first *attribute* access
@@ -272,6 +287,15 @@ class AnthropicProvider(LLMProvider):
     def model(self) -> str:
         """Return the Claude model identifier this provider uses."""
         return self._model
+
+    @classmethod
+    def capabilities(cls) -> ProviderCapabilities:
+        """Return the Anthropic capability advertisement.
+
+        Every capability group is implemented natively — including
+        batch, which maps directly onto the Message Batches API.
+        """
+        return _CAPABILITIES
 
     @staticmethod
     def _cache_tokens(usage: object) -> tuple[int, int]:

--- a/start_green_stay_green/ai/providers/base.py
+++ b/start_green_stay_green/ai/providers/base.py
@@ -13,6 +13,15 @@ multi-agent epic — can reason about exactly what a provider offers:
 * **batch** — :meth:`~LLMProvider.submit_tool_use_batch`,
   :meth:`~LLMProvider.poll_batch`, :meth:`~LLMProvider.fetch_batch_results`.
 
+Which optional groups a provider actually implements is advertised by
+:meth:`~LLMProvider.capabilities`, a frozen
+:class:`ProviderCapabilities` record readable from the class itself —
+no instance, no vendor SDK. The advertisement is the single source of
+truth for capability negotiation: providers that decline a group raise
+:class:`UnsupportedCapabilityError` *derived from* the advertisement
+(see :meth:`~LLMProvider._raise_unsupported_batch`), and orchestration
+code consults the same advertisement to fall back gracefully.
+
 Every request and response type referenced here lives in
 :mod:`start_green_stay_green.ai.types` or
 :mod:`start_green_stay_green.ai.batch` and is deliberately
@@ -23,7 +32,10 @@ from __future__ import annotations
 
 from abc import ABC
 from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Final
 from typing import Literal
+from typing import Never
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -36,9 +48,43 @@ if TYPE_CHECKING:
     from start_green_stay_green.ai.types import GenerationResult
     from start_green_stay_green.ai.types import ToolUseResult
 
-__all__ = ["LLMProvider", "UnsupportedCapabilityError"]
+__all__ = ["LLMProvider", "ProviderCapabilities", "UnsupportedCapabilityError"]
 
 OutputFormat = Literal["yaml", "toml", "markdown", "bash"]
+
+# Human-readable name of the batch capability group, echoed in every
+# typed batch decline. Single-sourced here so the error text and the
+# ``capability`` attribute can never drift between providers.
+_BATCH_CAPABILITY: Final[str] = "batch tool-use"
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Machine-readable advertisement of a provider's capability groups.
+
+    The single source of truth for capability negotiation (tracer T5,
+    #389): the batch-decline stubs
+    (:meth:`LLMProvider._raise_unsupported_batch`) and the
+    orchestrator/CLI batch-fallback decision both derive from this
+    structure, so flipping a flag here is the only change needed when
+    a provider gains or loses a capability.
+
+    Attributes:
+        provider: Registry name of the advertising provider (e.g.
+            ``"anthropic"``). Echoed into capability errors and the
+            ``green providers`` listing.
+        batch: Whether the batch group (submit / poll / fetch — the
+            shape of Anthropic's Message Batches API) is implemented.
+        tool_use: Whether forced tool-use (structured) generation is
+            implemented.
+        token_accounting: Whether token-usage telemetry is reported on
+            generation results.
+    """
+
+    provider: str
+    batch: bool
+    tool_use: bool
+    token_accounting: bool
 
 
 class UnsupportedCapabilityError(NotImplementedError):
@@ -49,9 +95,10 @@ class UnsupportedCapabilityError(NotImplementedError):
     OpenAI-compatible endpoints. A provider that cannot honestly
     implement a group raises this typed error instead of emulating it
     badly, so callers can catch it and fall back to a per-request
-    path. Full capability advertisement/negotiation arrives with
-    tracer T5 (#389); this minimal convention is what it will build
-    on.
+    path. The decision to decline derives from the provider's
+    :class:`ProviderCapabilities` advertisement (see
+    :meth:`LLMProvider._raise_unsupported_batch`), so the two cannot
+    drift apart.
 
     Subclasses :class:`NotImplementedError` so generic handlers keep
     working, while ``provider`` and ``capability`` stay machine-readable.
@@ -104,6 +151,50 @@ class LLMProvider(ABC):
             ``claude-...`` string). Stable for the provider's
             lifetime.
         """
+
+    @classmethod
+    @abstractmethod
+    def capabilities(cls) -> ProviderCapabilities:
+        """Return this provider's capability advertisement.
+
+        A classmethod (not a property) so callers — notably the
+        selection registry behind ``green providers`` — can read
+        capabilities without constructing a provider instance and
+        without the vendor SDK installed (provider modules import
+        their SDKs lazily).
+
+        Returns:
+            The frozen :class:`ProviderCapabilities` advertisement.
+            Stable for the lifetime of the class.
+        """
+
+    @classmethod
+    def _raise_unsupported_batch(cls) -> Never:
+        """Raise the typed batch decline derived from :meth:`capabilities`.
+
+        Providers advertising ``batch=False`` call this from their
+        batch-group method stubs, so both the decision to decline and
+        the provider name in the error come from the advertisement —
+        a single source of truth with no per-stub strings to drift.
+
+        Raises:
+            UnsupportedCapabilityError: Always, when the advertisement
+                says ``batch=False``.
+            RuntimeError: If called by a provider advertising batch
+                support — the advertisement and the implementation
+                disagree, which is a programming error.
+        """
+        caps = cls.capabilities()
+        if caps.batch:
+            msg = (
+                f"provider {caps.provider!r} advertises batch support; "
+                f"_raise_unsupported_batch must be unreachable"
+            )
+            raise RuntimeError(msg)
+        raise UnsupportedCapabilityError(
+            provider=caps.provider,
+            capability=_BATCH_CAPABILITY,
+        )
 
     @abstractmethod
     def generate(self, prompt: str, output_format: OutputFormat) -> GenerationResult:

--- a/start_green_stay_green/ai/providers/openai_provider.py
+++ b/start_green_stay_green/ai/providers/openai_provider.py
@@ -26,10 +26,13 @@ when a generation method first runs.
 
 Capability notes:
 
-* **Batch** is Anthropic-specific (Message Batches API); the three
-  batch methods honestly decline with a typed
+* **Batch** is Anthropic-specific (Message Batches API); the
+  provider advertises ``batch=False`` via
+  :meth:`~start_green_stay_green.ai.providers.base.LLMProvider.capabilities`,
+  and the three batch methods honestly decline with a typed
   :class:`~start_green_stay_green.ai.providers.base.UnsupportedCapabilityError`
-  (capability negotiation/fallback is tracer T5, #389).
+  derived from that advertisement. Orchestration consults the same
+  advertisement to fall back to sequential calls instead of crashing.
 * **Caching telemetry**: OpenAI prompt caching is automatic and only
   reports *read* hits (``usage.prompt_tokens_details.cached_tokens``);
   there is no cache-write count, so ``cache_creation_tokens`` is
@@ -56,7 +59,7 @@ from typing import cast
 
 from start_green_stay_green.ai.providers.base import LLMProvider
 from start_green_stay_green.ai.providers.base import OutputFormat
-from start_green_stay_green.ai.providers.base import UnsupportedCapabilityError
+from start_green_stay_green.ai.providers.base import ProviderCapabilities
 from start_green_stay_green.ai.types import GenerationError
 from start_green_stay_green.ai.types import GenerationResult
 from start_green_stay_green.ai.types import TokenUsage
@@ -87,6 +90,19 @@ _INSTALL_EXTRA: Final[str] = "openai"
 
 # Registry name of this provider, echoed in capability errors.
 _PROVIDER_NAME: Final[str] = "openai"
+
+# Capability advertisement (tracer T5, #389). Batch is declined:
+# Anthropic's Message Batches API has no OpenAI-compatible equivalent,
+# and emulating it would silently change cost/durability semantics.
+# This frozen record is the single source of truth — the batch stubs
+# below derive their typed declines from it via
+# ``LLMProvider._raise_unsupported_batch``.
+_CAPABILITIES: Final[ProviderCapabilities] = ProviderCapabilities(
+    provider=_PROVIDER_NAME,
+    batch=False,
+    tool_use=True,
+    token_accounting=True,
+)
 
 # Environment variable supplying the endpoint override for local/OSS
 # OpenAI-compatible servers (e.g. ``http://localhost:11434/v1`` for
@@ -290,6 +306,17 @@ class OpenAIProvider(LLMProvider):
     def model(self) -> str:
         """Return the model identifier this provider generates with."""
         return self._model
+
+    @classmethod
+    def capabilities(cls) -> ProviderCapabilities:
+        """Return the OpenAI capability advertisement.
+
+        Tool-use and token accounting are implemented; batch is not
+        (see the module-level ``_CAPABILITIES`` note). Callers — the
+        orchestrator's fallback decision and ``green providers`` —
+        consult this advertisement rather than probing for errors.
+        """
+        return _CAPABILITIES
 
     def _resolve_base_url(self) -> str | None:
         """Resolve the endpoint override: constructor arg, then env, then SDK.
@@ -898,9 +925,10 @@ class OpenAIProvider(LLMProvider):
         The batch capability group maps onto Anthropic's Message
         Batches API; emulating it with fan-out requests would silently
         change cost and durability semantics, so this provider
-        declines honestly (capability negotiation/fallback is tracer
-        T5, #389). The interface's input contract is still honored
-        first so callers get the most specific error.
+        declines honestly. The typed error derives from the
+        ``capabilities()`` advertisement (single source of truth), and
+        the interface's input contract is still honored first so
+        callers get the most specific error.
 
         Args:
             requests: Validated for emptiness, then declined.
@@ -912,10 +940,7 @@ class OpenAIProvider(LLMProvider):
         if not requests:
             msg = "submit_tool_use_batch requires at least one request"
             raise ValueError(msg)
-        raise UnsupportedCapabilityError(
-            provider=_PROVIDER_NAME,
-            capability="batch tool-use",
-        )
+        self._raise_unsupported_batch()
 
     async def poll_batch(self, batch_id: str) -> BatchPoll:
         """Decline batch polling; see :meth:`submit_tool_use_batch`.
@@ -930,10 +955,7 @@ class OpenAIProvider(LLMProvider):
         if not batch_id:
             msg = "poll_batch requires a non-empty batch_id"
             raise ValueError(msg)
-        raise UnsupportedCapabilityError(
-            provider=_PROVIDER_NAME,
-            capability="batch tool-use",
-        )
+        self._raise_unsupported_batch()
 
     async def fetch_batch_results(self, batch_id: str) -> BatchResultsBundle:
         """Decline batch fetching; see :meth:`submit_tool_use_batch`.
@@ -948,7 +970,4 @@ class OpenAIProvider(LLMProvider):
         if not batch_id:
             msg = "fetch_batch_results requires a non-empty batch_id"
             raise ValueError(msg)
-        raise UnsupportedCapabilityError(
-            provider=_PROVIDER_NAME,
-            capability="batch tool-use",
-        )
+        self._raise_unsupported_batch()

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
+    from start_green_stay_green.ai.providers.base import ProviderCapabilities
     from start_green_stay_green.generators.agent_context import AgentContextContent
     from start_green_stay_green.utils.enhance_state import EnhanceState
 
@@ -48,6 +49,7 @@ from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerati
 from start_green_stay_green.ai.provider_selection import ProviderSelection
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.ai.provider_selection import build_provider
+from start_green_stay_green.ai.provider_selection import describe_providers
 from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
 from start_green_stay_green.ai.provider_selection import resolve_provider_selection
 from start_green_stay_green.generators.agent_context import AGENT_CONTEXT_TARGETS
@@ -309,6 +311,51 @@ def version(
     else:
         # Simple version output
         console.print(f"[bold cyan]Start Green Stay Green v{version_str}[/bold cyan]")
+
+
+def _format_capability_flags(capabilities: ProviderCapabilities) -> str:
+    """Render one provider's capability flags as a short yes/no line.
+
+    Args:
+        capabilities: The provider's frozen advertisement.
+
+    Returns:
+        A comma-separated ``flag: yes/no`` summary, e.g.
+        ``"batch: yes, tool-use: yes, token accounting: yes"``.
+    """
+    flags = (
+        ("batch", capabilities.batch),
+        ("tool-use", capabilities.tool_use),
+        ("token accounting", capabilities.token_accounting),
+    )
+    return ", ".join(
+        f"{label}: {'yes' if supported else 'no'}" for label, supported in flags
+    )
+
+
+@app.command()
+def providers() -> None:
+    """List registered LLM providers and their capabilities.
+
+    Shows, for each provider the ``--provider`` flag accepts: the
+    default model, the environment variable its API key is read from,
+    and which capability groups it implements (batch, tool-use, token
+    accounting). The listing is read from each provider's capability
+    advertisement — no credentials, network access, or optional vendor
+    SDK required.
+    """
+    for listing in describe_providers():
+        flags = _format_capability_flags(listing.capabilities)
+        console.print(f"[bold]{listing.name}[/bold]")
+        console.print(f"  default model:   {listing.default_model}")
+        console.print(f"  API key env var: {listing.api_key_env_var}")
+        console.print(f"  capabilities:    {flags}")
+    console.print(
+        "\n[dim]Select with --provider/--model on `green init` / "
+        "`green enhance`, or via GREEN_LLM_PROVIDER / GREEN_LLM_MODEL. "
+        "Providers without batch support fall back to sequential API "
+        "calls (with a warning) when --batch is requested.[/dim]"
+    )
 
 
 def _validate_project_name(name: str) -> None:
@@ -3268,6 +3315,102 @@ def _validate_batch_targets(selected_targets: tuple[str, ...]) -> None:
     raise typer.Exit(code=1)
 
 
+def _validate_enhance_flags(
+    *,
+    batch: bool,
+    wait: bool,
+    selected_targets: tuple[str, ...],
+) -> None:
+    """Validate the ``--batch`` / ``--wait`` flag combination up front.
+
+    ``--batch`` only supports the batchable targets (see
+    :func:`_validate_batch_targets`), and ``--wait`` is meaningless
+    without ``--batch``. Both checks fail fast before any orchestrator
+    is constructed or API key resolved.
+
+    Args:
+        batch: Value of the ``--batch`` flag.
+        wait: Value of the ``--wait`` flag.
+        selected_targets: Resolved ``--targets`` selection.
+
+    Raises:
+        typer.Exit: With code 1 on an invalid combination.
+    """
+    if batch:
+        _validate_batch_targets(selected_targets)
+    if wait and not batch:
+        console.print("[red]Error:[/red] --wait only applies in --batch mode.")
+        raise typer.Exit(code=1)
+
+
+def _dispatch_enhance_batch(
+    *,
+    project: _EnhanceProjectContext,
+    orchestrator: AIOrchestrator,
+    file_writer: FileWriter,
+    dry_run: bool,
+    wait: bool,
+) -> bool:
+    """Run the batch path when the provider advertises batch support.
+
+    Capability negotiation (T5, #389): the decision derives from the
+    provider's capability advertisement, never from probing for the
+    typed batch decline. Batch-capable providers (Anthropic) take the
+    existing batch machinery unchanged; for everyone else this prints
+    the loud fallback warning and reports back so the caller runs the
+    same targets through the documented sequential pipeline instead —
+    no crash, no dropped work.
+
+    Args:
+        project: Project metadata for the enhance run.
+        orchestrator: Configured orchestrator wrapping the selected
+            provider.
+        file_writer: Conflict-resolution-aware writer.
+        dry_run: Skip API calls and writes (batch path only).
+        wait: Block in-process until the batch ends (resume calls).
+
+    Returns:
+        ``True`` when the batch path handled the run; ``False`` when
+        the provider lacks batch and the caller must fall back to the
+        sequential pipeline.
+    """
+    if not orchestrator.capabilities.batch:
+        _warn_batch_capability_fallback(orchestrator.capabilities)
+        return False
+    _run_enhance_batch(
+        project=project,
+        orchestrator=orchestrator,
+        file_writer=file_writer,
+        dry_run=dry_run,
+        wait=wait,
+    )
+    return True
+
+
+def _warn_batch_capability_fallback(capabilities: ProviderCapabilities) -> None:
+    """Print the loud fallback warning for ``--batch`` on a non-batch provider.
+
+    No work is dropped: the same subagent tunings run through the
+    documented sequential pipeline (:func:`_run_enhance_pipeline` —
+    the exact path the non-batch flow uses), producing the same
+    artifacts. What changes is the cost/latency semantics: no Batches
+    API discount, no submit/resume two-call flow — the calls run
+    in-process now.
+
+    Args:
+        capabilities: The selected provider's advertisement (its
+            ``batch`` flag is ``False`` when this fires).
+    """
+    console.print(
+        f"[yellow]Warning:[/yellow] provider {capabilities.provider!r} "
+        f"does not support the Message Batches API — falling back to "
+        f"sequential API calls now (same results; no batch discount, "
+        f"no submit/resume flow). Run `green providers` to see "
+        f"per-provider capabilities.",
+        style="bold",
+    )
+
+
 def _run_enhance_batch(
     *,
     project: _EnhanceProjectContext,
@@ -3558,7 +3701,10 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
                 "Batches API (50% cheaper, ≤24 h SLA). Use with "
                 "``--targets subagents``. The first run submits and "
                 "exits; re-run to fetch results, or pass ``--wait`` "
-                "to block until done. See ADR-001 for the rationale."
+                "to block until done. See ADR-001 for the rationale. "
+                "Providers without batch support (see `green "
+                "providers`) fall back to sequential API calls with "
+                "a warning."
             ),
         ),
     ] = False,
@@ -3608,7 +3754,10 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         force: Overwrite files without prompting.
         batch: Submit subagent tunings via the Anthropic Message
             Batches API. Submit-then-resume two-call flow; pair
-            with ``--wait`` for in-process polling.
+            with ``--wait`` for in-process polling. If the selected
+            provider does not advertise batch support, the same
+            targets fall back to sequential API calls with a loud
+            warning (never a crash, never dropped work).
         wait: Block in-process when ``--batch`` is set; polls every
             30 s until the batch ends or the timeout elapses.
         provider: Optional LLM provider override (``--provider``).
@@ -3637,11 +3786,11 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
     )
 
     selected_targets = _resolve_enhance_targets(targets)
-    if batch:
-        _validate_batch_targets(selected_targets)
-    if wait and not batch:
-        console.print("[red]Error:[/red] --wait only applies in --batch mode.")
-        raise typer.Exit(code=1)
+    _validate_enhance_flags(
+        batch=batch,
+        wait=wait,
+        selected_targets=selected_targets,
+    )
     orchestrator = _require_enhance_orchestrator(
         api_key,
         no_interactive=no_interactive,
@@ -3668,14 +3817,13 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         language=resolved_language,
     )
 
-    if batch:
-        _run_enhance_batch(
-            project=project,
-            orchestrator=orchestrator,
-            file_writer=file_writer,
-            dry_run=dry_run,
-            wait=wait,
-        )
+    if batch and _dispatch_enhance_batch(
+        project=project,
+        orchestrator=orchestrator,
+        file_writer=file_writer,
+        dry_run=dry_run,
+        wait=wait,
+    ):
         return
 
     _run_enhance_pipeline(

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -6,6 +6,7 @@ Implements the command-line interface using Typer with rich output formatting.
 from __future__ import annotations
 
 from contextlib import contextmanager
+import dataclasses
 from dataclasses import dataclass
 from datetime import UTC
 from datetime import datetime
@@ -19,6 +20,7 @@ import shutil
 import sys
 from typing import Annotated
 from typing import Any
+from typing import Final
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import assert_never
@@ -313,8 +315,18 @@ def version(
         console.print(f"[bold cyan]Start Green Stay Green v{version_str}[/bold cyan]")
 
 
+# Display labels for ProviderCapabilities flag fields whose name alone
+# doesn't read well; every other bool field falls back to its field
+# name with underscores spaced.
+_CAPABILITY_FLAG_LABELS: Final[dict[str, str]] = {"tool_use": "tool-use"}
+
+
 def _format_capability_flags(capabilities: ProviderCapabilities) -> str:
     """Render one provider's capability flags as a short yes/no line.
+
+    Derives the flag list from the dataclass's own bool fields so a new
+    capability added to :class:`ProviderCapabilities` shows up here
+    without a second edit point.
 
     Args:
         capabilities: The provider's frozen advertisement.
@@ -324,9 +336,12 @@ def _format_capability_flags(capabilities: ProviderCapabilities) -> str:
         ``"batch: yes, tool-use: yes, token accounting: yes"``.
     """
     flags = (
-        ("batch", capabilities.batch),
-        ("tool-use", capabilities.tool_use),
-        ("token accounting", capabilities.token_accounting),
+        (
+            _CAPABILITY_FLAG_LABELS.get(field.name, field.name.replace("_", " ")),
+            getattr(capabilities, field.name),
+        )
+        for field in dataclasses.fields(capabilities)
+        if isinstance(getattr(capabilities, field.name), bool)
     )
     return ", ".join(
         f"{label}: {'yes' if supported else 'no'}" for label, supported in flags
@@ -3403,7 +3418,7 @@ def _warn_batch_capability_fallback(capabilities: ProviderCapabilities) -> None:
     """
     console.print(
         f"[yellow]Warning:[/yellow] provider {capabilities.provider!r} "
-        f"does not support the Message Batches API — falling back to "
+        f"does not support batch processing — falling back to "
         f"sequential API calls now (same results; no batch discount, "
         f"no submit/resume flow). Run `green providers` to see "
         f"per-provider capabilities.",
@@ -3817,6 +3832,9 @@ def enhance(  # noqa: PLR0913 — top-level CLI command; matches init's pattern
         language=resolved_language,
     )
 
+    # A False return means the provider lacks batch support and a
+    # fallback warning was already printed — fall through to the
+    # sequential pipeline below instead of returning.
     if batch and _dispatch_enhance_batch(
         project=project,
         orchestrator=orchestrator,

--- a/tests/unit/ai/test_openai_provider.py
+++ b/tests/unit/ai/test_openai_provider.py
@@ -732,6 +732,16 @@ class TestBatchUnsupported:
         """Callers catching ``NotImplementedError`` still catch it."""
         assert issubclass(UnsupportedCapabilityError, NotImplementedError)
 
+    def test_decline_aligns_with_capability_advertisement(self) -> None:
+        """The advertisement is the single source the stubs derive from.
+
+        The batch stubs raise via
+        :meth:`LLMProvider._raise_unsupported_batch`, which reads
+        ``capabilities()`` — so ``batch=False`` here and the typed
+        declines above cannot drift apart.
+        """
+        assert OpenAIProvider.capabilities().batch is False
+
     @pytest.mark.asyncio
     async def test_empty_batch_submission_raises_value_error(self) -> None:
         """The interface's input contract is honored before declining."""

--- a/tests/unit/ai/test_provider_selection.py
+++ b/tests/unit/ai/test_provider_selection.py
@@ -31,10 +31,13 @@ from start_green_stay_green.ai.provider_selection import ProviderSelection
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.ai.provider_selection import _coalesce
 from start_green_stay_green.ai.provider_selection import build_provider
+from start_green_stay_green.ai.provider_selection import describe_providers
+from start_green_stay_green.ai.provider_selection import provider_capabilities
 from start_green_stay_green.ai.provider_selection import resolve_api_key_env_var
 from start_green_stay_green.ai.provider_selection import resolve_provider_selection
 from start_green_stay_green.ai.provider_selection import supported_providers
 from start_green_stay_green.ai.providers.base import LLMProvider
+from start_green_stay_green.ai.providers.base import ProviderCapabilities
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -420,3 +423,76 @@ def test_missing_openai_extra_raises_actionable_error_on_use(
     assert "pip install" in message
     assert "[openai]" in message
     assert isinstance(exc.value.__cause__, ImportError)
+
+
+# ----------------------- capabilities (T5, #389) ---------------------------
+def test_provider_capabilities_anthropic_supports_batch() -> None:
+    """The registry surfaces Anthropic's full capability set."""
+    caps = provider_capabilities("anthropic")
+    assert caps == ProviderCapabilities(
+        provider="anthropic",
+        batch=True,
+        tool_use=True,
+        token_accounting=True,
+    )
+
+
+def test_provider_capabilities_openai_lacks_batch() -> None:
+    """The registry surfaces OpenAI's batch-unsupported advertisement."""
+    caps = provider_capabilities("openai")
+    assert not caps.batch
+    assert caps.tool_use
+    assert caps.token_accounting
+    assert caps.provider == "openai"
+
+
+def test_provider_capabilities_normalizes_name() -> None:
+    """Provider names are case-insensitive registry keys here too."""
+    assert provider_capabilities("  OpenAI ") == provider_capabilities("openai")
+
+
+def test_provider_capabilities_unknown_provider_raises() -> None:
+    """An unknown provider raises the standard registry ValueError."""
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        provider_capabilities("does-not-exist")
+
+
+def test_provider_capabilities_readable_without_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capabilities resolve with the vendor SDK absent (lazy-import seam).
+
+    ``green providers`` must list every provider's capabilities even
+    when an optional extra is not installed, so the advertisement is
+    read from the (import-clean) provider class, never from an SDK.
+    """
+    _block_openai_import(monkeypatch)
+    assert not provider_capabilities("openai").batch
+
+
+def test_describe_providers_lists_every_registered_provider() -> None:
+    """The listing covers the whole registry in sorted name order."""
+    listings = describe_providers()
+    assert tuple(entry.name for entry in listings) == ("anthropic", "openai")
+
+
+def test_describe_providers_carries_spec_and_capabilities() -> None:
+    """Each row pairs registry metadata with the advertisement."""
+    by_name = {entry.name: entry for entry in describe_providers()}
+    anthropic = by_name["anthropic"]
+    assert anthropic.default_model == DEFAULT_MODEL
+    assert anthropic.api_key_env_var == "ANTHROPIC_API_KEY"  # pragma: allowlist secret
+    assert anthropic.capabilities.batch
+    openai = by_name["openai"]
+    assert openai.default_model == "gpt-5.5"
+    assert openai.api_key_env_var == "OPENAI_API_KEY"  # pragma: allowlist secret
+    assert not openai.capabilities.batch
+
+
+def test_describe_providers_works_without_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full listing also resolves with an optional extra absent."""
+    _block_openai_import(monkeypatch)
+    names = [entry.name for entry in describe_providers()]
+    assert "openai" in names

--- a/tests/unit/ai/test_provider_selection.py
+++ b/tests/unit/ai/test_provider_selection.py
@@ -27,6 +27,7 @@ import pytest
 from start_green_stay_green.ai.orchestrator import ModelConfig
 from start_green_stay_green.ai.provider_selection import DEFAULT_MODEL
 from start_green_stay_green.ai.provider_selection import DEFAULT_PROVIDER
+from start_green_stay_green.ai.provider_selection import OPENAI_DEFAULT_MODEL
 from start_green_stay_green.ai.provider_selection import ProviderSelection
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.ai.provider_selection import _coalesce
@@ -355,7 +356,7 @@ def test_openai_selection_uses_provider_default_model() -> None:
         env={},
     )
     assert selection.provider == "openai"
-    assert selection.model == "gpt-5.5"
+    assert selection.model == OPENAI_DEFAULT_MODEL
     assert selection.model != DEFAULT_MODEL
 
 
@@ -484,7 +485,7 @@ def test_describe_providers_carries_spec_and_capabilities() -> None:
     assert anthropic.api_key_env_var == "ANTHROPIC_API_KEY"  # pragma: allowlist secret
     assert anthropic.capabilities.batch
     openai = by_name["openai"]
-    assert openai.default_model == "gpt-5.5"
+    assert openai.default_model == OPENAI_DEFAULT_MODEL
     assert openai.api_key_env_var == "OPENAI_API_KEY"  # pragma: allowlist secret
     assert not openai.capabilities.batch
 

--- a/tests/unit/ai/test_providers.py
+++ b/tests/unit/ai/test_providers.py
@@ -16,6 +16,7 @@ network involvement.
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
@@ -33,6 +34,9 @@ from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import ModelConfig
 from start_green_stay_green.ai.providers import AnthropicProvider
 from start_green_stay_green.ai.providers import LLMProvider
+from start_green_stay_green.ai.providers import OpenAIProvider
+from start_green_stay_green.ai.providers import ProviderCapabilities
+from start_green_stay_green.ai.providers import UnsupportedCapabilityError
 from start_green_stay_green.ai.providers.outcomes import AttemptOutcome
 from start_green_stay_green.ai.providers.outcomes import ToolAttemptOutcome
 from start_green_stay_green.ai.types import GenerationError
@@ -162,6 +166,7 @@ class TestLLMProviderInterface:
         abstract = LLMProvider.__abstractmethods__
         assert abstract == {
             "model",
+            "capabilities",
             "generate",
             "generate_async",
             "generate_tool_use_async",
@@ -182,6 +187,77 @@ class TestLLMProviderInterface:
             "aclose",
         ):
             assert inspect.iscoroutinefunction(getattr(LLMProvider, name))
+
+
+class TestCapabilityAdvertisement:
+    """T5 (#389): providers advertise capabilities as one frozen structure.
+
+    The advertisement is the single source of truth for capability
+    negotiation: the batch-decline stubs and the orchestrator's
+    fallback decision both derive from it.
+    """
+
+    def test_anthropic_advertises_batch_supported(self) -> None:
+        """Anthropic implements every capability group, batch included."""
+        assert AnthropicProvider.capabilities() == ProviderCapabilities(
+            provider="anthropic",
+            batch=True,
+            tool_use=True,
+            token_accounting=True,
+        )
+
+    def test_openai_advertises_batch_unsupported(self) -> None:
+        """OpenAI declines batch but supports tool-use and token telemetry."""
+        assert OpenAIProvider.capabilities() == ProviderCapabilities(
+            provider="openai",
+            batch=False,
+            tool_use=True,
+            token_accounting=True,
+        )
+
+    def test_capabilities_readable_without_an_instance(self) -> None:
+        """The advertisement is a classmethod: no construction, no SDK.
+
+        ``green providers`` reads capabilities through the selection
+        registry, which must work without any vendor extra installed —
+        so the advertisement cannot live on a constructed instance.
+        """
+        assert OpenAIProvider.capabilities().batch is False
+        assert AnthropicProvider.capabilities().batch is True
+
+    def test_capabilities_structure_is_frozen(self) -> None:
+        """The advertisement is immutable — callers cannot flip flags."""
+        caps = AnthropicProvider.capabilities()
+        field_name = "batch"
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(caps, field_name, False)
+
+    def test_decline_helper_derives_error_from_advertisement(self) -> None:
+        """The typed decline carries the advertised provider name."""
+        with pytest.raises(UnsupportedCapabilityError) as exc:
+            OpenAIProvider._raise_unsupported_batch()
+        assert exc.value.provider == "openai"
+        assert exc.value.capability == "batch tool-use"
+
+    def test_decline_helper_refuses_batch_capable_provider(self) -> None:
+        """A batch-capable provider calling the decline helper is a bug."""
+        with pytest.raises(RuntimeError, match="advertises batch support"):
+            AnthropicProvider._raise_unsupported_batch()
+
+    def test_orchestrator_capabilities_delegates_to_provider(self) -> None:
+        """``AIOrchestrator.capabilities`` reads the injected provider's."""
+        provider = _spy_provider()
+        provider.capabilities = MagicMock(
+            return_value=OpenAIProvider.capabilities(),
+        )
+        orchestrator = AIOrchestrator(api_key="sk-test", provider=provider)
+        assert orchestrator.capabilities == OpenAIProvider.capabilities()
+        provider.capabilities.assert_called_once_with()
+
+    def test_default_orchestrator_advertises_batch(self) -> None:
+        """The zero-config (Anthropic) orchestrator advertises batch."""
+        orchestrator = AIOrchestrator(api_key="sk-test")
+        assert orchestrator.capabilities.batch is True
 
 
 class TestOrchestratorDefaultsToAnthropicProvider:

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -2801,6 +2801,35 @@ class TestEnhanceDispatchAssertion:
             cli._assert_enhance_dispatch_intact()
 
 
+class TestValidateEnhanceFlags:
+    """Direct unit tests for the extracted ``_validate_enhance_flags``."""
+
+    def test_wait_without_batch_exits(self) -> None:
+        """``--wait`` without ``--batch`` fails fast with exit code 1."""
+        with pytest.raises(typer.Exit) as exc_info:
+            cli._validate_enhance_flags(
+                batch=False, wait=True, selected_targets=("subagents",)
+            )
+        assert exc_info.value.exit_code == 1
+
+    def test_batch_with_unsupported_target_exits(self) -> None:
+        """``--batch`` with a non-batchable target fails fast."""
+        with pytest.raises(typer.Exit) as exc_info:
+            cli._validate_enhance_flags(
+                batch=True, wait=False, selected_targets=("claude-md",)
+            )
+        assert exc_info.value.exit_code == 1
+
+    def test_valid_combinations_pass(self) -> None:
+        """Supported combinations return without raising."""
+        cli._validate_enhance_flags(
+            batch=False, wait=False, selected_targets=("claude-md", "subagents")
+        )
+        cli._validate_enhance_flags(
+            batch=True, wait=True, selected_targets=("subagents",)
+        )
+
+
 class TestEnhanceBatchCLI:
     """Phase 5b: ``green enhance --batch`` flag wiring."""
 
@@ -3073,7 +3102,7 @@ class TestEnhanceBatchCLI:
 
         assert result.exit_code == 0
         flat = self._flat(result.stdout)
-        assert "does not support the Message Batches API" in flat
+        assert "does not support batch processing" in flat
         assert "sequential" in flat
         # Points the user at the capability listing for discoverability.
         assert "green providers" in flat
@@ -3152,7 +3181,7 @@ class TestEnhanceBatchCLI:
 
         assert result.exit_code == 0
         flat = self._flat(result.stdout)
-        assert "does not support the Message Batches API" not in flat
+        assert "does not support batch processing" not in flat
         run_batch.assert_called_once()
         run_pipeline.assert_not_called()
 

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -29,6 +29,7 @@ def test_something(mock_path: Mock) -> None:
 import asyncio
 import json
 from pathlib import Path
+import re
 from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
@@ -43,6 +44,7 @@ from start_green_stay_green import cli
 from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
 from start_green_stay_green.ai.orchestrator import AIOrchestrator
 from start_green_stay_green.ai.orchestrator import GenerationError as AIGenerationError
+from start_green_stay_green.ai.provider_selection import DEFAULT_MODEL
 from start_green_stay_green.ai.provider_selection import ProviderUnavailableError
 from start_green_stay_green.generators.base import SUPPORTED_LANGUAGES
 from start_green_stay_green.generators.subagents import REQUIRED_AGENTS
@@ -3033,3 +3035,185 @@ class TestEnhanceBatchCLI:
 
         with pytest.raises(AssertionError, match="unreachable"):
             cli._render_batch_resume_outcome(bad)
+
+    def test_batch_with_non_batch_provider_falls_back_to_sequential(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--batch`` on a non-batch provider warns and runs sequentially.
+
+        T5 (#389): the OpenAI provider advertises ``batch=False``, so
+        requesting batch must not crash with the typed capability
+        error — instead the same subagent tunings run through the
+        documented sequential pipeline (the very path the non-batch
+        flow uses), preceded by a loud warning. No work is dropped.
+        """
+        monkeypatch.delenv("GREEN_LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-local")
+        project = self._make_project(tmp_path)
+
+        with (
+            mock.patch("start_green_stay_green.cli._run_enhance_batch") as run_batch,
+            mock.patch(
+                "start_green_stay_green.cli._run_enhance_pipeline"
+            ) as run_pipeline,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                    "--provider",
+                    "openai",
+                ],
+            )
+
+        assert result.exit_code == 0
+        flat = self._flat(result.stdout)
+        assert "does not support the Message Batches API" in flat
+        assert "sequential" in flat
+        # Points the user at the capability listing for discoverability.
+        assert "green providers" in flat
+        run_batch.assert_not_called()
+        run_pipeline.assert_called_once()
+        # The fallback runs the exact targets --batch was asked for.
+        assert run_pipeline.call_args.kwargs["selected_targets"] == ("subagents",)
+
+    def test_fallback_with_wait_flag_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--batch --wait`` on a non-batch provider still falls back cleanly.
+
+        The sequential fallback completes in-process, so ``--wait`` is
+        trivially satisfied — it must not error or change the outcome.
+        """
+        monkeypatch.delenv("GREEN_LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-local")
+        project = self._make_project(tmp_path)
+
+        with (
+            mock.patch("start_green_stay_green.cli._run_enhance_batch") as run_batch,
+            mock.patch(
+                "start_green_stay_green.cli._run_enhance_pipeline"
+            ) as run_pipeline,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--wait",
+                    "--targets",
+                    "subagents",
+                    "--provider",
+                    "openai",
+                ],
+            )
+
+        assert result.exit_code == 0
+        run_batch.assert_not_called()
+        run_pipeline.assert_called_once()
+
+    def test_batch_with_anthropic_provider_takes_batch_path_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Anthropic fast path is untouched by capability negotiation.
+
+        With a batch-capable provider, ``--batch`` routes straight into
+        the existing batch machinery — no fallback warning, no
+        sequential pipeline call.
+        """
+        monkeypatch.delenv("GREEN_LLM_PROVIDER", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        project = self._make_project(tmp_path)
+
+        with (
+            mock.patch("start_green_stay_green.cli._run_enhance_batch") as run_batch,
+            mock.patch(
+                "start_green_stay_green.cli._run_enhance_pipeline"
+            ) as run_pipeline,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.app,
+                [
+                    "enhance",
+                    str(project),
+                    "--batch",
+                    "--targets",
+                    "subagents",
+                ],
+            )
+
+        assert result.exit_code == 0
+        flat = self._flat(result.stdout)
+        assert "does not support the Message Batches API" not in flat
+        run_batch.assert_called_once()
+        run_pipeline.assert_not_called()
+
+
+class TestProvidersCommand:
+    """``green providers``: user-facing capability discoverability (T5, #389)."""
+
+    @staticmethod
+    def _plain(text: str) -> str:
+        """Strip ANSI escapes and collapse whitespace for stable asserts."""
+        no_ansi = re.sub(r"\x1b\[[0-9;]*m", "", text)
+        return " ".join(no_ansi.split())
+
+    def test_lists_every_registered_provider(self) -> None:
+        """Both registry entries appear, with their key env vars."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["providers"])
+
+        assert result.exit_code == 0
+        plain = self._plain(result.output)
+        assert "anthropic" in plain
+        assert "openai" in plain
+        assert "ANTHROPIC_API_KEY" in plain
+        assert "OPENAI_API_KEY" in plain
+
+    def test_shows_capability_flags_per_provider(self) -> None:
+        """Anthropic shows batch yes; OpenAI shows batch no."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["providers"])
+
+        plain = self._plain(result.output)
+        assert "batch: yes, tool-use: yes, token accounting: yes" in plain
+        assert "batch: no, tool-use: yes, token accounting: yes" in plain
+        # Rows are sorted (anthropic first), so the batch-capable row
+        # precedes the batch-less one.
+        assert plain.index("batch: yes") < plain.index("batch: no")
+
+    def test_shows_per_provider_default_models(self) -> None:
+        """Each row names the model used when none is configured."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["providers"])
+
+        plain = self._plain(result.output)
+        assert DEFAULT_MODEL in plain
+        assert "gpt-5.5" in plain
+
+    def test_runs_without_api_keys_or_vendor_sdks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The listing needs no credentials and performs no I/O."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["providers"])
+
+        assert result.exit_code == 0
+
+    def test_mentions_batch_fallback_behavior(self) -> None:
+        """The trailer documents the --batch fallback honestly."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["providers"])
+
+        plain = self._plain(result.output)
+        assert "fall back to sequential" in plain


### PR DESCRIPTION
## Summary

Implements multi-agent tracer **T5** (final tracer of epic #379): providers advertise their capabilities and the `--batch` path degrades gracefully instead of crashing on a non-batch provider.

- **`ProviderCapabilities`** frozen dataclass in `ai/providers/base.py` (`provider`, `batch`, `tool_use`, `token_accounting`), advertised via a **classmethod** on each provider class. Anthropic: `batch=True`; OpenAI: `batch=False` (both support tool-use + token accounting). Because provider modules are import-clean (SDKs load lazily), capabilities are readable through the selection registry **without constructing a provider or installing the extra** — pinned by tests that block the `openai` import.
- **Single source of truth**: the #385 OpenAI batch stubs now route through `LLMProvider._raise_unsupported_batch()`, which builds the `UnsupportedCapabilityError` from `cls.capabilities()` (and raises `RuntimeError` if a batch-capable provider ever calls it). Flipping the advertisement flag is the only edit point.
- **Graceful fallback**: `green enhance --batch` on a non-batch provider previously crashed (`UnsupportedCapabilityError` was unhandled in the CLI). Now `_dispatch_enhance_batch` consults `orchestrator.capabilities.batch`; if unsupported it prints a loud warning and falls through to the sequential enhance pipeline with the same selected targets — which writes the identical per-agent artifacts the batch reconciliation writes. No dropped work, no crash; `--wait` trivially satisfied in-process.
- **Discoverability**: new `green providers` command listing each registered provider's default model, API-key env var, and capability flags, with an honest trailer documenting the sequential fallback; `--batch` help text updated.
- **Anthropic fast path unchanged**: `ai/batch.py` and `ai/batch_dispatch.py` have zero diff; the only addition on the batch route is one property read. A dedicated test pins batch-called / pipeline-not-called / no-warning for Anthropic, and all 9 pre-existing batch CLI tests pass unmodified.

## Test plan

- 23 new tests (TDD red-first) across `test_providers.py` (advertisement, frozen-ness, decline-helper both branches, orchestrator delegation), `test_provider_selection.py` (registry capabilities incl. with the openai SDK import blocked), `test_openai_provider.py` (stub/advertisement alignment), `test_cli_mocked.py` (`green providers` output with ANSI-strip/whitespace-collapse normalization per the #388 lesson; fallback warning + sequential dispatch; `--wait`; Anthropic-path-unchanged).
- Full suite 3340 passed; coverage 96.22% (≥90% threshold untouched).
- `./scripts/check-all.sh` ✅ 7/7; `pre-commit run --all-files` ✅ all hooks.

Closes #389
Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)