### PR TITLE
fix(ralph): resolve the main repo root from inside a worktree

### DIFF
--- a/reference/ralph/scripts/fleet.sh
+++ b/reference/ralph/scripts/fleet.sh
@@ -55,9 +55,22 @@ die() {
   exit 1
 }
 
-# Resolve the repository root so the script works from any worktree/subdir.
+# Resolve the MAIN repo root so the script works from any worktree/subdir.
+#
+# `git rev-parse --show-toplevel` returns the CURRENT worktree's root, not
+# the main repo's — from inside a worker's own worktree it returns that
+# worktree's own path, not the repo this script actually needs (STATE_FILE
+# location, worktree-root computation, `worktree prune` target). Every
+# worker runs fleet.sh from inside its own worktree, so this silently
+# resolved to the wrong root and corrupted state reads / active-lane
+# exclusion. `--git-common-dir` always resolves to the ORIGINAL repo's
+# `.git` (shared across every linked worktree), so its dirname is the main
+# root regardless of which worktree invoked this script.
 repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
+  local git_common_dir
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "not inside a git repository"
+  dirname "$git_common_dir"
 }
 
 # Read an integer/bool field from state.json with a fallback. Pure-python so we

--- a/reference/ralph/scripts/pick-next.sh
+++ b/reference/ralph/scripts/pick-next.sh
@@ -149,8 +149,14 @@ inflight=$(
 )
 
 # Issue numbers with a live worktree (started, PR not yet opened).
+#
+# `--git-common-dir` (not `--show-toplevel`) so this resolves the MAIN repo
+# root even when pick-next.sh runs from inside a worker's own worktree --
+# `--show-toplevel` there returns the worktree's own path, pointing
+# `wt_dir` at the wrong location (see fleet.sh's repo_root()).
 worktree_issues=""
-if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+if git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+  repo_root="$(dirname "$git_common_dir")"
   wt_dir="$repo_root/.ralph/worktrees"
   if [[ -d "$wt_dir" ]]; then
     worktree_issues=$(

--- a/reference/ralph/scripts/test_fleet.sh
+++ b/reference/ralph/scripts/test_fleet.sh
@@ -52,6 +52,18 @@ BR="$(cd "$DIR" && git rev-parse --abbrev-ref HEAD)"
 check "branch slug sanitized"      "issue/101-add-widget-endpoint" "$BR"
 check "path resolves"              "$DIR" "$(run path 101)"
 
+# --- repo_root() resolves the MAIN repo even from inside a worktree --------
+# Every real worker invokes fleet.sh from inside its OWN worktree (not the
+# main checkout). `git rev-parse --show-toplevel` there returns the
+# worktree's own path, which silently corrupted STATE_FILE reads and
+# worktree-root computation (regression guard for that bug).
+check "count from inside worktree matches main repo" \
+  "$(run count)" "$(cd "$DIR" && "$FLEET" count)"
+check "active from inside worktree matches main repo" \
+  "$(run active)" "$(cd "$DIR" && "$FLEET" active)"
+check "path from inside worktree matches main repo" \
+  "$(run path 101)" "$(cd "$DIR" && "$FLEET" path 101)"
+
 # --- assign is idempotent (re-entrant) -------------------------------------
 DIR2="$(run assign 101 'whatever' 2>/dev/null)"
 check "re-assign returns same dir" "$DIR" "$DIR2"

--- a/reference/ralph/scripts/test_pick_next.sh
+++ b/reference/ralph/scripts/test_pick_next.sh
@@ -245,6 +245,28 @@ new_scenario prio_high_beats_medium
 ij_add 5 "priority-medium"; ij_add 9 "priority-high"; ij_finalize
 check "priority-high (tier 1) beats priority-medium (tier 2)" "9" "$(run_pick)"
 
+# --- repo_root resolution from inside a REAL worktree -----------------------
+# Every prior "worktree" scenario simulates a live worker with a plain
+# `mkdir`, so pick-next.sh is always actually invoked from $REPO. A real
+# worker invokes pick-next.sh from inside its OWN worktree, where
+# `git rev-parse --show-toplevel` returns the worktree's own path rather
+# than $REPO -- silently pointing `wt_dir` at the wrong location and making
+# the worktree-exclusion check a no-op. Regression guard using a real
+# `git worktree add` (not the mkdir simulation above).
+
+# 20) Worktree exclusion still works when pick-next.sh itself runs from
+# inside a real linked worktree of $REPO.
+new_scenario real_worktree_repo_root
+candidate 10 ""; candidate 11 ""; candidate 12 ""
+worktree 10
+(cd "$REPO" && git commit -q --allow-empty -m "seed for worktree add")
+REAL_WT="$WORK/real-worktree"
+(cd "$REPO" && git worktree add -q -b real-worktree-branch "$REAL_WT" >/dev/null 2>&1)
+run_pick_from_worktree() { (cd "$REAL_WT" && PATH="$BIN:$PATH" "$PICK"); }
+check "worktree issue still excluded when run from inside a worktree" \
+  "11" "$(run_pick_from_worktree)"
+(cd "$REPO" && git worktree remove -f "$REAL_WT" >/dev/null 2>&1) || true
+
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/fleet.sh
+++ b/scripts/ralph/fleet.sh
@@ -55,9 +55,23 @@ die() {
   exit 1
 }
 
-# Resolve the repository root so the script works from any worktree/subdir.
+# Resolve the MAIN repo root so the script works from any worktree/subdir.
+#
+# `git rev-parse --show-toplevel` returns the CURRENT worktree's root, not
+# the main repo's — from inside `../sgsg-worktrees/issue-42` it returns that
+# worktree's own path. Every worker runs fleet.sh from inside its own
+# worktree, so that resolved to a nested, wrong `worktrees_root()`
+# (`.../sgsg-worktrees/issue-42/../sgsg-worktrees`) and corrupted
+# `STATE_FILE` reads and active-lane exclusion, causing the orchestrator to
+# spin retrying `assign` against a branch it already owns.
+# `--git-common-dir` always resolves to the ORIGINAL repo's `.git` (shared
+# across every linked worktree), so its dirname is the main root regardless
+# of which worktree invoked this script.
 repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
+  local git_common_dir
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || die "not inside a git repository"
+  dirname "$git_common_dir"
 }
 
 # Absolute path of the worktree fleet's root — a SIBLING of the repo root

