### PR TITLE
fix(cli): add top-level --version eager flag (#401)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1794
+        "line_number": 1821
       }
     ]
   },
-  "generated_at": "2026-06-11T16:07:25Z"
+  "generated_at": "2026-06-11T17:37:56Z"
 }

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -265,11 +265,41 @@ def _load_config_if_specified(
             raise typer.Exit(code=1) from e
 
 
+def _version_flag_callback(value: bool) -> None:  # noqa: FBT001
+    """Print the version and exit when ``--version`` is passed.
+
+    Eager Typer callback: runs before any command or option validation,
+    so ``sgsg --version`` works regardless of other arguments. Output
+    matches the ``version`` subcommand's simple form.
+
+    Args:
+        value: ``True`` when the flag was supplied on the command line.
+
+    Raises:
+        typer.Exit: Always, after printing (exit code 0).
+    """
+    if value:
+        console.print(f"[bold cyan]Start Green Stay Green v{get_version()}[/bold cyan]")
+        raise typer.Exit
+
+
+version_flag_option = Annotated[
+    bool,
+    typer.Option(
+        "--version",
+        help="Show the version and exit.",
+        callback=_version_flag_callback,
+        is_eager=True,
+    ),
+]
+
+
 @app.callback()
 def main(
     verbose: verbose_option = False,  # noqa: FBT002
     quiet: quiet_option = False,  # noqa: FBT002
     config: config_file_option = None,
+    version: version_flag_option = False,  # noqa: FBT002
 ) -> None:
     """Start Green Stay Green - Generate quality-controlled, AI-ready repositories.
 
@@ -280,7 +310,11 @@ def main(
         verbose: Enable verbose output.
         quiet: Suppress non-essential output.
         config: Path to configuration file.
+        version: Print the version and exit (handled eagerly).
     """
+    # The eager callback consumed --version before this body runs; the
+    # parameter exists only so Typer registers the option.
+    del version
     _validate_options(verbose, quiet)
     _load_config_if_specified(config, verbose)
 

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -89,6 +89,33 @@ class TestVersionCommand:
         assert all(part.isdigit() for part in parts)
 
 
+class TestVersionFlag:
+    """Top-level ``--version`` eager flag (#401)."""
+
+    def test_version_flag_prints_version_and_exits_zero(self) -> None:
+        """``sgsg --version`` prints the version and exits 0."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["--version"])
+        assert result.exit_code == 0
+        assert cli.get_version() in result.output
+
+    def test_version_flag_matches_version_subcommand_output(self) -> None:
+        """``--version`` output matches the ``version`` subcommand."""
+        runner = CliRunner()
+        flag = runner.invoke(cli.app, ["--version"])
+        sub = runner.invoke(cli.app, ["version"])
+        assert flag.exit_code == 0
+        assert sub.exit_code == 0
+        assert flag.output == sub.output
+
+    def test_version_flag_is_eager(self) -> None:
+        """``--version`` wins even alongside an invalid option combo."""
+        runner = CliRunner()
+        result = runner.invoke(cli.app, ["--version", "--verbose", "--quiet"])
+        assert result.exit_code == 0
+        assert cli.get_version() in result.output
+
+
 class TestConfigLoading:
     """Test configuration file loading."""
 


### PR DESCRIPTION
## Summary

`sgsg --version` errored ("no such option") because only the `sgsg version` subcommand existed. This adds the standard Typer eager `--version` option to the app callback:

- `_version_flag_callback` prints the same simple output as the `version` subcommand and raises `typer.Exit` (code 0).
- `is_eager=True` so it wins before any other option validation (`sgsg --version --verbose --quiet` still prints the version and exits 0).
- The `version` parameter is consumed by the eager callback; the body `del`s it with a comment explaining it exists only to register the option (root-cause fix for ARG001, no suppression).
- The `version` subcommand is unchanged.

## Test plan

- 3 new tests (TDD red-first, all failed before the fix): `--version` exits 0 with the version string; `--version` output matches the `version` subcommand byte-for-byte; eagerness pinned alongside an otherwise-invalid flag combo.
- `./scripts/check-all.sh` ✅ 7/7; `pre-commit run --all-files` ✅ all 30 hooks.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)