### PR TITLE
fix(generators): repair pre-commit/dependencies/metrics bootstrap bugs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,9 +205,9 @@
         "filename": "tests/unit/test_cli_mocked.py",
         "hashed_secret": "380653fc1e1344144c6374d9cc14754bf51a5eed",
         "is_verified": false,
-        "line_number": 1883
+        "line_number": 1973
       }
     ]
   },
-  "generated_at": "2026-07-05T00:36:35Z"
+  "generated_at": "2026-07-07T17:46:37Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,11 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "pytest-mock>=3.12.0",
     "hypothesis>=6.98.0",
-    "mutmut==3.6.0",  # Pinned: requires Python 3.11-3.13 (pony ORM incompatible with 3.14)
+    "mutmut==2.5.1",  # Pinned: 3.x crashes on our 2.x-schema [tool.mutmut] config
+    # and its results/show CLI crashes on py3.13's pony ORM
+    # ('QueryResultIterator' object is not iterable); `mutmut run` itself
+    # still works on 3.x, but the reporting side doesn't. See the
+    # reference-mutmut-tooling memory doc for the actual workflow.
     "defusedxml>=0.7.1",  # Safe XML parsing for generated-manifest tests (#356)
 
     # Pre-commit and git

--- a/reference/precommit/.pre-commit-config.yaml
+++ b/reference/precommit/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-all]
         args: [--strict]
 
   # Bandit - Security linting

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,10 @@ defusedxml>=0.7.1,<1.0.0
 hypothesis>=6.98.0,<7.0.0
 
 # Mutation testing
-mutmut>=2.4.0,<4.0.0
+# Pinned exact: 3.x crashes on our 2.x-schema [tool.mutmut] config, and its
+# results/show CLI crashes on py3.13's pony ORM. See pyproject.toml's
+# mutmut entry / the reference-mutmut-tooling memory doc.
+mutmut==2.5.1
 
 # Pre-commit and git hooks
 pre-commit>=3.6.0,<5.0.0

--- a/scripts/collect_metrics.py
+++ b/scripts/collect_metrics.py
@@ -33,10 +33,7 @@ import sys
 from typing import Any
 from typing import TYPE_CHECKING
 
-from start_green_stay_green.generators.metrics import ci_status
-from start_green_stay_green.generators.metrics import count_ci_jobs
-from start_green_stay_green.generators.metrics import count_precommit_hooks
-from start_green_stay_green.generators.metrics import precommit_status
+import yaml
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -48,6 +45,110 @@ GITHUB_API_TIMEOUT_SECONDS = 10
 
 # ``owner/repo`` slug as provided by the GITHUB_REPOSITORY env var.
 GITHUB_REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+# --- Vendored from start_green_stay_green.generators.metrics ---------------