--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -162,8 +162,14 @@ inflight=$(
 # Issue numbers with a live worktree (started, PR not yet opened). Worktrees
 # live at ../sgsg-worktrees/issue-<N> — a SIBLING of the repo root, never
 # nested inside it (see scripts/ralph/fleet.sh).
+#
+# `--git-common-dir` (not `--show-toplevel`) so this resolves the MAIN repo
+# root even when pick-next.sh runs from inside a worker's own worktree —
+# `--show-toplevel` there returns the worktree's own path, which pointed
+# `wt_dir` at a nested, nonexistent directory (see fleet.sh's repo_root()).
 worktree_issues=""
-if repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+if git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+  repo_root="$(dirname "$git_common_dir")"
   wt_dir="$(dirname "$repo_root")/sgsg-worktrees"
   if [[ -d "$wt_dir" ]]; then
     worktree_issues=$(

--- a/scripts/ralph/test_fleet.sh
+++ b/scripts/ralph/test_fleet.sh
@@ -52,6 +52,18 @@ BR="$(cd "$DIR" && git rev-parse --abbrev-ref HEAD)"
 check "branch slug sanitized"      "issue/101-add-widget-endpoint" "$BR"
 check "path resolves"              "$DIR" "$(run path 101)"
 
+# --- repo_root() resolves the MAIN repo even from inside a worktree --------
+# Every real worker invokes fleet.sh from inside its OWN worktree (not the
+# main checkout). `git rev-parse --show-toplevel` there returns the
+# worktree's own path, which silently corrupted STATE_FILE reads and
+# worktree-root computation (regression guard for that bug).
+check "count from inside worktree matches main repo" \
+  "$(run count)" "$(cd "$DIR" && "$FLEET" count)"
+check "active from inside worktree matches main repo" \
+  "$(run active)" "$(cd "$DIR" && "$FLEET" active)"
+check "path from inside worktree matches main repo" \
+  "$(run path 101)" "$(cd "$DIR" && "$FLEET" path 101)"
+
 # --- assign is idempotent (re-entrant) -------------------------------------
 DIR2="$(run assign 101 'whatever' 2>/dev/null)"
 check "re-assign returns same dir" "$DIR" "$DIR2"

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -281,6 +281,34 @@ ij_add 8 "epic:cli" "epic: CLI overhaul"
 ij_finalize
 check "the umbrella issue alone yields nothing (only candidate excluded)" "" "$(run_pick)"
 
+# --- repo_root resolution from inside a REAL worktree -----------------------
+# Every prior "worktree" scenario simulates a live worker with a plain
+# `mkdir`, so pick-next.sh is always actually invoked from $REPO. A real
+# worker invokes pick-next.sh from inside its OWN worktree, where
+# `git rev-parse --show-toplevel` returns the worktree's own path rather
+# than $REPO -- silently pointing `wt_dir` at the wrong location and making
+# the worktree-exclusion check a no-op. Regression guard using a real
+# `git worktree add` (not the mkdir simulation above).
+
+# 24) Worktree exclusion still works when pick-next.sh itself runs from
+# inside a real linked worktree of $REPO.
+#
+# The real worktree is nested a level DEEPER than $REPO
+# ($WORK/deeper/real-worktree vs $WORK/repo) so `dirname` of each diverges --
+# both sitting directly under $WORK would make the bug's wrong `wt_dir`
+# computation accidentally coincide with the correct one and mask the bug.
+new_scenario real_worktree_repo_root
+candidate 10 ""; candidate 11 ""; candidate 12 ""
+worktree 10
+(cd "$REPO" && git commit -q --allow-empty -m "seed for worktree add")
+mkdir -p "$WORK/deeper"
+REAL_WT="$WORK/deeper/real-worktree"
+(cd "$REPO" && git worktree add -q -b real-worktree-branch "$REAL_WT" >/dev/null 2>&1)
+run_pick_from_worktree() { (cd "$REAL_WT" && PATH="$BIN:$PATH" "$PICK"); }
+check "worktree issue still excluded when run from inside a worktree" \
+  "11" "$(run_pick_from_worktree)"
+(cd "$REPO" && git worktree remove -f "$REAL_WT" >/dev/null 2>&1) || true
+
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Found while dogfooding via hedgekit (a project bootstrapped with `green init --with-ralph-loop`): PR #84 there is titled "fleet scripts resolve wrong repo root when invoked from inside a worktree (caused orchestrator spin)".

`fleet.sh`'s `repo_root()` and `pick-next.sh`'s inline worktree-detection block both used `git rev-parse --show-toplevel`, which returns the **current worktree's** root, not the main repo's. Every real fleet worker invokes both scripts from inside its own worktree — that's the entire point of the fleet — so this silently resolved to the wrong root:
- `fleet.sh`'s `STATE_FILE` reads and worktree-root computation broke.
- `pick-next.sh`'s worktree-exclusion check pointed at a nonexistent directory and became a no-op (an issue with a live worker could get picked again).

hedgekit's incident: a ~2 minute orchestrator spin where `assign` kept failing with "branch already used by worktree", because the fleet state `fleet.sh` itself was reading was wrong.

**This bug is live in SGSG's own currently-running Ralph fleet loop right now**, not just the downstream template — fixed in both copies:
- `scripts/ralph/` (SGSG's own adopted copy, sibling `../sgsg-worktrees/` convention)
- `reference/ralph/scripts/` (the generic `--with-ralph-loop` downstream template, nested `.ralph/worktrees/` convention)

`--git-common-dir` always resolves to the ORIGINAL repo's `.git` (shared across every linked worktree), so its `dirname` is the main root regardless of which worktree invoked the script.

## Test plan
- [x] Added regression tests to both `test_fleet.sh` copies: run `count`/`active`/`path` from inside a real `git worktree add` checkout (not the existing plain-`mkdir` simulation) and verify they match invoking from the main repo
- [x] Added regression tests to both `test_pick_next.sh` copies: verify worktree-exclusion still works when `pick-next.sh` runs from inside a real linked worktree
- [x] Confirmed every new test **fails** against the pre-fix scripts (via `git stash`) and **passes** against the fix
- [x] `shellcheck` clean on all 8 changed files
- [x] Full existing `test_fleet.sh`/`test_pick_next.sh` suites still pass (53 pre-existing checks across both copies)
- [x] `pre-commit run --all-files` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)