### PR TITLE
chore(release): polish release-readiness verification script + tests (#402)

### DIFF
--- a/scripts/verify_release_readiness.py
+++ b/scripts/verify_release_readiness.py
@@ -174,6 +174,10 @@ def _check_scripts_executable(project_dir: Path) -> list[str]:
 def _check_precommit_hooks(project_dir: Path) -> list[str]:
     """Check that the pre-commit config declares at least the minimum hooks.
 
+    A missing config file is not reported here: ``_check_required_files``
+    already reports it, so this check returns cleanly instead of crashing
+    with ``FileNotFoundError`` (#402).
+
     Args:
         project_dir: Root of the generated project.
 
@@ -181,6 +185,8 @@ def _check_precommit_hooks(project_dir: Path) -> list[str]:
         A list of failure messages (empty when enough hooks are declared).
     """
     config = project_dir / ".pre-commit-config.yaml"
+    if not config.is_file():
+        return []
     text = config.read_text(encoding="utf-8")
     hook_count = sum(
         1 for line in text.splitlines() if line.strip().startswith("- id:")

--- a/tests/e2e/test_release_readiness_e2e.py
+++ b/tests/e2e/test_release_readiness_e2e.py
@@ -20,11 +20,17 @@ fully deterministic and offline (no API key required).
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import subprocess
 import tempfile
 
 from tests.conftest import get_env_without_api_keys
+
+# Hard ceiling for each `sgsg init` subprocess so a hang fails fast instead of
+# stalling CI (#402). Override via SGSG_E2E_INIT_TIMEOUT (seconds) for slow
+# environments.
+INIT_TIMEOUT_SECONDS = int(os.environ.get("SGSG_E2E_INIT_TIMEOUT", "120"))
 
 # Artifacts that --enable-live-dashboard must produce (relative to project root).
 EXPECTED_DASHBOARD_ARTIFACTS = (
@@ -64,6 +70,7 @@ def _run_init_with_dashboard(
         text=True,
         check=False,
         env=get_env_without_api_keys(),
+        timeout=INIT_TIMEOUT_SECONDS,
     )
 
 
@@ -159,6 +166,7 @@ class TestLiveDashboardE2E:
                 text=True,
                 check=False,
                 env=get_env_without_api_keys(),
+                timeout=INIT_TIMEOUT_SECONDS,
             )
             assert result.returncode == 0, f"sgsg init failed: {result.stdout}"
 

--- a/tests/unit/test_verify_release_readiness.py
+++ b/tests/unit/test_verify_release_readiness.py
@@ -8,16 +8,43 @@ by ``tests/e2e/test_release_readiness_e2e.py``.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
-import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
-import verify_release_readiness as vrr
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_release_readiness.py"
+)
+
+
+def _load_script_module() -> ModuleType:
+    """Load the verification script directly from its file path (#402).
+
+    ``scripts/`` is not a package, so the module is loaded via importlib
+    instead of mutating ``sys.path`` (which would leak the directory into
+    every other test's import resolution).
+
+    Returns:
+        The loaded ``verify_release_readiness`` module object.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "verify_release_readiness", _SCRIPT_PATH
+    )
+    if spec is None or spec.loader is None:
+        msg = f"cannot build import spec for {_SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vrr = _load_script_module()
 
 
 def _always_posix() -> bool:
@@ -39,7 +66,7 @@ def _make_valid_project(root: Path) -> Path:
     Returns:
         The project root path.
     """
-    project = root / vrr.PROJECT_NAME
+    project: Path = root / vrr.PROJECT_NAME
     project.mkdir()
 
     for relative in vrr.REQUIRED_FILES:
@@ -170,6 +197,16 @@ class TestPrecommitHooks:
         project = _make_valid_project(tmp_path)
         assert vrr._check_precommit_hooks(project) == []
 
+    def test_missing_config_yields_no_failures(self, tmp_path: Path) -> None:
+        """An absent config returns a clean empty list, not a crash (#402).
+
+        The missing file itself is already reported by _check_required_files,
+        so this check must not raise FileNotFoundError nor double-report.
+        """
+        project = tmp_path / "empty"
+        project.mkdir()
+        assert vrr._check_precommit_hooks(project) == []
+
     def test_reports_too_few_hooks(self, tmp_path: Path) -> None:
         """Too few declared hooks are reported with the actual count."""
         project = _make_valid_project(tmp_path)
@@ -285,3 +322,118 @@ class TestVerify:
         project = _make_valid_project(tmp_path)
         (project / "README.md").unlink()
         assert vrr._verify(project) == 1
+
+
+class TestMain:
+    """Tests for main() orchestration (#402).
+
+    ``_run_init`` and ``_verify`` are mocked so no real CLI is invoked;
+    ``tempfile.mkdtemp`` is pinned to a directory under ``tmp_path`` so the
+    keep-vs-cleanup behavior can be observed hermetically.
+    """
+
+    @staticmethod
+    def _pin_mkdtemp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """Pin tempfile.mkdtemp to a fresh directory under tmp_path.
+
+        Args:
+            monkeypatch: The pytest monkeypatch fixture.
+            tmp_path: The pytest per-test temporary directory.
+
+        Returns:
+            The directory that main() will receive from mkdtemp.
+        """
+        tmpdir = tmp_path / "sgsg-release-pinned"
+        tmpdir.mkdir()
+        monkeypatch.setattr(vrr.tempfile, "mkdtemp", lambda **_kwargs: str(tmpdir))
+        return tmpdir
+
+    @staticmethod
+    def _verify_must_not_run(project_dir: Path) -> int:
+        """Fail the test if main() reaches _verify on an error path."""
+        msg = f"_verify must not be called, got {project_dir}"
+        raise AssertionError(msg)
+
+    def test_keep_preserves_temp_dir(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--keep leaves the generated temp directory on disk."""
+        tmpdir = self._pin_mkdtemp(monkeypatch, tmp_path)
+        (tmpdir / vrr.PROJECT_NAME).mkdir()
+        monkeypatch.setattr(vrr, "_run_init", lambda _output_dir: [])
+        monkeypatch.setattr(vrr, "_verify", lambda _project_dir: 0)
+
+        assert vrr.main(["--keep"]) == 0
+        assert tmpdir.is_dir(), "--keep must preserve the temp directory"
+        out = capsys.readouterr().out
+        assert f"Kept generated project at {tmpdir}" in out
+        assert "All automatable release-readiness checks PASSED." in out
+
+    def test_temp_dir_removed_without_keep(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Without --keep the temp directory is removed after verification."""
+        tmpdir = self._pin_mkdtemp(monkeypatch, tmp_path)
+        (tmpdir / vrr.PROJECT_NAME).mkdir()
+        monkeypatch.setattr(vrr, "_run_init", lambda _output_dir: [])
+        monkeypatch.setattr(vrr, "_verify", lambda _project_dir: 0)
+
+        assert vrr.main([]) == 0
+        assert not tmpdir.exists(), "temp directory must be cleaned up"
+        assert "Kept generated project" not in capsys.readouterr().out
+
+    def test_reports_init_failures_and_cleans_up(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Init failures are printed, exit 1, _verify skipped, dir removed."""
+        tmpdir = self._pin_mkdtemp(monkeypatch, tmp_path)
+        monkeypatch.setattr(vrr, "_run_init", lambda _output_dir: ["init boom"])
+        monkeypatch.setattr(vrr, "_verify", self._verify_must_not_run)
+
+        assert vrr.main([]) == 1
+        assert not tmpdir.exists(), "finally block must clean up on init failure"
+        assert "FAIL  generate project: init boom" in capsys.readouterr().out
+
+    def test_reports_project_dir_not_created(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A successful init without a project dir exits 1 and cleans up."""
+        tmpdir = self._pin_mkdtemp(monkeypatch, tmp_path)
+        monkeypatch.setattr(vrr, "_run_init", lambda _output_dir: [])
+        monkeypatch.setattr(vrr, "_verify", self._verify_must_not_run)
+
+        assert vrr.main([]) == 1
+        assert not tmpdir.exists(), "finally block must clean up on error path"
+        out = capsys.readouterr().out
+        expected = f"FAIL  project directory not created: {tmpdir / vrr.PROJECT_NAME}"
+        assert expected in out
+
+    def test_failure_summary_when_verify_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A failing verification exits 1 with the FAILED summary line."""
+        tmpdir = self._pin_mkdtemp(monkeypatch, tmp_path)
+        (tmpdir / vrr.PROJECT_NAME).mkdir()
+        monkeypatch.setattr(vrr, "_run_init", lambda _output_dir: [])
+        monkeypatch.setattr(vrr, "_verify", lambda _project_dir: 1)
+
+        assert vrr.main([]) == 1
+        assert not tmpdir.exists(), "temp directory must be cleaned up"
+        out = capsys.readouterr().out
+        assert "Release-readiness verification FAILED." in out
+        assert "PASSED" not in out


### PR DESCRIPTION
## Summary

Addresses all four author's-discretion items deferred from PR #400's review:

1. **Latent crash guard**: `_check_precommit_hooks` in `scripts/verify_release_readiness.py` now returns a clean empty list when `.pre-commit-config.yaml` is absent (that failure is already reported by `_check_required_files`) instead of raising `FileNotFoundError`. Docstring documents the division of responsibility.
2. **`main()` unit coverage**: new `TestMain` (5 tests) exercising `--keep` (temp dir preserved) vs default (removed), the init-failure path, the "project directory not created" error path, and the `finally` cleanup — with `_run_init`/`_verify` mocked and `mkdtemp` pinned to a pytest tmp dir.
3. **E2E hang protection**: `sgsg init` subprocess calls in `tests/e2e/test_release_readiness_e2e.py` now carry `timeout=INIT_TIMEOUT_SECONDS` (default 120, overridable via `SGSG_E2E_INIT_TIMEOUT`).
4. **Robust script import**: the unit tests load the script via `importlib.util.spec_from_file_location` instead of `sys.path.insert`.

## Test plan

- 6 new tests (TDD: the missing-config test failed with `FileNotFoundError` before the guard): `test_missing_config_yields_no_failures` + the 5 `TestMain` cases. Full unit file: 27 passed.
- `./scripts/check-all.sh` ✅ 7/7; `pre-commit run --all-files` ✅ all 30 hooks.

Closes #402
Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)