### PR TITLE
fix(ci): harden claude-code-review against silent no-verdict passes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -17,6 +17,13 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #
+    # Skip Dependabot PRs: GitHub does not expose Actions secrets (incl.
+    # CLAUDE_CODE_OAUTH_TOKEN) to dependabot-triggered runs, so the action would
+    # hard-fail before reviewing and block the PR's required check. Dependency
+    # bumps merge on green CI + human judgment instead (see the Ralph
+    # dependencies-PR handling in .claude/commands/ralph-tick.md).
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -27,54 +34,116 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e  # v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"
+          show_full_output: true
           prompt:  |
-            Please review this pull request and provide feedback using the following template:
+            Review this pull request against the repository's CLAUDE.md. Read the
+            change with `gh pr diff` and `gh pr view` (and any files you need).
 
-            ## Summary
-            Brief overview (2-3 sentences)
+            Do NOT post a comment yourself. Return ONLY the structured result with
+            three fields:
 
-            ## Strengths
-            What's done well?
+            - "review_markdown": the full review as GitHub markdown, using this
+              template (omit the verdict here — it is a separate field below):
 
-            ## Security Concerns
-            Vulnerabilities? 🔴 BLOCKING | 🟡 HIGH | 🟢 LOW
+              ## Summary
+              Brief overview (2-3 sentences)
+              ## Strengths
+              What's done well?
+              ## Security Concerns
+              Vulnerabilities? 🔴 BLOCKING | 🟡 HIGH | 🟢 LOW
+              ## Problems
+              Critical issues blocking merge (mark 🔴)
+              ## Code Quality
+              Non-blocking improvements (these are COMMENTS, not blockers)
+              ## CLAUDE.md Adherence
+              ✅/❌ Coverage, linting, types, patterns, commits
+              ## Testing
+              Test quality (insufficient testing is BLOCKING)
+              ## Documentation
+              Docs completeness
 
-            ## Problems
-            Critical issues blocking merge (mark 🔴)
-            Consider priority greater than Minor as "Blocking"
+            - "verdict": exactly one of CHANGES_REQUESTED, COMMENTS, LGTM. Take a
+              clear stance — do NOT default to COMMENTS as a safe middle ground.
+              Reason about it like this:
 
-            ## Code Quality
-            Non-blocking improvements for educational purposes or for future GitHub Issues
+                1. Is there ANY blocking problem? A real bug, a 🔴 security issue,
+                   insufficient/missing tests, or a CLAUDE.md violation that must
+                   be fixed before merge → CHANGES_REQUESTED.
+                2. Otherwise, would you merge this as-is right now? If the only
+                   remarks are nits you would not block on (or there is nothing to
+                   note), say so → LGTM. Minor style nits do NOT downgrade an
+                   otherwise-mergeable PR.
+                3. Reserve COMMENTS for the genuine middle: nothing blocks merge,
+                   but there ARE substantive non-blocking suggestions the author
+                   should weigh first. If you reach for COMMENTS, name the specific
+                   suggestion that keeps it out of LGTM — if you can't, it's LGTM.
 
-            ## CLAUDE.md Adherence
-            ✅/❌ Coverage, linting, types, patterns, commits
+            - "verdict_rationale": one or two sentences justifying the verdict,
+              required for ALL THREE outcomes. For CHANGES_REQUESTED, name the
+              blocking issue(s). For COMMENTS, name the substantive suggestion(s)
+              that kept it from LGTM. For LGTM, state why it is ready to merge.
 
-            ## Testing
-            Test quality evaluation
-            Insufficient testing is Blocking (mark 🔴)
+          # The --json-schema flag makes the action return a validated
+          # ``structured_output`` JSON string (verdict + rationale +
+          # review_markdown) instead of relying on the agent to remember to post a
+          # comment — the "Post review" step below then posts it deterministically
+          # (fixes flaky success-with-no-comment runs, where the action's own job
+          # reports success even though the inner Claude session errored before
+          # ever calling `gh pr comment`). gh pr comment is intentionally NOT in
+          # allowed-tools so the agent cannot post on its own.
+          claude_args: >-
+            --model sonnet
+            --json-schema '{"type":"object","additionalProperties":false,"required":["verdict","verdict_rationale","review_markdown"],"properties":{"verdict":{"type":"string","enum":["CHANGES_REQUESTED","COMMENTS","LGTM"]},"verdict_rationale":{"type":"string"},"review_markdown":{"type":"string"}}}'
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
 
