### PR TITLE
fix(deps): bump black 26.5.1, mutmut 3.6.0, codecov-action v7

### DIFF
--- a/.claude/docs/troubleshooting.md
+++ b/.claude/docs/troubleshooting.md
@@ -413,7 +413,7 @@ different Black formatting output.
 versions. If `requirements-dev.txt` uses a version range (e.g.,
 `>=26.3.1,<27.0.0`), local venvs may have a different Black version than CI.
 
-**Fix**: Black is pinned to an exact version (`==26.3.1`) in
+**Fix**: Black is pinned to an exact version (`==26.5.1`) in
 `requirements-dev.txt`. After pulling changes that update the Black pin:
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           echo "Coverage: $COVERAGE%" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         continue-on-error: true  # Don't fail CI if codecov has issues
         with:
           files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.12.0",
     "hypothesis>=6.98.0",
-    "mutmut==3.5.0",  # Pinned: requires Python 3.11-3.13 (pony ORM incompatible with 3.14)
+    "mutmut==3.6.0",  # Pinned: requires Python 3.11-3.13 (pony ORM incompatible with 3.14)
     "defusedxml>=0.7.1",  # Safe XML parsing for generated-manifest tests (#356)
 
     # Pre-commit and git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ openai>=2.0.0,<3.0.0
 
 # Linting and formatting
 ruff>=0.2.0,<1.0.0
-black==26.3.1
+black==26.5.1
 isort>=5.13.0,<9.0.0
 mypy>=1.8.0,<3.0.0
 pylint>=3.0.0,<5.0.0

--- a/tests/unit/test_dev_dependency_pinning.py
+++ b/tests/unit/test_dev_dependency_pinning.py
@@ -60,11 +60,11 @@ class TestFormattingToolPinning:
             f"See Issue #280."
         )
 
-    def test_black_pinned_to_26_3_1(self, requirements_dev_content: str) -> None:
-        """Test that Black is pinned to 26.3.1 (current CI version)."""
+    def test_black_pinned_to_26_5_1(self, requirements_dev_content: str) -> None:
+        """Test that Black is pinned to 26.5.1 (current CI version)."""
         version_spec = _parse_requirement_version(requirements_dev_content, "black")
-        assert version_spec == "==26.3.1", (
-            f"Black must be pinned to ==26.3.1 to match CI. "
+        assert version_spec == "==26.5.1", (
+            f"Black must be pinned to ==26.5.1 to match CI. "
             f"Found: black{version_spec}. "
             f"See Issue #280."
         )


### PR DESCRIPTION
## Summary

Consolidates the three open Dependabot dependency PRs into a single change so
the black bump can carry its required guard-test/doc updates (which Dependabot
could not make on its own branch):

| Dependency | Change | Supersedes |
|-----------|--------|-----------|
| `black` | `==26.3.1` → `==26.5.1` (`requirements-dev.txt`) | #333 |
| `mutmut` | `==3.5.0` → `==3.6.0` (`pyproject.toml` dev extras) | #418 |
| `codecov/codecov-action` | `@v6` → `@v7` (`.github/workflows/ci.yml`) | #417 |

### Why consolidated

Dependabot's standalone black PR (#333) failed CI on the
`test_dev_dependency_pinning` guard, which asserts black is pinned to an exact
version to prevent CI/local formatting drift (Issue #280). Bumping black
therefore requires updating that guard (now tracks `==26.5.1`) and the matching
reference in `.claude/docs/troubleshooting.md` — changes Dependabot cannot add.
The mutmut and codecov bumps are folded in to land all dependency updates as one
reviewed unit.

## Test plan

- `black --check .` with black 26.5.1 → **all 180 files unchanged** (no
  reformatting; the exact-pin policy of Issue #280 is preserved, only the
  version advances).
- `pytest tests/unit/test_dev_dependency_pinning.py` → **7 passed**.
- `pip install black==26.5.1 mutmut==3.6.0` resolves cleanly (versions exist on
  PyPI).
- codecov-action is `continue-on-error: true`, so the v7 bump cannot regress CI.

Closes #333
Closes #417
Closes #418

https://claude.ai/code/session_01SCeJYxcCxJhki82WmhpoDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCeJYxcCxJhki82WmhpoDG)_