+# This script is copied verbatim into every `--enable-live-dashboard`
+# project (see cli.py's `_copy_metrics_assets`), which does NOT have the
+# `start_green_stay_green` package installed. These four functions (plus
+# their private helpers) are duplicated here rather than imported so the
+# copied script is fully self-contained. Keep behaviorally identical to
+# `start_green_stay_green/generators/metrics.py` — a parity test
+# (tests/unit/test_collect_metrics.py) compares both copies' outputs.
+
+
+def _load_precommit_repos(config_path: Path) -> list[object]:
+    """Load the ``repos`` list from a pre-commit config, degrading to ``[]``."""
+    if not config_path.is_file():
+        return []
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+    repos = data.get("repos") if isinstance(data, dict) else None
+    return repos if isinstance(repos, list) else []
+
+
+def _repo_hook_count(repo: object) -> int:
+    """Return the number of hooks declared by a single pre-commit repo entry."""
+    if not isinstance(repo, dict):
+        return 0
+    hooks = repo.get("hooks")
+    return len(hooks) if isinstance(hooks, list) else 0
+
+
+def count_precommit_hooks(config_path: Path) -> int:
+    """Count the total number of hooks in a pre-commit config file."""
+    repos = _load_precommit_repos(config_path)
+    return sum(_repo_hook_count(repo) for repo in repos)
+
+
+def precommit_status(
+    total_hooks: int, passing_hooks: int | None = None
+) -> dict[str, object]:
+    """Build the canonical Pre-Commit Status dict for the metrics dashboard."""
+    if passing_hooks is None:
+        passing_hooks = total_hooks
+    has_hooks = total_hooks > 0
+    percentage = (passing_hooks / total_hooks * 100) if has_hooks else 0.0
+    return {
+        "total_hooks": total_hooks,
+        "passing_hooks": passing_hooks,
+        "percentage": percentage,
+        "status": "passing" if has_hooks else "unknown",
+    }
+
+
+def _workflow_job_count(workflow_path: Path) -> int:
+    """Return the number of jobs declared in a single workflow file."""
+    try:
+        data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return 0
+    jobs = data.get("jobs") if isinstance(data, dict) else None
+    return len(jobs) if isinstance(jobs, dict) else 0
+
+
+def count_ci_jobs(workflows_dir: Path) -> int:
+    """Count GitHub Actions jobs across all workflow files in a directory."""
+    if not workflows_dir.is_dir():
+        return 0
+    workflow_files = sorted(
+        [*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")]
+    )
+    return sum(_workflow_job_count(path) for path in workflow_files)
+
+
+def _ci_status_label(total_jobs: int, passing_jobs: int | None) -> str:
+    """Derive the CI status label from job counts."""
+    if passing_jobs is None or total_jobs <= 0:
+        return "unknown"
+    return "passing" if passing_jobs >= total_jobs else "failing"
+
+
+def ci_status(
+    total_jobs: int,
+    passing_jobs: int | None = None,
+    *,
+    run_url: str | None = None,
+) -> dict[str, object]:
+    """Build the canonical CI Status dict for the metrics dashboard."""
+    status = _ci_status_label(total_jobs, passing_jobs)
+    resolved_passing = passing_jobs if passing_jobs is not None else 0
+    percentage = (resolved_passing / total_jobs * 100) if total_jobs > 0 else 0.0
+
+    result: dict[str, object] = {
+        "total_jobs": total_jobs,
+        "passing_jobs": resolved_passing,
+        "percentage": percentage,
+        "status": status,
+    }
+    if run_url is not None:
+        result["run_url"] = run_url
+    return result
+
+
+# --- End vendored section ---------------------------------------------------
 
 
 def _github_api_json(path: str, token: str) -> object | None:

--- a/start_green_stay_green/cli.py
+++ b/start_green_stay_green/cli.py
@@ -90,6 +90,7 @@ from start_green_stay_green.generators.precommit import (
 )
 from start_green_stay_green.generators.precommit import GenerationConfig
 from start_green_stay_green.generators.precommit import PreCommitGenerator
+from start_green_stay_green.generators.precommit import generate_secrets_baseline
 from start_green_stay_green.generators.ralph_loop import copy_ralph_loop
 from start_green_stay_green.generators.readme import ReadmeConfig
 from start_green_stay_green.generators.readme import ReadmeGenerator
@@ -1216,7 +1217,37 @@ def _generate_precommit_step(
         generated_content = precommit_result["content"]
 
         _write_precommit_config(precommit_file, generated_content, file_writer)
+        _write_secrets_baseline(project_path / ".secrets.baseline", file_writer)
     console.print("[green]✓[/green] Generated pre-commit config")
+
+
+def _write_secrets_baseline(
+    baseline_file: Path,
+    file_writer: FileWriter | None,
+) -> None:
+    """Write an initial ``.secrets.baseline`` if one doesn't already exist.
+
+    The detect-secrets pre-commit hook (wired in by every LANGUAGE_CONFIGS
+    entry) requires ``--baseline .secrets.baseline`` to already exist —
+    without this, the very first ``pre-commit run`` in a generated project
+    fails outright on a missing file.
+
+    Args:
+        baseline_file: Path to ``.secrets.baseline``.
+        file_writer: Optional FileWriter for additive/force conflict
+            resolution; when ``None``, writes directly unless the file
+            already exists.
+    """
+    if file_writer is None:
+        if not baseline_file.exists():
+            content = generate_secrets_baseline(datetime.now(UTC).isoformat())
+            baseline_file.write_text(content, encoding="utf-8")
+        return
+
+    if baseline_file.exists() and not file_writer.is_force:
+        return
+    content = generate_secrets_baseline(datetime.now(UTC).isoformat())
+    file_writer.write_file(baseline_file, content)
 
 
 def _write_precommit_config(
@@ -1678,6 +1709,31 @@ def _write_initial_metrics_json(
     )
 
 
+def _drop_regenerate_dashboard_step(workflow_content: str) -> str:
+    """Strip the "Regenerate dashboard.html" step from a copied metrics.yml.
+
+    SGSG's own ``metrics.yml`` (the source this is copied from) calls
+    ``scripts/regenerate_dashboard.py``, which depends on
+    ``start_green_stay_green.generators.metrics.MetricsGenerator`` -- not
+    installed in a generated project, so that step would crash every run.
+    That script is intentionally never copied downstream (unlike
+    ``collect_metrics.py``, its templating logic isn't reasonably portable).
+    ``dashboard.html`` is already rendered once at ``green init`` time;
+    downstream CI only needs to refresh ``metrics.json`` and republish the
+    existing ``dashboard.html`` to Pages.
+
+    Args:
+        workflow_content: The copied ``metrics.yml`` content.
+
+    Returns:
+        The content with the regenerate-dashboard step removed, if present.
+    """
+    step_pattern = re.compile(
+        r"\n *- name: Regenerate dashboard\.html from template\n" r"(?: +.*\n)*",
+    )
+    return step_pattern.sub("", workflow_content)
+
+
 def _copy_metrics_assets(project_path: Path, project_name: str) -> tuple[bool, bool]:
     """Copy the metrics workflow and collection script into the project.
 
@@ -1702,6 +1758,7 @@ def _copy_metrics_assets(project_path: Path, project_name: str) -> tuple[bool, b
         workflow_content = workflow_content.replace(
             "start-green-stay-green", project_name
         )
+        workflow_content = _drop_regenerate_dashboard_step(workflow_content)
         target_workflow.write_text(workflow_content, encoding="utf-8")
 
     scripts_dir = project_path / "scripts"

--- a/start_green_stay_green/generators/dependencies.py
+++ b/start_green_stay_green/generators/dependencies.py
@@ -269,10 +269,17 @@ radon>=6.0.0
 xenon>=0.9.0
 
 # Mutation testing
-mutmut>=2.4.0
+# Upper-bounded: 3.x renamed [tool.mutmut]'s config keys (paths_to_mutate/
+# tests_dir -> different schema), so an unbounded pin resolves to 3.x and
+# crashes against the 2.x-schema config generated below.
+mutmut>=2.4.0,<3.0.0
 
 # Pre-commit hooks
 pre-commit>=3.4.0
+
+# YAML parsing (used by scripts/collect_metrics.py when
+# --enable-live-dashboard is passed)
+PyYAML>=6.0.0
 
 # Type stubs
 types-PyYAML>=6.0.0
@@ -317,8 +324,9 @@ dev = [
     "bandit>=1.7.5",
     "pip-audit>=2.7.0",
     "radon>=6.0.0",
-    "mutmut>=2.4.0",
+    "mutmut>=2.4.0,<3.0.0",
     "pre-commit>=3.4.0",
+    "PyYAML>=6.0.0",
 ]
 
 [build-system]

--- a/start_green_stay_green/generators/precommit.py
+++ b/start_green_stay_green/generators/precommit.py
@@ -6,7 +6,9 @@ with language-appropriate hooks for formatting, linting, security, and quality.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
+import json
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import cast
@@ -89,7 +91,6 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
                 "hooks": [
                     {
                         "id": "mypy",
-                        "additional_dependencies": ["types-all"],
                         "args": ["--strict"],
                     },
                 ],
@@ -172,7 +173,7 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
                 "hooks": [
                     {
                         "id": "vulture",
-                        "args": ["start_green_stay_green/", "--min-confidence", "80"],
+                        "args": ["{package_name}/", "--min-confidence", "80"],
                     },
                 ],
             },
@@ -923,6 +924,47 @@ LANGUAGE_CONFIGS: dict[str, dict[str, Any]] = {
 }
 
 
+def _substitute_package_name(
+    repos: list[dict[str, Any]], package_name: str
+) -> list[dict[str, Any]]:
+    """Deep-copy ``repos`` substituting the ``{package_name}`` template token.
+
+    ``LANGUAGE_CONFIGS`` is a shared module-level template — hook arg lists
+    containing the literal token ``{package_name}`` (e.g. Python's vulture
+    scan target) get the target project's actual package name substituted
+    into a fresh copy, leaving the module-level template untouched for the
+    next call.
+
+    Args:
+        repos: The language's ``hooks`` (pre-commit ``repos`` entries).
+        package_name: Target project's package/module name.
+
+    Returns:
+        A deep copy of ``repos`` with every ``{package_name}`` token resolved.
+    """
+    repos_copy = copy.deepcopy(repos)
+    for repo in repos_copy:
+        for hook in repo.get("hooks", []):
+            _substitute_hook_args(hook, package_name)
+    return repos_copy
+
+
+def _substitute_hook_args(hook: dict[str, Any], package_name: str) -> None:
+    """Resolve the ``{package_name}`` token in a single hook's ``args``, in place.
+
+    Args:
+        hook: A single pre-commit hook entry (mutated in place).
+        package_name: Target project's package/module name.
+    """
+    args = hook.get("args")
+    if not args:
+        return
+    hook["args"] = [
+        arg.replace("{package_name}", package_name) if isinstance(arg, str) else arg
+        for arg in args
+    ]
+
+
 class PreCommitGenerator(BaseGenerator):
     """Generates .pre-commit-config.yaml for target projects.
 
@@ -982,19 +1024,23 @@ class PreCommitGenerator(BaseGenerator):
             )
             raise ValueError(msg)
 
-    def _build_config_dict(self, language: str) -> dict[str, Any]:
+    def _build_config_dict(self, language: str, package_name: str) -> dict[str, Any]:
         """Build pre-commit configuration dictionary.
 
         Args:
             language: Language identifier.
+            package_name: Target project's package/module name, substituted
+                into any hook arg containing the ``{package_name}`` template
+                token (e.g. Python's vulture scan target).
 
         Returns:
             Configuration dictionary with repos, CI settings, and language versions.
         """
         language_config = LANGUAGE_CONFIGS[language]
+        repos = _substitute_package_name(language_config["hooks"], package_name)
         return {
             "default_language_version": language_config["default_language_version"],
-            "repos": language_config["hooks"],
+            "repos": repos,
             "ci": {
                 "autofix_commit_msg": "style: auto-fix by pre-commit hooks",
                 "autoupdate_commit_msg": "chore: update pre-commit hooks",
@@ -1060,7 +1106,8 @@ class PreCommitGenerator(BaseGenerator):
                 raise TypeError(msg)
 
         self._validate_language_supported(config.language)
-        config_dict = self._build_config_dict(config.language)
+        package_name = config.project_name.replace("-", "_")
+        config_dict = self._build_config_dict(config.language, package_name)
 
         # Convert to YAML
         yaml_content = yaml.dump(
@@ -1187,3 +1234,79 @@ class PreCommitGenerator(BaseGenerator):
 
         hooks_config = LANGUAGE_CONFIGS[language]["hooks"]
         return self._sum_hooks_in_repos(hooks_config)
+
+
+# The exact plugin/filter set ``detect-secrets scan`` (v1.4.0, matching the
+# ``rev:`` every LANGUAGE_CONFIGS entry pins) produces on a fresh repo with
+# no findings. Every generated project's detect-secrets hook is pointed at
+# ``--baseline .secrets.baseline`` (see LANGUAGE_CONFIGS above), but nothing
+# ever wrote that file, so a project's first ``pre-commit run`` failed
+# outright on a missing baseline. ``results`` is intentionally empty: the
+# hook scans fresh and self-updates this file in place as it encounters
+# (and the user allowlists) real findings.
+_DETECT_SECRETS_BASELINE: dict[str, Any] = {
+    "version": "1.4.0",
+    "plugins_used": [
+        {"name": "ArtifactoryDetector"},
+        {"name": "AWSKeyDetector"},
+        {"name": "AzureStorageKeyDetector"},
+        {"name": "Base64HighEntropyString", "limit": 4.5},
+        {"name": "BasicAuthDetector"},
+        {"name": "CloudantDetector"},
+        {"name": "DiscordBotTokenDetector"},
+        {"name": "GitHubTokenDetector"},
+        {"name": "HexHighEntropyString", "limit": 3.0},
+        {"name": "IbmCloudIamDetector"},
+        {"name": "IbmCosHmacDetector"},
+        {"name": "JwtTokenDetector"},
+        {"name": "KeywordDetector", "keyword_exclude": ""},
+        {"name": "MailchimpDetector"},
+        {"name": "NpmDetector"},
+        {"name": "PrivateKeyDetector"},
+        {"name": "SendGridDetector"},
+        {"name": "SlackDetector"},
+        {"name": "SoftlayerDetector"},
+        {"name": "SquareOAuthDetector"},
+        {"name": "StripeDetector"},
+        {"name": "TwilioKeyDetector"},
+    ],
+    "filters_used": [
+        {"path": "detect_secrets.filters.allowlist.is_line_allowlisted"},
+        {
+            "path": "detect_secrets.filters.common.is_baseline_file",
+            "filename": ".secrets.baseline",
+        },
+        {
+            "path": (
+                "detect_secrets.filters.common."
+                "is_ignored_due_to_verification_policies"
+            ),
+            "min_level": 2,
+        },
+        {"path": "detect_secrets.filters.heuristic.is_indirect_reference"},
+        {"path": "detect_secrets.filters.heuristic.is_likely_id_string"},
+        {"path": "detect_secrets.filters.heuristic.is_lock_file"},
+        {"path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"},
+        {"path": "detect_secrets.filters.heuristic.is_potential_uuid"},
+        {"path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"},
+        {"path": "detect_secrets.filters.heuristic.is_sequential_string"},
+        {"path": "detect_secrets.filters.heuristic.is_swagger_file"},
+        {"path": "detect_secrets.filters.heuristic.is_templated_secret"},
+    ],
+    "results": {},
+}
+
+
+def generate_secrets_baseline(generated_at: str) -> str:
+    """Render an initial, empty ``.secrets.baseline`` for a fresh project.
+
+    Args:
+        generated_at: ISO-8601 timestamp to embed as ``generated_at``
+            (caller-supplied so this function stays a pure renderer).
+
+    Returns:
+        JSON content for ``.secrets.baseline``, matching the shape
+        ``detect-secrets scan`` itself would produce on an empty repo.
+    """
+    baseline = _DETECT_SECRETS_BASELINE | {"generated_at": generated_at}
+    return json.dumps(baseline, indent=2) + "\n"

--- a/tests/integration/test_init_flow.py
+++ b/tests/integration/test_init_flow.py
@@ -294,6 +294,38 @@ class TestInitFlowIntegration:
         assert "repos:" in content
         assert "hooks:" in content
 
+    def test_init_generates_secrets_baseline(self, tmp_path: Path) -> None:
+        """detect-secrets' --baseline .secrets.baseline must exist on first run.
+
+        Without this, the very first `pre-commit run` in a generated
+        project fails outright on a missing baseline file.
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--project-name",
+                "test-secrets-baseline",
+                "--language",
+                "python",
+                "--output-dir",
+                str(tmp_path),
+                "--no-interactive",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        project_path = tmp_path / "test-secrets-baseline"
+        baseline_file = project_path / ".secrets.baseline"
+
+        assert baseline_file.exists()
+        baseline = json.loads(baseline_file.read_text())
+        assert baseline["results"] == {}
+        assert baseline["plugins_used"]
+        assert baseline["version"]
+
     @patch("start_green_stay_green.cli._generate_review_step", _stub_review_step)
     @patch("start_green_stay_green.cli._generate_ci_step", _stub_ci_step)
     def test_init_generates_github_workflows(self, tmp_path: Path) -> None:

--- a/tests/unit/generators/test_precommit.py
+++ b/tests/unit/generators/test_precommit.py
@@ -234,6 +234,59 @@ class TestGenerateWithPython:
         repo_urls = [repo.get("repo", "") for repo in repos]
         assert any("black" in url for url in repo_urls)
 
+    def test_generate_python_vulture_targets_real_package(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Vulture's target substitutes the project's own package name."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        config = GenerationConfig(
+            project_name="my-cool-app",
+            language="python",
+            language_config={},
+        )
+        result = generator.generate(config)
+        repos = result["repos"]
+        vulture_repo = next(r for r in repos if "vulture" in r.get("repo", ""))
+        assert vulture_repo["hooks"][0]["args"][0] == "my_cool_app/"
+
+    def test_generate_python_twice_does_not_leak_package_name(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Substitution must not mutate the shared LANGUAGE_CONFIGS template."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        generator.generate(
+            GenerationConfig(
+                project_name="first-app", language="python", language_config={}
+            )
+        )
+        second = generator.generate(
+            GenerationConfig(
+                project_name="second-app", language="python", language_config={}
+            )
+        )
+        vulture_repo = next(
+            r for r in second["repos"] if "vulture" in r.get("repo", "")
+        )
+        assert vulture_repo["hooks"][0]["args"][0] == "second_app/"
+        assert LANGUAGE_CONFIGS["python"]["hooks"][13]["hooks"][0]["args"][0] == (
+            "{package_name}/"
+        )
+
+    def test_generate_python_mypy_has_no_additional_dependencies(
+        self, mock_orchestrator: Mock
+    ) -> None:
+        """Generated mypy hook must not reference the broken types-all package."""
+        generator = PreCommitGenerator(mock_orchestrator)
+        config = GenerationConfig(
+            project_name="test-project",
+            language="python",
+            language_config={},
+        )
+        result = generator.generate(config)
+        repos = result["repos"]
+        mypy_repo = next(r for r in repos if "mirrors-mypy" in r.get("repo", ""))
+        assert "additional_dependencies" not in mypy_repo["hooks"][0]
+
     def test_generate_python_has_default_language_version(
         self, mock_orchestrator: Mock
     ) -> None:
@@ -2242,10 +2295,10 @@ class TestMutationKillers:
         hooks = LANGUAGE_CONFIGS["python"]["hooks"][4]["hooks"]
         assert hooks[0]["id"] == "mypy"
 
-    def test_python_mypy_additional_dependencies_exact(self) -> None:
-        """Test mypy additional_dependencies are exact."""
+    def test_python_mypy_has_no_additional_dependencies(self) -> None:
+        """mypy must not pin the unresolvable ``types-all`` meta-package."""
         hooks = LANGUAGE_CONFIGS["python"]["hooks"][4]["hooks"]
-        assert hooks[0]["additional_dependencies"] == ["types-all"]
+        assert "additional_dependencies" not in hooks[0]
 
     def test_python_mypy_args_exact(self) -> None:
         """Test mypy args are exact."""
@@ -2330,9 +2383,9 @@ class TestMutationKillers:
         assert hooks[0]["id"] == "vulture"
 
     def test_python_vulture_args_exact(self) -> None:
-        """Test vulture args are exact."""
+        """Vulture's target is a template token, substituted at generate() time."""
         hooks = LANGUAGE_CONFIGS["python"]["hooks"][13]["hooks"]
-        assert hooks[0]["args"] == ["start_green_stay_green/", "--min-confidence", "80"]
+        assert hooks[0]["args"] == ["{package_name}/", "--min-confidence", "80"]
 
     def test_python_detect_secrets_hook_id_exact(self) -> None:
         """Test detect-secrets hook ID is exact."""
@@ -2572,21 +2625,21 @@ class TestMutationKillers:
     def test_ci_autofix_commit_msg_exact(self, mock_orchestrator: Mock) -> None:
         """Test CI autofix_commit_msg is exact."""
         generator = PreCommitGenerator(mock_orchestrator)
-        config_dict = generator._build_config_dict("python")
+        config_dict = generator._build_config_dict("python", "test_project")
         expected = "style: auto-fix by pre-commit hooks"
         assert config_dict["ci"]["autofix_commit_msg"] == expected
 
     def test_ci_autoupdate_commit_msg_exact(self, mock_orchestrator: Mock) -> None:
         """Test CI autoupdate_commit_msg is exact."""
         generator = PreCommitGenerator(mock_orchestrator)
-        config_dict = generator._build_config_dict("python")
+        config_dict = generator._build_config_dict("python", "test_project")
         expected = "chore: update pre-commit hooks"
         assert config_dict["ci"]["autoupdate_commit_msg"] == expected
 
     def test_ci_skip_is_empty_list(self, mock_orchestrator: Mock) -> None:
         """Test CI skip is empty list."""
         generator = PreCommitGenerator(mock_orchestrator)
-        config_dict = generator._build_config_dict("python")
+        config_dict = generator._build_config_dict("python", "test_project")
         assert config_dict["ci"]["skip"] == []
 
     # Header Generation Exact Tests

--- a/tests/unit/test_cli_mocked.py
+++ b/tests/unit/test_cli_mocked.py
@@ -26,6 +26,7 @@ def test_something(mock_path: Mock) -> None:
 ```
 """
 
+import ast
 import asyncio
 import json
 from pathlib import Path
@@ -39,6 +40,7 @@ from unittest.mock import patch
 import pytest
 import typer
 from typer.testing import CliRunner
+import yaml
 
 from start_green_stay_green import cli
 from start_green_stay_green.ai.batch_dispatch import ResumeOutcome
@@ -55,6 +57,7 @@ from start_green_stay_green.utils.enhance_state import BatchProgress
 from start_green_stay_green.utils.enhance_state import EnhanceState
 from start_green_stay_green.utils.enhance_state import load_state
 from start_green_stay_green.utils.enhance_state import save_state
+from start_green_stay_green.utils.file_writer import FileWriter
 
 
 def _make_orch_mock(mock_init: Mock) -> MagicMock:
@@ -1079,6 +1082,53 @@ class TestMetricsDashboardGeneration:
             assert "my-new-project" in content
             assert "start-green-stay-green" not in content
 
+    def test_copy_metrics_assets_produces_self_contained_script(
+        self, tmp_path: Path
+    ) -> None:
+        """The real copied collect_metrics.py must not import start_green_stay_green.
+
+        Regression test: this script is copied verbatim into any
+        ``--enable-live-dashboard`` project, which never has the
+        ``start_green_stay_green`` package installed. Uses the real
+        ``shutil.copy`` (no mocking) against this repo's actual source
+        files so drift is caught immediately.
+        """
+        cli._copy_metrics_assets(tmp_path, "my-new-project")
+
+        script_content = (tmp_path / "scripts" / "collect_metrics.py").read_text()
+        tree = ast.parse(script_content)
+        imported_modules = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        } | {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert not any(
+            mod == "start_green_stay_green" or mod.startswith("start_green_stay_green.")
+            for mod in imported_modules
+        )
+
+    def test_copy_metrics_assets_drops_regenerate_dashboard_step(
+        self, tmp_path: Path
+    ) -> None:
+        """The copied metrics.yml must not invoke regenerate_dashboard.py.
+
+        That script depends on MetricsGenerator, which isn't installed
+        downstream, and is never copied into generated projects.
+        """
+        cli._copy_metrics_assets(tmp_path, "my-new-project")
+
+        workflow_content = (
+            tmp_path / ".github" / "workflows" / "metrics.yml"
+        ).read_text()
+        assert "regenerate_dashboard.py" not in workflow_content
+        parsed = yaml.safe_load(workflow_content)
+        assert parsed["jobs"]["generate-metrics"]["steps"]
+
 
 class TestShowDryRunPreview:
     """Test dry run preview display."""
@@ -1330,6 +1380,46 @@ class TestGenerateSteps:
             cli._generate_precommit_step(mock_path, "my-project", "python")
 
         mock_generator.generate.assert_called()
+
+    def test_write_secrets_baseline_creates_file_without_writer(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a FileWriter, writes the baseline if absent."""
+        baseline_file = tmp_path / ".secrets.baseline"
+        cli._write_secrets_baseline(baseline_file, None)
+        assert baseline_file.exists()
+        baseline = json.loads(baseline_file.read_text())
+        assert baseline["results"] == {}
+
+    def test_write_secrets_baseline_skips_existing_without_writer(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a FileWriter, an existing baseline is never overwritten."""
+        baseline_file = tmp_path / ".secrets.baseline"
+        baseline_file.write_text("user's own baseline", encoding="utf-8")
+        cli._write_secrets_baseline(baseline_file, None)
+        assert baseline_file.read_text() == "user's own baseline"
+
+    def test_write_secrets_baseline_skips_existing_with_writer(
+        self, tmp_path: Path
+    ) -> None:
+        """FileWriter's default (non-force) mode must not clobber a real baseline."""
+        baseline_file = tmp_path / ".secrets.baseline"
+        baseline_file.write_text("user's own baseline", encoding="utf-8")
+        writer = FileWriter(project_root=tmp_path)
+        cli._write_secrets_baseline(baseline_file, writer)
+        assert baseline_file.read_text() == "user's own baseline"
+
+    def test_write_secrets_baseline_force_overwrites_with_writer(
+        self, tmp_path: Path
+    ) -> None:
+        """--force mode does overwrite an existing baseline."""
+        baseline_file = tmp_path / ".secrets.baseline"
+        baseline_file.write_text("stale baseline", encoding="utf-8")
+        writer = FileWriter(project_root=tmp_path, force=True)
+        cli._write_secrets_baseline(baseline_file, writer)
+        baseline = json.loads(baseline_file.read_text())
+        assert baseline["results"] == {}
 
     @patch("start_green_stay_green.cli._copy_reference_skills")
     def test_generate_skills_step_copies_skills(self, mock_copy: Mock) -> None:

--- a/tests/unit/test_collect_metrics.py
+++ b/tests/unit/test_collect_metrics.py
@@ -1207,22 +1207,22 @@ class TestCollectPrecommitStatus:
 
             assert collector.metrics["precommit_status"]["total_hooks"] == 0
 
-    def test_uses_canonical_package_hook_counter(self) -> None:
-        """collect_metrics imports the canonical hook counter (no duplication).
+    def test_hook_counter_is_self_contained_with_canonical_parity(self) -> None:
+        """collect_metrics vendors its own hook counter, not an import.
 
-        Issue #154 DRY consolidation: the hook-counting helpers must live only
-        in ``start_green_stay_green.generators.metrics``. ``collect_metrics``
-        must import and reuse that canonical ``count_precommit_hooks`` rather
-        than redefining its own ``_load_precommit_repos`` / ``_repo_hook_count``
-        / ``_count_precommit_hooks`` copies.
+        ``scripts/collect_metrics.py`` is copied verbatim into every
+        ``--enable-live-dashboard`` project (cli.py's
+        ``_copy_metrics_assets``), which does NOT have the
+        ``start_green_stay_green`` package installed -- importing from
+        ``start_green_stay_green.generators.metrics`` crashed every such
+        project's metrics workflow. The script must vendor its own copy of
+        ``count_precommit_hooks``/``_load_precommit_repos``/
+        ``_repo_hook_count``, kept behaviorally identical to the canonical
+        package version (asserted below), not object-identical.
         """
-        # The duplicated private helpers must be gone from the script module.
-        assert not hasattr(collect_metrics, "_load_precommit_repos")
-        assert not hasattr(collect_metrics, "_repo_hook_count")
-        assert not hasattr(collect_metrics, "_count_precommit_hooks")
-        # The script re-exports the canonical helper (same object), so
-        # collected status matches the canonical count for the same config.
-        assert collect_metrics.__dict__["count_precommit_hooks"] is (
+        assert hasattr(collect_metrics, "_load_precommit_repos")
+        assert hasattr(collect_metrics, "_repo_hook_count")
+        assert collect_metrics.__dict__["count_precommit_hooks"] is not (
             count_precommit_hooks
         )
         with TemporaryDirectory() as tmpdir:
@@ -1231,31 +1231,29 @@ class TestCollectPrecommitStatus:
 
             collector.collect_precommit_status(config_path)
 
+            # Vendored and canonical counters must agree on the same input.
             assert collector.metrics["precommit_status"]["total_hooks"] == (
                 count_precommit_hooks(config_path)
             )
+            assert collect_metrics.count_precommit_hooks(config_path) == (
+                count_precommit_hooks(config_path)
+            )
 
-    def test_collect_precommit_status_delegates_to_shared_builder(self) -> None:
-        """The status dict is built by the canonical ``precommit_status`` helper.
+    def test_collect_precommit_status_matches_canonical_builder(self) -> None:
+        """The vendored ``precommit_status`` builder matches the canonical one.
 
-        Issue #154 DRY consolidation: ``collect_precommit_status`` must not
-        re-derive ``has_hooks``/``passing_hooks``/``percentage``/``status``;
-        it must delegate dict construction to the shared
-        ``precommit_status`` builder in the metrics generator module.
+        Behavioral parity, not shared-object delegation: the script cannot
+        import the canonical builder (see the self-containment test above),
+        so this asserts its vendored copy produces an identical dict.
         """
         with TemporaryDirectory() as tmpdir:
             config_path = self._write_config(Path(tmpdir), 13)
             collector = MetricsCollector("test", {})
 
-            with patch.object(
-                collect_metrics,
-                "precommit_status",
-                wraps=precommit_status,
-            ) as spy:
-                collector.collect_precommit_status(config_path)
+            collector.collect_precommit_status(config_path)
 
-            spy.assert_called_once_with(13)
             assert collector.metrics["precommit_status"] == precommit_status(13)
+            assert collect_metrics.precommit_status(13) == precommit_status(13)
 
 
 class TestCollectCIStatus:
@@ -1553,18 +1551,19 @@ class TestCollectCIStatus:
         mock_api.assert_not_called()
         assert collector.metrics["ci_status"]["status"] == "unknown"
 
-    def test_uses_canonical_package_job_counter(
+    def test_job_counter_is_self_contained_with_canonical_parity(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """collect_metrics imports the canonical CI helpers (no duplication).
+        """collect_metrics vendors its own CI helpers, not an import.
 
-        Issue #159 DRY: the job-counting and status-building helpers live
-        only in ``start_green_stay_green.generators.metrics``;
-        ``collect_metrics`` reuses the same objects instead of redefining
-        them.
+        Same deployability constraint as the precommit-hook counter above:
+        the copied script has no ``start_green_stay_green`` package to
+        import from, so it vendors ``count_ci_jobs``/``ci_status`` and is
+        verified for behavioral (not object) parity with the canonical
+        package version.
         """
-        assert collect_metrics.__dict__["count_ci_jobs"] is count_ci_jobs
-        assert collect_metrics.__dict__["ci_status"] is ci_status
+        assert collect_metrics.__dict__["count_ci_jobs"] is not count_ci_jobs
+        assert collect_metrics.__dict__["ci_status"] is not ci_status
 
         self._clear_github_env(monkeypatch)
         with TemporaryDirectory() as tmpdir:
@@ -1577,6 +1576,8 @@ class TestCollectCIStatus:
             assert collector.metrics["ci_status"]["total_jobs"] == (
                 count_ci_jobs(workflows)
             )
+            assert collect_metrics.count_ci_jobs(workflows) == count_ci_jobs(workflows)
+            assert collect_metrics.ci_status(3, 2) == ci_status(3, 2)
 
 
 class TestMainScriptMode:


### PR DESCRIPTION
## Summary

Dogfooding revealed these by bootstrapping a real project (hedgekit) with `green init --enable-live-dashboard` and scanning its first ~40 PRs for issues traceable back to SGSG's generated scaffolding rather than the project's own code. Four distinct bugs, all confirmed reproducible:

- **vulture hook hardcoded path**: `generators/precommit.py`'s vulture scan target was the literal string `"start_green_stay_green/"` (this repo's own package) in every generated `.pre-commit-config.yaml`, instead of the target project's package. Now templated via a `{package_name}` token substituted at `generate()` time.
- **broken mypy dependency**: `additional_dependencies: ["types-all"]` pins a long-deprecated, unresolvable meta-package, blocking the mypy hook's environment build entirely. Removed.
- **missing `.secrets.baseline`**: every language's detect-secrets hook points `--baseline` at a file no generator ever wrote, so a fresh project's very first `pre-commit run` failed outright. Now generated (empty `results`, real plugin/filter list matching the pinned detect-secrets version).
- **mutmut pin/schema mismatch**: generated projects pinned `mutmut>=2.4.0` unbounded while shipping the 2.x-only `[tool.mutmut]` config schema (`paths_to_mutate`/`tests_dir`) — an unbounded pin resolves to 3.x and crashes at config load. Now upper-bounded `<3.0.0`. This repo's own `pyproject.toml` had the identical latent bug (pinned exactly `3.6.0` against the same 2.x schema), masked by a stale local `2.5.1` install — fixed to match the actually-working version.
- **metrics dashboard workflow crash**: `scripts/collect_metrics.py`, copied verbatim into every `--enable-live-dashboard` project, imported from `start_green_stay_green.generators.metrics` — never installed downstream — crashing the metrics workflow on every push. It also invoked `scripts/regenerate_dashboard.py`, which is never copied to generated projects at all. Fixed by vendoring the four small metrics helpers directly into the copied script (kept in parity-tested lockstep with the canonical `generators/metrics.py` versions), adding the `PyYAML` runtime dependency the vendored code needs, and dropping the regenerate-dashboard step from the copied workflow.

## Test plan
- [x] New/updated unit tests for every fix (vulture templating + no-mutation-leak-across-calls, mypy dependency absence, `.secrets.baseline` generation incl. force/skip semantics, metrics script self-containment via AST import check, dropped workflow step via real YAML parse)
- [x] Live-verified: generated a real project and confirmed `.secrets.baseline` is created with `project_name`'s vulture target correctly substituted
- [x] `pre-commit run --all-files` on every changed file — all green
- [x] Full affected test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)