-            ## Documentation
-            Docs completeness
-
-
-            ## Verdict
-            ✅ LGTM | 🔄 CHANGES_REQUESTED | 💬 COMMENTS
-            **Reasoning:** Specific references
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+      - name: Post review
+        # Deterministic: this step always runs after a successful review and posts
+        # the comment. If the action produced no structured output (a genuinely
+        # failed/empty review), fail so the check is red and the review is
+        # re-run — never a silent success with no review.
+        env:
+          # Prefer a real PAT with pull-requests:write (GEOFFE_GA_PAT — the same
+          # one iteration-trigger.yml uses) so the verdict comment is authored by
+          # an account any downstream webhook can recognize; fall back to
+          # GITHUB_TOKEN (github-actions[bot]) if the PAT secret is absent. NOT
+          # the action's Claude App github_token output — that 401s with gh.
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          STRUCTURED: ${{ steps.claude-review.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STRUCTURED:-}" ]; then
+            # claude-code-action self-skips (anti-tamper) on any PR that edits this
+            # workflow file, so there is no review to post — that is expected and
+            # must not fail the check (the workflow change is reviewed manually).
+            if gh pr diff "$PR_NUMBER" -R "$REPO" --name-only \
+                 | grep -qx '.github/workflows/claude-code-review.yml'; then
+              echo "::warning::This PR edits the review workflow, so the action self-skips — no automated verdict; review manually."
+              exit 0
+            fi
+            echo "::error::Claude review produced no structured output — failing so it is re-run, never a silent no-review."
+            exit 1
+          fi
+          verdict=$(jq -r '.verdict' <<<"$STRUCTURED")
+          rationale=$(jq -r '.verdict_rationale // ""' <<<"$STRUCTURED")
+          jq -r '.review_markdown' <<<"$STRUCTURED" > review.md
+          # Keep the "## Verdict: <verdict>" line exactly — downstream skills
+          # (address-feedback, await-claude-review) parse it. The rationale goes
+          # on the following line so the verdict is never ambiguous.
+          printf '\n\n## Verdict: %s\n' "$verdict" >> review.md
+          if [ -n "$rationale" ]; then
+            printf '\n%s\n' "$rationale" >> review.md
+          fi
+          gh pr comment "$PR_NUMBER" -R "$REPO" --body-file review.md
+          echo "Posted review with verdict: ${verdict}"


### PR DESCRIPTION
## Summary

Ports well-worn-tools' hardened `claude-code-review.yml`, which fixes exactly the failure PR #455 hit: the `claude-review` job reported "success" at the GitHub Actions level even though the inner Claude Code session errored after one turn (`is_error: true`, `total_cost_usd: 0`) and never posted a review comment — leaving the PR green with no verdict, indefinitely (I had to manually notice this and merge on green-CI-without-verdict as a fallback).

**Root cause:** the old prompt told the agent to `gh pr comment` its own review at the end of a long session. If the session errors before reaching that step, nothing gets posted — but the action step itself still exits 0.

**Fix:**
- The model returns a validated `--json-schema` structured result (`verdict` + `verdict_rationale` + `review_markdown`) instead of freeform text, and a separate deterministic "Post review" step posts it. `gh pr comment` is removed from the model's `allowed-tools` so it can't post directly — only the deterministic step can.
- If the structured output is empty, the step **fails loudly** (`exit 1`) so the check goes red and the review re-runs — except when the PR itself edits this workflow file, where the action's own anti-tamper self-skip is expected, and the step exits 0 with a warning instead of a false failure.
- Also: skip Dependabot PRs entirely (they don't get repo secrets under `pull_request`, so the action would hard-fail before reviewing), listen for `ready_for_review`/`reopened` in addition to `opened`/`synchronize`, and SHA-pin `actions/checkout` + `claude-code-action` to match the rest of the newly-adopted Ralph workflows (#455).
- Uses this repo's existing `GEOFFE_GA_PAT` secret (not well-worn-tools' generic `RALPH_BOT_PAT` placeholder), matching `iteration-trigger.yml`'s convention.

## Note on this PR's own review

This PR edits `claude-code-review.yml` itself, so its own `claude-review` check will **self-skip** per the anti-tamper behavior described above — no automated verdict is possible for this specific PR by design. Merge on green CI + manual review.

## Test plan
- [x] YAML validity confirmed.
- [x] `pre-commit run --all-files` green.
- [ ] CI green (all jobs).
- [ ] Manual review (automated verdict not possible for this PR, see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)